### PR TITLE
chore(ci): prune dead OVERRUN_ALLOWLIST entries

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -64,13 +64,10 @@ jobs:
       - name: Validate translated skills
         run: |
           # Known accepted overruns — translations whose source-fidelity outweighs
-          # the 500-line ceiling. Keep this list short; prefer extracting examples
-          # to references/EXAMPLES.md when adding new translations.
-          OVERRUN_ALLOWLIST=(
-            "i18n/caveman/skills/collect-preserve-specimens/SKILL.md"
-            "i18n/caveman-lite/skills/collect-preserve-specimens/SKILL.md"
-            "i18n/wenyan-lite/skills/create-2d-composition/SKILL.md"
-          )
+          # the 500-line ceiling. Currently none (all translations are within the
+          # ceiling). Keep this list short; prefer extracting examples to
+          # references/EXAMPLES.md over allowlisting when adding new translations.
+          OVERRUN_ALLOWLIST=()
 
           is_allowed() {
             local path="$1"


### PR DESCRIPTION
## Summary

Removes 3 stale entries from the `OVERRUN_ALLOWLIST` in `validate-skills.yml`. These translation skills were trimmed under #266 and now sit within the 500-line ceiling:

| File | Lines |
|---|---|
| `i18n/caveman/skills/collect-preserve-specimens/SKILL.md` | 445 |
| `i18n/caveman-lite/skills/collect-preserve-specimens/SKILL.md` | 445 |
| `i18n/wenyan-lite/skills/create-2d-composition/SKILL.md` | 419 |

A full scan confirms **no** i18n skill exceeds 500 lines, so the entries were pure dead code.

## Approach

Empty the array rather than removing the machinery — the `is_allowed` + WARN branch is a documented safety valve for legitimate future translation overruns. Verified the empty array is safe under the GitHub Actions shell (`bash -eo pipefail`): `is_allowed` returns false cleanly, no `set -u` expansion error.

## Notes

- Housekeeping item carried forward from the #258 / #266 work (CONTINUE_HERE next-steps).
- No issue closed; pure CI hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)