### PR TITLE
fix: keep translated skills under the 500-line cap (#266)

### DIFF
--- a/i18n/caveman-lite/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/caveman-lite/skills/collect-preserve-specimens/SKILL.md
@@ -2,7 +2,7 @@
 name: collect-preserve-specimens
 locale: caveman-lite
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -221,67 +221,7 @@ NEVER use:
 
 Pin each specimen through the correct location for its order. Proper pin placement is essential for both access to diagnostic features and long-term structural integrity.
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+Full pin-placement-by-order table, pin selection, pin height, and wing-spreading steps in [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md).
 
 **Got:** Each specimen pinned through the correct position for its order, at the correct height on the pin, with wings spread where required (Lepidoptera, Odonata). Specimens allowed to dry fully before handling.
 

--- a/i18n/caveman-lite/skills/create-2d-composition/SKILL.md
+++ b/i18n/caveman-lite/skills/create-2d-composition/SKILL.md
@@ -2,7 +2,7 @@
 name: create-2d-composition
 locale: caveman-lite
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -220,91 +220,7 @@ def wrap_text(text, max_width=20):
 
 Combine multiple images using Pillow:
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+Full Pillow compositing example (grid, horizontal, vertical layouts plus image annotation) in [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md).
 
 **Got:** Composite image created with proper layout
 **If fail:** Check all input images exist, verify image modes compatible

--- a/i18n/caveman-ultra/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/caveman-ultra/skills/collect-preserve-specimens/SKILL.md
@@ -2,7 +2,7 @@
 name: collect-preserve-specimens
 locale: caveman-ultra
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -214,67 +214,7 @@ NEVER use:
 
 Pin each specimen through correct location for its order. Proper pin placement essential → diagnostic access + long-term integrity.
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+Full pin table + pin pick + height + wing-spread → [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md).
 
 **→** Each specimen pinned correct position for order, correct pin height, wings spread where req'd (Lepidoptera, Odonata). Specimens fully dry before handling.
 

--- a/i18n/caveman-ultra/skills/create-2d-composition/SKILL.md
+++ b/i18n/caveman-ultra/skills/create-2d-composition/SKILL.md
@@ -2,7 +2,7 @@
 name: create-2d-composition
 locale: caveman-ultra
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -212,91 +212,7 @@ def wrap_text(text, max_width=20):
 
 ### 4. Composite Raster
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+Full Pillow composite (grid/horiz/vert + annotate) → [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md).
 
 **Got:** Composite img w/ layout
 **If err:** Check inputs exist, img modes compat

--- a/i18n/caveman/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/caveman/skills/collect-preserve-specimens/SKILL.md
@@ -2,7 +2,7 @@
 name: collect-preserve-specimens
 locale: caveman
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -221,67 +221,7 @@ NEVER use:
 
 Pin each specimen through correct location for its order. Proper pin placement essential for both access to diagnostic features and long-term structural integrity.
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+Full pin-placement-by-order table, pin pick, pin height, wing-spread steps live in [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md).
 
 **Got:** Each specimen pinned through correct position for its order, at correct height on pin, with wings spread where required (Lepidoptera, Odonata). Specimens allowed to dry fully before handling.
 

--- a/i18n/caveman/skills/create-2d-composition/SKILL.md
+++ b/i18n/caveman/skills/create-2d-composition/SKILL.md
@@ -2,7 +2,7 @@
 name: create-2d-composition
 locale: caveman
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -217,91 +217,7 @@ def wrap_text(text, max_width=20):
 
 Combine many images with Pillow:
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+Full Pillow composite example (grid, horizontal, vertical layout + image annotate) live in [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md).
 
 **Got:** Composite image made with right layout. **If fail:** Check all input images exist. Verify image modes match
 

--- a/i18n/de/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/de/skills/collect-preserve-specimens/SKILL.md
@@ -22,7 +22,7 @@ metadata:
   tags: entomology, insects, collection, preservation, pinning, taxonomy, museum
   locale: de
   source_locale: en
-  source_commit: f1162126
+  source_commit: "ca20dd87"
   translator: claude
   translation_date: "2026-03-17"
 ---
@@ -221,67 +221,7 @@ NEVER use:
 
 Pin each specimen durch the correct location for its order. Proper pin placement is essential for both access to diagnostic features and long-term structural integrity.
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+Vollständige Pin-Platzierungstabelle nach Ordnung, Nadelauswahl, Nadelhöhe und Spreizverfahren: siehe [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md).
 
 **Erwartet:** Each specimen pinned durch the correct position for its order, at the correct height on the pin, with wings spread where required (Lepidoptera, Odonata). Specimens allowed to dry fully vor handling.
 

--- a/i18n/de/skills/create-2d-composition/SKILL.md
+++ b/i18n/de/skills/create-2d-composition/SKILL.md
@@ -19,7 +19,7 @@ metadata:
   tags: svg, 2d, graphics, composition, diagrams, scripting, batch-processing
   locale: de
   source_locale: en
-  source_commit: 4859067d
+  source_commit: "ca20dd87"
   translator: claude
   translation_date: "2026-03-17"
 ---
@@ -221,91 +221,7 @@ def wrap_text(text, max_width=20):
 
 Mehrere Bilder mit Pillow kombinieren:
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+Vollständiges Pillow-Kompositionsbeispiel (Raster-, horizontale und vertikale Layouts sowie Bildbeschriftung): siehe [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md).
 
 **Erwartet:** Kompositbild mit korrektem Layout erstellt
 **Bei Fehler:** Pruefen, dass alle Eingabebilder existieren, Bildmodus-Kompatibilitaet verifizieren

--- a/i18n/es/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/es/skills/collect-preserve-specimens/SKILL.md
@@ -22,7 +22,7 @@ metadata:
   tags: entomology, insects, collection, preservation, pinning, taxonomy, museum
   locale: es
   source_locale: en
-  source_commit: f1162126
+  source_commit: "ca20dd87"
   translator: claude
   translation_date: "2026-03-17"
 ---
@@ -221,67 +221,7 @@ NEVER use:
 
 Pin each specimen through the correct location for its order. Proper pin placement is essential for both access to diagnostic features and long-term structural integrity.
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+Tabla completa de colocación de alfileres por orden, selección de alfiler, altura y procedimiento de extensión de alas: véase [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md).
 
 **Esperado:** Each specimen pinned through the correct position for its order, at the correct height on the pin, with wings spread where required (Lepidoptera, Odonata). Specimens allowed to dry fully before handling.
 

--- a/i18n/es/skills/create-2d-composition/SKILL.md
+++ b/i18n/es/skills/create-2d-composition/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   tags: svg, 2d, graphics, composition, diagrams, scripting, batch-processing
   locale: es
   source_locale: en
-  source_commit: 4859067d
+  source_commit: "ca20dd87"
   translator: claude
   translation_date: "2026-03-17"
 ---
@@ -220,91 +220,7 @@ def wrap_text(text, max_width=20):
 
 Combine multiple images using Pillow:
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+Ejemplo completo de composición con Pillow (diseños en cuadrícula, horizontal y vertical, además de anotación de imágenes): véase [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md).
 
 **Esperado:** Composite image created with proper layout
 **En caso de fallo:** Check all input images exist, verify image modes compatible

--- a/i18n/ja/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/ja/skills/collect-preserve-specimens/SKILL.md
@@ -20,7 +20,7 @@ metadata:
   tags: entomology, insects, collection, preservation, pinning, taxonomy, museum
   locale: ja
   source_locale: en
-  source_commit: f1162126
+  source_commit: "ca20dd87"
   translator: claude
   translation_date: "2026-03-17"
 ---
@@ -219,67 +219,7 @@ NEVER use:
 
 各標本を目に応じた正しい位置でピニングする。適切なピン位置は、診断的特徴へのアクセスと長期的な構造的完全性の両方に不可欠。
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+目別のピン位置表、ピンの選択、高さ、展翅手順の完全版は [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md) を参照。
 
 **期待結果:** 各標本が目に応じた正しい位置でピニングされ、ピン上の正しい高さに、必要に応じて翅が展翅されている（鱗翅目、トンボ目）。取り扱う前に標本が完全に乾燥するまで放置。
 

--- a/i18n/ja/skills/create-2d-composition/SKILL.md
+++ b/i18n/ja/skills/create-2d-composition/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   tags: svg, 2d, graphics, composition, diagrams, scripting, batch-processing
   locale: ja
   source_locale: en
-  source_commit: 4859067d
+  source_commit: "ca20dd87"
   translator: claude
   translation_date: "2026-03-17"
 ---
@@ -219,74 +219,7 @@ def wrap_text(text, max_width=20):
 
 Pillowを使用して複数の画像を結合する:
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text, font=font, fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+Pillow による合成の完全な例（グリッド・水平・垂直レイアウトと画像注釈）は [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md) を参照。
 
 **期待結果:** 適切なレイアウトで合成画像が作成される
 **失敗時:** すべての入力画像が存在するか確認し、画像モードに互換性があるか検証する

--- a/i18n/wenyan-lite/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/wenyan-lite/skills/collect-preserve-specimens/SKILL.md
@@ -2,7 +2,7 @@
 name: collect-preserve-specimens
 locale: wenyan-lite
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -217,67 +217,7 @@ NEVER use:
 
 針每標本穿其目之正確位。正確之針位於診斷特徵之存取與長期結構完整皆為必需。
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+完整針位表（按目）、針擇、針高、展翅之法，見 [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md)。
 
 **預期：** 每標本針穿其目之正確位，於正確高度，需展翅者（鱗翅目、蜻蜓目）已展翅。標本完全乾前勿動。
 

--- a/i18n/wenyan-lite/skills/create-2d-composition/SKILL.md
+++ b/i18n/wenyan-lite/skills/create-2d-composition/SKILL.md
@@ -2,7 +2,7 @@
 name: create-2d-composition
 locale: wenyan-lite
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -220,91 +220,7 @@ def wrap_text(text, max_width=20):
 
 以 Pillow 合多圖：
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+完整 Pillow 合成例（網格、橫、縱佈局及圖注），見 [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md)。
 
 **預期：** 合成圖已生，佈局得宜
 **失敗時：** 察輸入圖皆在、驗圖像模式相容

--- a/i18n/wenyan-ultra/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/wenyan-ultra/skills/collect-preserve-specimens/SKILL.md
@@ -2,7 +2,7 @@
 name: collect-preserve-specimens
 locale: wenyan-ultra
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -221,67 +221,7 @@ NEVER use:
 
 每標依目針正位。位正為診特徵取與久結構之要。
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+針位表、針擇、高、展翅，見 [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md)。
 
 **得：** 每標依目針正位、針高正、鱗翅蜻蜓翅展。標全乾方動。
 

--- a/i18n/wenyan-ultra/skills/create-2d-composition/SKILL.md
+++ b/i18n/wenyan-ultra/skills/create-2d-composition/SKILL.md
@@ -2,7 +2,7 @@
 name: create-2d-composition
 locale: wenyan-ultra
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -220,91 +220,7 @@ def wrap_text(text, max_width=20):
 
 以 Pillow 合多像：
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+Pillow 合成例（網格/橫/縱+注），見 [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md)。
 
 **得：** 合像成含正排
 **敗：** 察諸入像存、驗像模相容

--- a/i18n/wenyan/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/wenyan/skills/collect-preserve-specimens/SKILL.md
@@ -2,7 +2,7 @@
 name: collect-preserve-specimens
 locale: wenyan
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -214,67 +214,7 @@ NEVER use:
 
 每標依其目之正處而針。正針之位關乎診特之達與久之構。
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+全目別針位之表、針之擇、針之高、展翅之法，見 [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md)。
 
 **得：** 每標依目正位針、正高於針，需展翅者展之（鱗翅、蜻蜓）。待乾乃動。
 

--- a/i18n/wenyan/skills/create-2d-composition/SKILL.md
+++ b/i18n/wenyan/skills/create-2d-composition/SKILL.md
@@ -2,7 +2,7 @@
 name: create-2d-composition
 locale: wenyan
 source_locale: en
-source_commit: 82c77053
+source_commit: "ca20dd87"
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-04-19"
 description: >
@@ -220,91 +220,7 @@ def wrap_text(text, max_width=20):
 
 以 Pillow 合多像：
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+全 Pillow 合成之例（網格、橫、縱之佈局，及圖之注），見 [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md)。
 
 **得：** 合像成，佈正
 **敗則：** 察諸入像皆存，驗像模式相容

--- a/i18n/zh-CN/skills/collect-preserve-specimens/SKILL.md
+++ b/i18n/zh-CN/skills/collect-preserve-specimens/SKILL.md
@@ -22,7 +22,7 @@ metadata:
   tags: entomology, insects, collection, preservation, pinning, taxonomy, museum
   locale: zh-CN
   source_locale: en
-  source_commit: f1162126
+  source_commit: "ca20dd87"
   translator: claude
   translation_date: "2026-03-17"
 ---
@@ -221,67 +221,7 @@ NEVER use:
 
 Pin each specimen through the correct location for its order. Proper pin placement is essential for both access to diagnostic features and long-term structural integrity.
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+完整的按目别针放置表、针的选择、针的高度和展翅步骤见 [references/EXAMPLES.md](../../../../skills/collect-preserve-specimens/references/EXAMPLES.md)。
 
 **预期结果：** Each specimen pinned through the correct position for its order, at the correct height on the pin, with wings spread where required (Lepidoptera, Odonata). Specimens allowed to dry fully before handling.
 

--- a/i18n/zh-CN/skills/create-2d-composition/SKILL.md
+++ b/i18n/zh-CN/skills/create-2d-composition/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   tags: svg, 2d, graphics, composition, diagrams, scripting, batch-processing
   locale: zh-CN
   source_locale: en
-  source_commit: 4859067d
+  source_commit: "ca20dd87"
   translator: claude
   translation_date: "2026-03-17"
 ---
@@ -220,91 +220,7 @@ def wrap_text(text, max_width=20):
 
 Combine multiple images using Pillow:
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+完整的 Pillow 合成示例（网格、水平、垂直布局及图像标注）见 [references/EXAMPLES.md](../../../../skills/create-2d-composition/references/EXAMPLES.md)。
 
 **预期结果：** Composite image created with proper layout
 **失败处理：** Check all input images exist, verify image modes compatible

--- a/skills/collect-preserve-specimens/SKILL.md
+++ b/skills/collect-preserve-specimens/SKILL.md
@@ -216,67 +216,7 @@ NEVER use:
 
 Pin each specimen through the correct location for its order. Proper pin placement is essential for both access to diagnostic features and long-term structural integrity.
 
-```
-Pin Placement by Order:
-+--------------------+------------------------------------------+
-| Order              | Pin Position                             |
-+--------------------+------------------------------------------+
-| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
-| (beetles)          | cover), approximately 1/3 from the       |
-|                    | anterior edge, so the pin emerges        |
-|                    | between the middle and hind legs.        |
-+--------------------+------------------------------------------+
-| Lepidoptera        | Through the CENTER OF THE THORAX         |
-| (butterflies/moths)| (mesothorax), between the wing bases.    |
-|                    | Wings must be spread on a spreading      |
-|                    | board before the specimen dries.         |
-+--------------------+------------------------------------------+
-| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
-| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
-| (flies)            | (mesothorax), between the wing bases.    |
-+--------------------+------------------------------------------+
-| Hemiptera          | Through the RIGHT SIDE OF THE            |
-| (true bugs)        | SCUTELLUM (triangular plate between      |
-|                    | wing bases), slightly to the right of    |
-|                    | center.                                  |
-+--------------------+------------------------------------------+
-| Orthoptera         | Through the RIGHT SIDE OF THE            |
-| (grasshoppers)     | PRONOTUM (just behind the head), to      |
-|                    | the right of the midline.                |
-+--------------------+------------------------------------------+
-| Odonata            | Through the CENTER OF THE THORAX.        |
-| (dragonflies)      | Wings must be spread. Alternatively,     |
-|                    | store in glassine envelopes.             |
-+--------------------+------------------------------------------+
-| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
-|                    | unless order-specific guidance is        |
-|                    | available.                               |
-+--------------------+------------------------------------------+
-
-Pin Selection:
-- Standard entomological pins: stainless steel, sizes 0-7
-- Size 3 (0.50mm) is the most commonly used general-purpose size
-- Size 1-2 for small beetles and flies; size 4-5 for large beetles
-- Specimens under 5mm: mount on a paper point (triangular card
-  glued to a standard pin) rather than pinning directly
-
-Pin Height:
-- The specimen should sit approximately 2/3 up the pin (leaving
-  room below for 2 labels and above for handling)
-- Use a pinning block (stepped block with 3 heights) to ensure
-  consistent specimen and label heights across the collection
-
-Spreading Wings (Lepidoptera, Odonata):
-1. Pin the specimen through the thorax
-2. Place on the spreading board with the body in the groove
-3. Use paper strips to hold wings in position
-4. Adjust wings so the hind margin of the forewing is perpendicular
-   to the body axis
-5. Leave on the board for 3-7 days until completely dry
-6. Remove paper strips carefully
-```
+See [references/EXAMPLES.md](references/EXAMPLES.md) for the full pin-placement-by-order table, pin selection and height guidance, and the wing-spreading procedure.
 
 **Expected:** Each specimen pinned through the correct position for its order, at the correct height on the pin, with wings spread where required (Lepidoptera, Odonata). Specimens allowed to dry fully before handling.
 

--- a/skills/collect-preserve-specimens/references/EXAMPLES.md
+++ b/skills/collect-preserve-specimens/references/EXAMPLES.md
@@ -1,0 +1,67 @@
+# Examples — collect-preserve-specimens
+
+Extended reference material extracted from `SKILL.md` to keep it under the 500-line limit (progressive disclosure: https://agentskills.io/specification).
+
+## Pin Placement Reference (Step 4)
+
+```
+Pin Placement by Order:
++--------------------+------------------------------------------+
+| Order              | Pin Position                             |
++--------------------+------------------------------------------+
+| Coleoptera         | Through the RIGHT ELYTRON (front wing    |
+| (beetles)          | cover), approximately 1/3 from the       |
+|                    | anterior edge, so the pin emerges        |
+|                    | between the middle and hind legs.        |
++--------------------+------------------------------------------+
+| Lepidoptera        | Through the CENTER OF THE THORAX         |
+| (butterflies/moths)| (mesothorax), between the wing bases.    |
+|                    | Wings must be spread on a spreading      |
+|                    | board before the specimen dries.         |
++--------------------+------------------------------------------+
+| Hymenoptera        | Through the RIGHT SIDE OF THE THORAX     |
+| (bees/wasps/ants)  | (mesothorax), between the wing bases.    |
++--------------------+------------------------------------------+
+| Diptera            | Through the RIGHT SIDE OF THE THORAX     |
+| (flies)            | (mesothorax), between the wing bases.    |
++--------------------+------------------------------------------+
+| Hemiptera          | Through the RIGHT SIDE OF THE            |
+| (true bugs)        | SCUTELLUM (triangular plate between      |
+|                    | wing bases), slightly to the right of    |
+|                    | center.                                  |
++--------------------+------------------------------------------+
+| Orthoptera         | Through the RIGHT SIDE OF THE            |
+| (grasshoppers)     | PRONOTUM (just behind the head), to      |
+|                    | the right of the midline.                |
++--------------------+------------------------------------------+
+| Odonata            | Through the CENTER OF THE THORAX.        |
+| (dragonflies)      | Wings must be spread. Alternatively,     |
+|                    | store in glassine envelopes.             |
++--------------------+------------------------------------------+
+| All other orders   | Through the RIGHT SIDE OF THE THORAX     |
+|                    | unless order-specific guidance is        |
+|                    | available.                               |
++--------------------+------------------------------------------+
+
+Pin Selection:
+- Standard entomological pins: stainless steel, sizes 0-7
+- Size 3 (0.50mm) is the most commonly used general-purpose size
+- Size 1-2 for small beetles and flies; size 4-5 for large beetles
+- Specimens under 5mm: mount on a paper point (triangular card
+  glued to a standard pin) rather than pinning directly
+
+Pin Height:
+- The specimen should sit approximately 2/3 up the pin (leaving
+  room below for 2 labels and above for handling)
+- Use a pinning block (stepped block with 3 heights) to ensure
+  consistent specimen and label heights across the collection
+
+Spreading Wings (Lepidoptera, Odonata):
+1. Pin the specimen through the thorax
+2. Place on the spreading board with the body in the groove
+3. Use paper strips to hold wings in position
+4. Adjust wings so the hind margin of the forewing is perpendicular
+   to the body axis
+5. Leave on the board for 3-7 days until completely dry
+6. Remove paper strips carefully
+```

--- a/skills/create-2d-composition/SKILL.md
+++ b/skills/create-2d-composition/SKILL.md
@@ -213,93 +213,9 @@ def wrap_text(text, max_width=20):
 
 ### 4. Composite Raster Images
 
-Combine multiple images using Pillow:
+Combine multiple images using Pillow.
 
-```python
-from PIL import Image, ImageDraw, ImageFont, ImageFilter
-import os
-
-def composite_images(image_paths, output_path, layout='grid'):
-    """Composite multiple images into single output."""
-    # Load images
-    images = [Image.open(path) for path in image_paths]
-
-    if layout == 'grid':
-        # Calculate grid dimensions
-        n = len(images)
-        cols = int(n ** 0.5)
-        rows = (n + cols - 1) // cols
-
-        # Get max dimensions
-        max_width = max(img.width for img in images)
-        max_height = max(img.height for img in images)
-
-        # Create composite canvas
-        canvas_width = cols * max_width
-        canvas_height = rows * max_height
-        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
-
-        # Paste images
-        for i, img in enumerate(images):
-            row = i // cols
-            col = i % cols
-            x = col * max_width
-            y = row * max_height
-            composite.paste(img, (x, y))
-
-    elif layout == 'horizontal':
-        # Horizontal concatenation
-        total_width = sum(img.width for img in images)
-        max_height = max(img.height for img in images)
-        composite = Image.new('RGB', (total_width, max_height), 'white')
-
-        x_offset = 0
-        for img in images:
-            composite.paste(img, (x_offset, 0))
-            x_offset += img.width
-
-    elif layout == 'vertical':
-        # Vertical concatenation
-        max_width = max(img.width for img in images)
-        total_height = sum(img.height for img in images)
-        composite = Image.new('RGB', (max_width, total_height), 'white')
-
-        y_offset = 0
-        for img in images:
-            composite.paste(img, (0, y_offset))
-            y_offset += img.height
-
-    composite.save(output_path)
-    print(f"Saved composite: {output_path}")
-
-def add_annotations(image_path, annotations, output_path):
-    """Add text annotations to image."""
-    img = Image.open(image_path)
-    draw = ImageDraw.Draw(img)
-
-    # Load font
-    try:
-        font = ImageFont.truetype("Arial.ttf", 24)
-    except:
-        font = ImageFont.load_default()
-
-    for annotation in annotations:
-        text = annotation['text']
-        position = annotation['position']
-        color = annotation.get('color', 'black')
-
-        # Add text shadow for readability
-        shadow_offset = 2
-        draw.text(
-            (position[0] + shadow_offset, position[1] + shadow_offset),
-            text,
-            font=font,
-            fill='white'
-        )
-        draw.text(position, text, font=font, fill=color)
-
-    img.save(output_path)
-```
+See [references/EXAMPLES.md](references/EXAMPLES.md) for the full Pillow compositing example (grid, horizontal, and vertical layouts plus image annotation).
 
 **Expected:** Composite image created with proper layout
 **On failure:** Check all input images exist, verify image modes compatible

--- a/skills/create-2d-composition/references/EXAMPLES.md
+++ b/skills/create-2d-composition/references/EXAMPLES.md
@@ -1,0 +1,91 @@
+# Examples — create-2d-composition
+
+Extended reference material extracted from `SKILL.md` to keep it under the 500-line limit (progressive disclosure: https://agentskills.io/specification).
+
+## Composite Raster Images (Step 4)
+
+```python
+from PIL import Image, ImageDraw, ImageFont, ImageFilter
+import os
+
+def composite_images(image_paths, output_path, layout='grid'):
+    """Composite multiple images into single output."""
+    # Load images
+    images = [Image.open(path) for path in image_paths]
+
+    if layout == 'grid':
+        # Calculate grid dimensions
+        n = len(images)
+        cols = int(n ** 0.5)
+        rows = (n + cols - 1) // cols
+
+        # Get max dimensions
+        max_width = max(img.width for img in images)
+        max_height = max(img.height for img in images)
+
+        # Create composite canvas
+        canvas_width = cols * max_width
+        canvas_height = rows * max_height
+        composite = Image.new('RGB', (canvas_width, canvas_height), 'white')
+
+        # Paste images
+        for i, img in enumerate(images):
+            row = i // cols
+            col = i % cols
+            x = col * max_width
+            y = row * max_height
+            composite.paste(img, (x, y))
+
+    elif layout == 'horizontal':
+        # Horizontal concatenation
+        total_width = sum(img.width for img in images)
+        max_height = max(img.height for img in images)
+        composite = Image.new('RGB', (total_width, max_height), 'white')
+
+        x_offset = 0
+        for img in images:
+            composite.paste(img, (x_offset, 0))
+            x_offset += img.width
+
+    elif layout == 'vertical':
+        # Vertical concatenation
+        max_width = max(img.width for img in images)
+        total_height = sum(img.height for img in images)
+        composite = Image.new('RGB', (max_width, total_height), 'white')
+
+        y_offset = 0
+        for img in images:
+            composite.paste(img, (0, y_offset))
+            y_offset += img.height
+
+    composite.save(output_path)
+    print(f"Saved composite: {output_path}")
+
+def add_annotations(image_path, annotations, output_path):
+    """Add text annotations to image."""
+    img = Image.open(image_path)
+    draw = ImageDraw.Draw(img)
+
+    # Load font
+    try:
+        font = ImageFont.truetype("Arial.ttf", 24)
+    except:
+        font = ImageFont.load_default()
+
+    for annotation in annotations:
+        text = annotation['text']
+        position = annotation['position']
+        color = annotation.get('color', 'black')
+
+        # Add text shadow for readability
+        shadow_offset = 2
+        draw.text(
+            (position[0] + shadow_offset, position[1] + shadow_offset),
+            text,
+            font=font,
+            fill='white'
+        )
+        draw.text(position, text, font=font, fill=color)
+
+    img.save(output_path)
+```


### PR DESCRIPTION
## Summary

Resolves #266 — three translated `SKILL.md` files exceeded the 500-line CI cap (`Validate Translations`), with seven more sitting at exactly 500 (one keystroke from breaking).

**Root cause:** two English sources sat at the 500-line ceiling, which forces every translation 5–6 lines over once the mandatory i18n frontmatter (`locale`, `source_locale`, `source_commit`, `translator`, `translation_date`) is added. **Fix:** extract the largest Step-4 block from each source into `references/EXAMPLES.md` (progressive disclosure) and mirror the removal across English + all 10 locale variants, leaving a pointer to the canonical examples file.

## Changes

| File set | Change |
|----------|--------|
| `skills/collect-preserve-specimens/SKILL.md` | Pin-placement-by-order tables → `references/EXAMPLES.md`; 500 → 440 |
| `skills/create-2d-composition/SKILL.md` | Pillow compositing example → `references/EXAMPLES.md`; 498 → 414 |
| `skills/*/references/EXAMPLES.md` (2 new) | Extracted reference blocks |
| `i18n/<10 locales>/skills/<both>/SKILL.md` (20) | Same block replaced by a locale-appropriate pointer; `source_commit` refreshed to `ca20dd87` |

Every locale variant is now **≤ 445 lines** (was: 3 over 500, 7 at exactly 500).

## Note on the issue's "Option 1"

#266 proposed trimming English sources to "fix all variants in one shot." That can't work as written — i18n `SKILL.md` files are **independent copies**, not regenerated from source, so trimming English alone doesn't shrink them. This PR mirrors the trim across English + all locale variants (the issue's structural intent, implemented correctly).

## Reviewer note: line endings

The 2 English files show a near-full-file diff. That is **CRLF→LF normalization** per `.gitattributes` (`*.md text eol=lf`) — main's blobs are legacy CRLF and git's clean filter stores LF on any edit. The substantive change is only the Step-4 block move.

## Does NOT affect PR #256

#256's `Validate Translations` runs on the rust-cli branch HEAD (still the 505-line files). It greens only after this lands on main **and** main is merged into rust-cli — separate from that branch's Rust CI.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
