### PR TITLE
fix(ci): full-history checkout for translation staleness

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -19,6 +19,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history: generate-translation-status.js derives staleness from
+          # per-file `git log` + `merge-base --is-ancestor`; a shallow clone
+          # makes every translation read as fresh (stale: 0) — see #279.
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/i18n/de/translation_status.yml
+++ b/i18n/de/translation_status.yml
@@ -1,11 +1,11 @@
 locale: de
-last_updated: '2026-06-10'
+last_updated: '2026-06-05'
 coverage:
   skills:
     translated: 352
     total: 352
     pct: 100
-    stale: 0
+    stale: 133
     stubs: 0
   agents:
     translated: 3
@@ -17,17 +17,17 @@ coverage:
     translated: 1
     total: 17
     pct: 5.9
-    stale: 0
+    stale: 1
     stubs: 0
   guides:
     translated: 3
     total: 28
     pct: 10.7
-    stale: 0
+    stale: 1
     stubs: 1
   total:
     translated: 359
     total: 469
     pct: 76.5
-    stale: 0
+    stale: 135
     stubs: 1

--- a/i18n/es/translation_status.yml
+++ b/i18n/es/translation_status.yml
@@ -1,11 +1,11 @@
 locale: es
-last_updated: '2026-06-10'
+last_updated: '2026-06-05'
 coverage:
   skills:
     translated: 352
     total: 352
     pct: 100
-    stale: 0
+    stale: 136
     stubs: 0
   agents:
     translated: 3
@@ -17,17 +17,17 @@ coverage:
     translated: 1
     total: 17
     pct: 5.9
-    stale: 0
+    stale: 1
     stubs: 0
   guides:
     translated: 3
     total: 28
     pct: 10.7
-    stale: 0
+    stale: 1
     stubs: 1
   total:
     translated: 359
     total: 469
     pct: 76.5
-    stale: 0
+    stale: 138
     stubs: 1

--- a/i18n/ja/translation_status.yml
+++ b/i18n/ja/translation_status.yml
@@ -1,11 +1,11 @@
 locale: ja
-last_updated: '2026-06-10'
+last_updated: '2026-06-05'
 coverage:
   skills:
     translated: 352
     total: 352
     pct: 100
-    stale: 0
+    stale: 119
     stubs: 0
   agents:
     translated: 3
@@ -17,17 +17,17 @@ coverage:
     translated: 1
     total: 17
     pct: 5.9
-    stale: 0
+    stale: 1
     stubs: 0
   guides:
     translated: 3
     total: 28
     pct: 10.7
-    stale: 0
+    stale: 1
     stubs: 1
   total:
     translated: 359
     total: 469
     pct: 76.5
-    stale: 0
+    stale: 121
     stubs: 1

--- a/i18n/zh-CN/translation_status.yml
+++ b/i18n/zh-CN/translation_status.yml
@@ -1,11 +1,11 @@
 locale: zh-CN
-last_updated: '2026-06-10'
+last_updated: '2026-06-05'
 coverage:
   skills:
     translated: 352
     total: 352
     pct: 100
-    stale: 0
+    stale: 126
     stubs: 0
   agents:
     translated: 3
@@ -17,17 +17,17 @@ coverage:
     translated: 1
     total: 17
     pct: 5.9
-    stale: 0
+    stale: 1
     stubs: 0
   guides:
     translated: 3
     total: 28
     pct: 10.7
-    stale: 0
+    stale: 1
     stubs: 1
   total:
     translated: 359
     total: 469
     pct: 76.5
-    stale: 0
+    stale: 128
     stubs: 1

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -27,6 +27,18 @@ if (!existsSync(configPath)) {
 }
 const config = yaml.load(readFileSync(configPath, 'utf8'));
 
+// Staleness needs full history: per-file `git log` and `merge-base
+// --is-ancestor` both misreport in a shallow clone, so every translation
+// would read as fresh (stale: 0) — see #279.
+const isShallow = execSync('git rev-parse --is-shallow-repository', {
+  cwd: ROOT, encoding: 'utf8'
+}).trim();
+if (isShallow === 'true') {
+  console.error('ERROR: shallow clone detected — staleness would be silently wrong.');
+  console.error('Fetch full history first (actions/checkout fetch-depth: 0, or git fetch --unshallow).');
+  process.exit(1);
+}
+
 // Derive source counts from registries (single source of truth)
 const skillsRegistry = yaml.load(readFileSync(resolve(ROOT, 'skills/_registry.yml'), 'utf8'));
 const agentsRegistry = yaml.load(readFileSync(resolve(ROOT, 'agents/_registry.yml'), 'utf8'));


### PR DESCRIPTION
## Summary

- `update-readmes.yml` ran `generate-translation-status.js` in a depth-1 shallow clone; `git log -1 -- <file>` returns the grafted HEAD and `merge-base --is-ancestor` throws on absent commits, so `isStale()` silently reported everything fresh. Every CI auto-commit overwrote honest stale counts with zeros (latest: `ce282bb5` zeroed the honest counts from `95e380cc`).
- Fix: `fetch-depth: 0` on checkout, plus a loud-failure guard in the generator (`git rev-parse --is-shallow-repository` → abort with a clear message) so a shallow environment can never silently write zeros again.
- Catch-up: restore the 4 prose-locale `translation_status.yml` from honest commit `95e380cc` — no content commit landed in between, so staleness is unchanged; the diff is the exact inverse of the `ce282bb5` overwrite.

Full analysis in #279. Honest per-locale numbers recorded in #278.

Note: this PR's paths don't match the workflow's `on.push.paths` filter, so no auto-regen fires on merge; the next legitimate trigger regenerates with full history.

## Test plan

- [x] `node --check scripts/generate-translation-status.js`
- [x] workflow YAML parses (js-yaml)
- [x] `git rev-parse --is-shallow-repository` → `false` locally (guard passes on full clones)
- [x] restored status files byte-identical to `95e380cc` blobs

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)