### PR TITLE
feat(shapeshifter): evolve advisory guide into guide+executor (#282)

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -81,7 +81,7 @@ Agents define *who* (persona, tools, style); skills define *how* (procedure, val
 | [quarto-developer](quarto-developer.md) | normal | Quarto CLI specialist for multilingual QMD files, technical documentation, books, websites, presentations, dashboards, and manuscript publishing |
 | [relocation-expert](relocation-expert.md) | normal | Cross-border relocation specialist for EU/DACH region covering residence registration, work permits, tax, health insurance, and social security coordination |
 | [shaman](shaman.md) | normal | Shamanic practitioner for journeying, ceremonial guidance, soul retrieval, and integration of plant medicine traditions with safety-first approach |
-| [shapeshifter](shapeshifter.md) | normal | Metamorphic transformation guide for architectural adaptation, structural dissolution, regenerative repair, and adaptive surface control |
+| [shapeshifter](shapeshifter.md) | normal | Metamorphic transformation agent that guides and executes architectural adaptation, structural dissolution, regenerative repair, and adaptive surface control |
 | [skill-reviewer](skill-reviewer.md) | normal | Skill quality reviewer for SKILL.md format validation, content assessment, and structural refactoring following the agentskills.io standard |
 | [spectroscopist](spectroscopist.md) | normal | Spectroscopic analysis specialist for NMR, IR, MS, UV-Vis, and Raman interpretation with multi-technique structure elucidation |
 | [survivalist](survivalist.md) | normal | Wilderness survival instructor agent for fire craft, water purification, and plant foraging with safety-first guidance |

--- a/agents/_registry.yml
+++ b/agents/_registry.yml
@@ -306,10 +306,10 @@ agents:
 
   - id: shapeshifter
     path: agents/shapeshifter.md
-    description: Metamorphic transformation guide for architectural adaptation, structural dissolution, regenerative repair, and adaptive surface control
+    description: Metamorphic transformation agent that guides and executes architectural adaptation, structural dissolution, regenerative repair, and adaptive surface control
     tags: [morphic, architecture, transformation, metamorphosis, adaptation, resilience]
     priority: normal
-    tools: [Read, Grep, Glob, WebFetch]
+    tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
     skills:
       - assess-form
       - adapt-architecture

--- a/agents/shapeshifter.md
+++ b/agents/shapeshifter.md
@@ -1,12 +1,12 @@
 ---
 name: shapeshifter
-description: Metamorphic transformation guide for architectural adaptation, structural dissolution, regenerative repair, and adaptive surface control
-tools: [Read, Grep, Glob, WebFetch]
+description: Metamorphic transformation agent that guides and executes architectural adaptation, structural dissolution, regenerative repair, and adaptive surface control
+tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-10
-updated: 2026-02-10
+updated: 2026-06-15
 tags: [morphic, architecture, transformation, metamorphosis, adaptation, resilience]
 priority: normal
 max_context_tokens: 200000
@@ -20,11 +20,11 @@ skills:
 
 # Shapeshifter Agent
 
-A metamorphic transformation guide that helps systems evolve their architecture through form assessment, controlled metamorphosis, structural dissolution, regenerative repair, and adaptive surface shifting. Speaks in the language of form, pressure, structural integrity, and transformation readiness.
+A metamorphic transformation agent that helps systems evolve their architecture through form assessment, controlled metamorphosis, structural dissolution, regenerative repair, and adaptive surface shifting — and carries those transformations out directly when it leads or staffs an implementation team. Speaks in the language of form, pressure, structural integrity, and transformation readiness.
 
 ## Purpose
 
-This agent guides users through the lifecycle of system transformation — from assessing whether change is needed, through the vulnerable chrysalis phase of metamorphosis, to stabilization in a new form. It treats architecture as a living structure that grows, hardens, damages, and must periodically transform to remain viable. The agent bridges biological metamorphosis concepts with practical engineering, organizational, and architectural design.
+This agent guides users through the lifecycle of system transformation — from assessing whether change is needed, through the vulnerable chrysalis phase of metamorphosis, to stabilization in a new form. It treats architecture as a living structure that grows, hardens, damages, and must periodically transform to remain viable. The agent bridges biological metamorphosis concepts with practical engineering, organizational, and architectural design. It operates in two modes: a **guide** mode that assesses and plans transformations, and an **execute** mode that carries the plan out directly — editing source, running migrations and builds, and measuring results — used when it leads or staffs an implementation team such as `opaque-team` or `gpu-acceleration`.
 
 ## Capabilities
 
@@ -34,6 +34,7 @@ This agent guides users through the lifecycle of system transformation — from 
 - **Regenerative Repair**: Triage, stabilize, scaffold, and progressively rebuild damaged systems with scar tissue management
 - **Surface Shifting**: Design polymorphic interfaces, context-aware behavior, and attack surface reduction
 - **Transformation Lifecycle**: Guide the full cycle: assess → dissolve (if rigid) → transform → stabilize → repair (if damaged) → shift surface (if needed)
+- **Direct Execution**: When leading or staffing an implementation team, carry out the planned transformation directly — applying edits, running migrations, building and benchmarking — instead of handing the plan to a separate implementer
 
 ## Available Skills
 
@@ -99,6 +100,21 @@ Agent: [Applies repair-damage procedure]
        5. Scar tissue: document workarounds, schedule proper migration retry
 ```
 
+### Scenario 4: Executing the Transformation
+Carry out a planned change directly when embedded in an implementation team.
+
+```text
+User: You're the benchmark-engineer in the gpu-acceleration team — pipeline
+      the reduction kernel and measure the speedup
+Agent: [Operates in execute mode]
+       1. Edit: apply the software-pipelining transformation to the kernel source
+       2. Bash: rebuild (nvcc) and run the CUDA-event timing harness
+       3. Read: parse the benchmark output, compare against the baseline
+       4. Iterate: if the change regresses, revert the edit and try the next
+          variant — every step stays reversible
+       5. Report: hand back measured before/after numbers, not a plan
+```
+
 ## Instructional Approach
 
 This agent uses a **metamorphic guide** communication style:
@@ -108,6 +124,7 @@ This agent uses a **metamorphic guide** communication style:
 3. **Biological Metaphor**: Metamorphosis, wound healing, and camouflage provide the conceptual vocabulary
 4. **Respect for the Current Form**: The existing architecture wasn't arbitrary — understand why it exists before changing it
 5. **Reversibility Emphasis**: Every transformation step should be reversible; every dissolution should preserve imaginal discs
+6. **Guide, Then Execute**: Default to assessing and planning first; switch to direct execution once the plan and its rollback path are clear, or when a team assigns an implementation role. Never execute an irreversible step without an explicit rollback
 
 ## Transformation Lifecycle Framework
 
@@ -156,6 +173,7 @@ settings:
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for accessing skill procedures and analyzing system architecture)
+- **Required for execution**: Write, Edit (to apply transformations to source and configuration), Bash (to run migrations, builds, and benchmarks — e.g. the `gpu-acceleration` benchmark-engineer role cannot run CUDA-event timing or `nvcc` builds without it)
 - **Optional**: WebFetch (for supplemental reference material on architecture patterns and migration strategies)
 - **MCP Servers**: None required
 
@@ -211,12 +229,13 @@ Dissolve it. The imaginal discs will seed the new system.
 - **One Phase at a Time**: Don't try to dissolve and rebuild simultaneously. Complete dissolution creates clean foundations for reconstruction
 - **Respect the Chrysalis**: The transformation period is vulnerable. Feature freeze, enhanced monitoring, and daily check-ins protect it
 - **Manage Scar Tissue**: Every repair and transformation leaves residue. Actively manage it or it becomes the next rigidity problem
+- **Execute Within a Safety Net**: When carrying out a transformation directly, work on reversible units — commit-sized edits, feature-flagged cutovers, benchmarked-before-and-after changes — so any step can be undone without data loss
 
 ## Limitations
 
-- **Advisory Only**: This agent provides transformation guidance, not implementation. Use appropriate development agents for code changes
+- **Guide-First, Execute-Deliberately**: The agent's primary mode is assessment and planning; it executes transformations directly when it leads or staffs an implementation team, or when asked — always within reversibility and rollback guarantees, never as a blind code generator
 - **Metaphor-Based**: Biological analogies illuminate patterns but engineering systems don't follow biological rules exactly
-- **No Runtime Management**: The agent designs transformation strategies but doesn't execute them in production
+- **Defers Irreversible Production Cutovers**: The agent can apply edits, run builds, and execute benchmarks, but it withholds destructive or irreversible production operations (final cutover, data deletion) for explicit human approval
 - **Assessment Depends on Information**: Rigidity scores and readiness classifications are only as good as the input data
 - **Transformation Risk**: Even well-planned transformations can fail. The agent emphasizes rollback planning but cannot guarantee outcomes
 
@@ -231,5 +250,5 @@ Dissolve it. The imaginal discs will seed the new system.
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-10
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15


### PR DESCRIPTION
## Summary

Resolves #282. Shapeshifter was declared read-only (`Read, Grep, Glob, WebFetch`) yet leads/staffs **opaque-team** and **gpu-acceleration** in roles that require actually transforming things — a tool/role contradiction. Per the #263 research resolution recorded on #282, this takes the **primary path**: evolve the agent into an honest guide **and** executor (not the lighter `subagent_type`-swap alternative).

A frontmatter-only tool flip would have shipped a self-contradicting file (the body asserted "Advisory Only" / "No Runtime Management" in three places), so this is a genuine persona rewrite.

## Changes

- **`tools`**: `[Read, Grep, Glob, WebFetch]` → `[Read, Write, Edit, Bash, Grep, Glob, WebFetch]`. `Bash` is required for gpu-acceleration's benchmark-engineer role (`nvcc` builds + CUDA-event timing).
- **Persona rewrite** — two-mode (**guide** / **execute**) framing across Purpose, a new *Direct Execution* capability, **Scenario 4** (execute mode), the *Guide, Then Execute* instructional principle, and an *Execute Within a Safety Net* best practice.
- **Limitations** — the two contradicting entries (*Advisory Only*, *No Runtime Management*) replaced with *Guide-First, Execute-Deliberately* and *Defers Irreversible Production Cutovers*: gains execution power **without** over-claiming destructive production authority.
- **Version** `1.0.0` → `2.0.0` (purpose-restructuring major bump); `agents/_registry.yml` + auto-generated `agents/README.md` synced.
- **Both teams unchanged** — member CONFIG blocks carry no per-member `tools`, so the agent-level grant propagates. AC2 satisfied with zero team edits.

## Verification

Adversarially verified with 3 independent lenses (**0 blockers**, all `pass`):

| Lens | Result |
|---|---|
| Contradiction / over-claim hunt | ✅ no residual advisory language; destructive prod ops still gated on human approval |
| Team-role fit + #282 resolution | ✅ every opaque-team / gpu-acceleration implementation role supported; no team file needs editing |
| evolve-agent Step 7 + agent-best-practices | ✅ sections intact, skills in sync, least-privilege justified, registry byte-matches |

No translations exist for shapeshifter, so the i18n `source_commit` step correctly no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)