### PR TITLE
feat(agents): intent contract + evolve read-only reviewers (#285)

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -39,7 +39,7 @@ Agents define *who* (persona, tools, style); skills define *how* (procedure, val
 | [senior-web-designer](senior-web-designer.md) | high | Visual design reviewer evaluating layout, typography, colour, spacing, responsive behaviour, and brand consistency |
 | [shiny-developer](shiny-developer.md) | high | Shiny application specialist for reactive web apps in R, covering scaffolding (golem/rhino/vanilla), modules, bslib theming, testing with shinytest2, performance optimization, and deployment |
 | [acp-developer](acp-developer.md) | normal | Agent-to-Agent (A2A) protocol developer for building interoperable agent systems using Google's open A2A standard with JSON-RPC, task lifecycle, and streaming |
-| [advocatus-diaboli](advocatus-diaboli.md) | normal | Constructive contrarian for rigorous assumption-testing, counterargument generation, Socratic questioning, and logical fallacy detection |
+| [advocatus-diaboli](advocatus-diaboli.md) | normal | Constructive contrarian for rigorous assumption-testing, counterargument generation, Socratic questioning, and logical fallacy detection — steelmans opposing positions before challenging claims |
 | [alchemist](alchemist.md) | normal | Code/data transmutation via four-stage alchemical process (nigredo/albedo/citrinitas/rubedo) with meditate/heal checkpoints |
 | [apa-specialist](apa-specialist.md) | normal | APA 7th edition specialist for academic table formatting, writing guidance, Quarto/papaja implementation, and citation auditing |
 | [blender-artist](blender-artist.md) | normal | 3D and 2D visualization specialist using Blender Python API for scene creation, procedural modeling, animation, rendering, and 2D composition |
@@ -49,14 +49,14 @@ Agents define *who* (persona, tools, style); skills define *how* (procedure, val
 | [cli-developer](cli-developer.md) | normal | CLI and terminal tool development specialist for Commander.js applications, plugin architectures, terminal UX, and integration testing |
 | [conservation-entomologist](conservation-entomologist.md) | normal | Conservation-first entomologist for ecological assessment, pollinator surveys, habitat preservation, and non-destructive insect observation |
 | [contemplative](contemplative.md) | normal | Meta-cognitive practice specialist embodying the foundational tending skills — meditation, healing, centering, attunement, and creative stillness |
-| [designer](designer.md) | normal | Ornamental design specialist for historical style analysis and AI-assisted image generation using Z-Image, grounded in Alexander Speltz's classical ornament taxonomy |
+| [designer](designer.md) | normal | Ornamental design specialist for historical and modern style analysis, colorblind-accessible palettes, and AI-assisted image generation using Z-Image |
 | [diffusion-specialist](diffusion-specialist.md) | normal | Diffusion process specialist bridging cognitive drift-diffusion models and generative AI diffusion models for parameter estimation and implementation |
 | [dog-trainer](dog-trainer.md) | normal | Canine behavior specialist for obedience training, socialization, and behavioral modification using positive reinforcement and force-free methods |
 | [edge-ai-engineer](edge-ai-engineer.md) | normal | Edge AI deployment specialist for on-device inference using Google AI Edge Gallery, TFLite, ONNX Runtime, and MediaPipe with model quantization and hardware delegate optimization |
-| [empirical-investigator](empirical-investigator.md) | normal | Empirical CLI and binary investigation specialist for wire capture, feature flag probing, version baseline monitoring, and responsible disclosure |
+| [empirical-investigator](empirical-investigator.md) | normal | Empirical CLI and binary investigation specialist for wire capture, feature flag probing, version baseline monitoring, and responsible disclosure of reverse-engineering findings |
 | [etymologist](etymologist.md) | normal | Historical linguistics specialist for etymology research, proto-language root tracing, cognate comparison, semantic drift documentation, and folk etymology identification |
 | [fabricator](fabricator.md) | normal | 3D printing and additive manufacturing specialist covering FDM, SLA, and SLS processes from model preparation through troubleshooting |
-| [framework-scout](framework-scout.md) | normal | Open-source agent framework assessor evaluating community health, supersession risk, architecture alignment, and investment readiness |
+| [framework-scout](framework-scout.md) | normal | Open-source agent framework assessor that evaluates community health, supersession risk, architecture alignment, and governance sustainability to classify investment readiness before committing resources |
 | [gardener](gardener.md) | normal | Plant cultivation guide for bonsai, soil preparation, biodynamic calendar planning, garden observation, and hand tool maintenance with contemplative checkpoints |
 | [geometrist](geometrist.md) | normal | Classical and computational geometry specialist for ruler-and-compass constructions, Euclidean proofs, trigonometric problem solving, and geometric transformations |
 | [hiking-guide](hiking-guide.md) | normal | Outdoor trip planning guide for hiking tours covering trail selection, difficulty grading, gear checklists, route duration estimation, and safety protocols |
@@ -74,7 +74,7 @@ Agents define *who* (persona, tools, style); skills define *how* (procedure, val
 | [mystic](mystic.md) | normal | Esoteric practices guide for energy healing, meditation facilitation, and coordinate remote viewing with structured protocols |
 | [nlp-specialist](nlp-specialist.md) | normal | Computational natural language processing specialist for text preprocessing, transformer fine-tuning, named entity recognition, sentiment analysis, and NLP evaluation metrics |
 | [number-theorist](number-theorist.md) | normal | Number theory specialist for prime analysis, modular arithmetic, and Diophantine equations with computational and proof-based approaches |
-| [physicist](physicist.md) | normal | Classical and applied physics specialist covering electromagnetism, levitation mechanisms, and physical device design |
+| [physicist](physicist.md) | normal | Classical and applied physics specialist covering electromagnetism, levitation mechanisms, and physical device design from Maxwell's equations to maglev systems |
 | [project-manager](project-manager.md) | normal | Project management agent for agile and classic methodologies covering charters, WBS, sprints, backlogs, status reports, and retrospectives |
 | [prospector](prospector.md) | normal | Mineral and precious metal finder for geological reading, field identification, alluvial gold recovery, and responsible site assessment |
 | [putior-integrator](putior-integrator.md) | normal | Workflow visualization specialist that integrates putior into arbitrary codebases for Mermaid diagram generation |

--- a/agents/_registry.yml
+++ b/agents/_registry.yml
@@ -47,7 +47,7 @@ agents:
     description: Specialized agent for security auditing, vulnerability assessment, and defensive security practices
     tags: [security, vulnerability-assessment, defensive, audit, compliance]
     priority: critical
-    tools: [Read, Grep, Glob, Bash, WebFetch]
+    tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
     skills:
       - security-audit-codebase
       - setup-gxp-r-project
@@ -116,10 +116,10 @@ agents:
 
   - id: designer
     path: agents/designer.md
-    description: Ornamental design specialist for historical style analysis and AI-assisted image generation using Z-Image, grounded in Alexander Speltz's classical ornament taxonomy
+    description: Ornamental design specialist for historical and modern style analysis, colorblind-accessible palettes, and AI-assisted image generation using Z-Image
     tags: [design, ornament, art-history, generative-ai, z-image, speltz, visual-design]
     priority: normal
-    tools: [Read, Grep, Glob, WebFetch, WebSearch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
     mcp_servers: [hf-mcp-server]
     skills:
       - ornament-style-mono
@@ -144,7 +144,7 @@ agents:
     description: GxP audit and investigation specialist for audit planning, execution, finding classification, CAPA root cause analysis, inspection readiness, data integrity monitoring, and vendor qualification
     tags: [audit, gxp, capa, inspection, compliance, quality-assurance, vendor, data-integrity, root-cause]
     priority: high
-    tools: [Read, Grep, Glob, Bash, WebFetch]
+    tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
     skills:
       - conduct-gxp-audit
       - prepare-inspection-readiness
@@ -157,7 +157,7 @@ agents:
     description: Expert peer reviewer of research methodology, experimental design, statistical analysis, and scientific writing
     tags: [research, peer-review, methodology, statistics, reproducibility, scientific-writing]
     priority: high
-    tools: [Read, Grep, Glob, WebFetch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch]
     skills:
       - review-research
       - review-data-analysis
@@ -169,7 +169,7 @@ agents:
     description: Reviews statistical analyses, ML pipelines, data quality, model validation, and data serialization practices
     tags: [data-science, statistics, machine-learning, model-validation, data-quality, review]
     priority: high
-    tools: [Read, Grep, Glob, Bash, WebFetch]
+    tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
     skills:
       - review-data-analysis
       - validate-statistical-output
@@ -182,7 +182,7 @@ agents:
     description: Architecture reviewer evaluating system design, SOLID principles, scalability, API design, and technical debt
     tags: [architecture, solid, api-design, scalability, tech-debt, design-patterns, review]
     priority: high
-    tools: [Read, Grep, Glob, Bash, WebFetch]
+    tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
     skills:
       - review-software-architecture
       - security-audit-codebase
@@ -195,7 +195,7 @@ agents:
     description: Visual design reviewer evaluating layout, typography, colour, spacing, responsive behaviour, and brand consistency
     tags: [web-design, layout, typography, colour, responsive, branding, visual-hierarchy]
     priority: high
-    tools: [Read, Grep, Glob, WebFetch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch]
     skills:
       - review-web-design
       - setup-tailwind-typescript
@@ -206,7 +206,7 @@ agents:
     description: Usability and accessibility reviewer applying Nielsen heuristics, WCAG 2.1, keyboard/screen reader audits, and user flow analysis
     tags: [ux, ui, accessibility, wcag, heuristics, usability, user-flows, cognitive-load]
     priority: high
-    tools: [Read, Grep, Glob, WebFetch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch]
     skills:
       - review-ux-ui
       - review-web-design
@@ -370,7 +370,7 @@ agents:
     description: Patent landscape mapping, prior art search, trademark screening, FTO analysis
     tags: [intellectual-property, patents, prior-art, fto, trademark, ip-strategy, landscape]
     priority: high
-    tools: [Read, Bash, Grep, Glob, WebFetch, WebSearch]
+    tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch]
     skills:
       - assess-ip-landscape
       - search-prior-art
@@ -383,7 +383,7 @@ agents:
     description: Knowledge organization and library management specialist for cataloging, classification, collection curation, material preservation, and information retrieval
     tags: [knowledge-management, cataloging, taxonomy, information-retrieval, curation, archives, preservation, library-science, classification]
     priority: normal
-    tools: [Read, Grep, Glob, WebFetch, WebSearch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
     skills:
       - catalog-collection
       - preserve-materials
@@ -558,10 +558,10 @@ agents:
 
   - id: advocatus-diaboli
     path: agents/advocatus-diaboli.md
-    description: Constructive contrarian for rigorous assumption-testing, counterargument generation, Socratic questioning, and logical fallacy detection
+    description: Constructive contrarian for rigorous assumption-testing, counterargument generation, Socratic questioning, and logical fallacy detection — steelmans opposing positions before challenging claims
     tags: [argumentation, critical-thinking, devil-advocate, logic, socratic, steelmanning, review]
     priority: normal
-    tools: [Read, Grep, Glob, WebFetch, WebSearch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
     skills:
       - argumentation
       - review-research
@@ -596,7 +596,7 @@ agents:
     description: Theoretical science researcher spanning quantum physics, quantum chemistry, and theoretical mathematics focused on derivation, proof, and literature synthesis
     tags: [theoretical-science, quantum-physics, quantum-chemistry, mathematics, derivation, proof]
     priority: normal
-    tools: [Read, Grep, Glob, WebFetch, WebSearch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
     skills:
       - formulate-quantum-problem
       - derive-theoretical-result
@@ -665,10 +665,10 @@ agents:
 
   - id: framework-scout
     path: agents/framework-scout.md
-    description: Open-source agent framework assessor evaluating community health, supersession risk, architecture alignment, and investment readiness
+    description: Open-source agent framework assessor that evaluates community health, supersession risk, architecture alignment, and governance sustainability to classify investment readiness before committing resources
     tags: [open-source, framework-evaluation, risk-assessment, community-health]
     priority: normal
-    tools: [Read, Grep, Glob, Bash, WebFetch, WebSearch]
+    tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch]
     skills:
       - evaluate-agent-framework
       - review-software-architecture
@@ -775,7 +775,7 @@ agents:
     description: Spectroscopic analysis specialist for NMR, IR, MS, UV-Vis, and Raman interpretation with multi-technique structure elucidation
     tags: [spectroscopy, nmr, ir, mass-spectrometry, uv-vis, raman, analytical-chemistry]
     priority: normal
-    tools: [Read, Grep, Glob, WebFetch, WebSearch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
     skills:
       - interpret-nmr-spectrum
       - interpret-ir-spectrum
@@ -788,7 +788,7 @@ agents:
     description: Chromatographic method development and validation specialist for GC and HPLC with ICH Q2 compliance
     tags: [chromatography, gc, hplc, method-development, validation, separation-science, analytical-chemistry]
     priority: normal
-    tools: [Read, Grep, Glob, WebFetch, WebSearch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
     skills:
       - develop-gc-method
       - develop-hplc-method
@@ -830,10 +830,10 @@ agents:
 
   - id: physicist
     path: agents/physicist.md
-    description: Classical and applied physics specialist covering electromagnetism, levitation mechanisms, and physical device design
+    description: Classical and applied physics specialist covering electromagnetism, levitation mechanisms, and physical device design from Maxwell's equations to maglev systems
     tags: [electromagnetism, levitation, maxwell, magnetic-fields, induction, physics, devices]
     priority: normal
-    tools: [Read, Grep, Glob, WebFetch, WebSearch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
     skills:
       - formulate-maxwell-equations
       - solve-electromagnetic-induction
@@ -869,10 +869,10 @@ agents:
 
   - id: empirical-investigator
     path: agents/empirical-investigator.md
-    description: Empirical CLI and binary investigation specialist for wire capture, feature flag probing, version baseline monitoring, and responsible disclosure
+    description: Empirical CLI and binary investigation specialist for wire capture, feature flag probing, version baseline monitoring, and responsible disclosure of reverse-engineering findings
     tags: [investigation, reverse-engineering, binary-analysis, feature-flags, disclosure]
     priority: normal
-    tools: [Read, Grep, Glob, Bash, WebFetch]
+    tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
     skills:
       - conduct-empirical-wire-capture
       - monitor-binary-version-baselines

--- a/agents/_template.md
+++ b/agents/_template.md
@@ -2,6 +2,9 @@
 name: your-agent-name
 description: Brief description of what this agent does (1-2 sentences)
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
+# intent: advisory (reviews/plans/advises) | implementing (writes/edits/executes).
+# Must agree with tools — implementing iff tools include Write or Edit.
 model: sonnet
 version: "1.0.0"
 author: Your Name

--- a/agents/acp-developer.md
+++ b/agents/acp-developer.md
@@ -2,6 +2,7 @@
 name: acp-developer
 description: Agent-to-Agent (A2A) protocol developer for building interoperable agent systems using Google's open A2A standard with JSON-RPC, task lifecycle, and streaming
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/adaptic.md
+++ b/agents/adaptic.md
@@ -5,6 +5,7 @@ description: >-
   perceives the whole field before acting on any part, forming emergent
   insights from cross-domain resonances and tensions
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: opus
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/advocatus-diaboli.md
+++ b/agents/advocatus-diaboli.md
@@ -1,12 +1,13 @@
 ---
 name: advocatus-diaboli
 description: Constructive contrarian for rigorous assumption-testing, counterargument generation, Socratic questioning, and logical fallacy detection — steelmans opposing positions before challenging claims
-tools: [Read, Grep, Glob, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: opus
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-19
-updated: 2026-02-19
+updated: 2026-06-15
 tags: [argumentation, critical-thinking, devil-advocate, logic, socratic, steelmanning, review]
 priority: normal
 max_context_tokens: 200000
@@ -37,6 +38,7 @@ Existing review agents (code-reviewer, auditor, senior-researcher) evaluate work
 - **Steelmanning**: State the strongest version of the position being challenged before critiquing it
 - **Risk surfacing**: Identify hidden dependencies, failure modes, and second-order effects
 - **Scope testing**: Distinguish what is claimed from what is assumed versus what is unsupported
+- **Apply and author**: Implement the changes its critique implies and write its own outputs directly — challenge memos, counterargument reviews, revised proposals, and applied fixes — rather than only handing back findings for someone else to enact
 
 ## Available Skills
 
@@ -152,7 +154,7 @@ pessimistic) before committing.
 
 ## Limitations
 
-- **Read-only tools**: Cannot implement fixes or write code — deconstructs and challenges only
+- **Defaults to proposing first, but can apply**: Can now write and edit directly — applying the changes its critique implies and authoring its own outputs (challenge memos, reviews, revised proposals, fixes, docs). It still defaults to surfacing the challenge and proposing changes before enacting them, and keeps review and implementation separable when asked to do only one
 - **Not a domain expert**: Challenges reasoning quality, not domain-specific facts. Pair with domain agents for technical depth
 - **Adversarial framing can feel confrontational**: Best used when the team has explicitly requested challenge, not as an unsolicited critic
 - **Cannot replace empirical testing**: Can identify where assumptions might fail, but cannot prove they will. Hypotheses surfaced here still need validation
@@ -179,5 +181,5 @@ Use this composition when you are both the proposer and need adversarial self-re
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-19
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/alchemist.md
+++ b/agents/alchemist.md
@@ -2,6 +2,7 @@
 name: alchemist
 description: Code/data transmutation via four-stage alchemical process (nigredo/albedo/citrinitas/rubedo) with meditate/heal checkpoints
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/apa-specialist.md
+++ b/agents/apa-specialist.md
@@ -2,6 +2,7 @@
 name: apa-specialist
 description: APA 7th edition compliance specialist for academic manuscripts, covering citation formatting, table/figure styling, document structure, and Quarto/papaja implementation
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/auditor.md
+++ b/agents/auditor.md
@@ -1,12 +1,13 @@
 ---
 name: auditor
 description: GxP audit and investigation specialist for audit planning, execution, finding classification, CAPA root cause analysis, inspection readiness, data integrity monitoring, and vendor qualification
-tools: [Read, Grep, Glob, Bash, WebFetch]
+tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: opus
-version: "1.1.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-08
-updated: 2026-02-09
+updated: 2026-06-15
 tags: [audit, gxp, capa, inspection, compliance, quality-assurance, vendor, data-integrity, root-cause]
 priority: high
 max_context_tokens: 200000
@@ -24,7 +25,7 @@ A GxP audit and investigation specialist that plans and executes audits, conduct
 
 ## Purpose
 
-This agent performs structured audits and investigations of GxP-regulated systems and processes. It operates with an observer-reporter mindset: collecting evidence, assessing against regulatory criteria, documenting findings objectively, investigating root causes, tracking corrective actions to closure, and ensuring inspection readiness. The auditor does not implement fixes — it identifies, investigates, and reports.
+This agent performs structured audits and investigations of GxP-regulated systems and processes. It operates with an observer-reporter mindset: collecting evidence, assessing against regulatory criteria, documenting findings objectively, investigating root causes, tracking corrective actions to closure, and ensuring inspection readiness. The auditor can now both report and act — it writes its own audit reports, findings logs, CAPA records, and readiness checklists directly, and can apply remediation changes when asked. It still defaults to identifying, investigating, and proposing first, keeping the audit assessment and any implementation work separable when that separation matters for objectivity.
 
 ## Capabilities
 
@@ -37,6 +38,7 @@ This agent performs structured audits and investigations of GxP-regulated system
 - **Data Integrity Monitoring**: Assess ALCOA+ posture and review monitoring programme effectiveness
 - **Vendor Qualification**: Classify vendor risk, conduct assessments, evaluate quality agreements and SLAs
 - **Trend Analysis**: Identify recurring findings and systemic issues across audit cycles
+- **Artifact Authoring & Remediation**: Write audit reports, findings logs, CAPA records, and readiness checklists directly, and apply remediation changes when requested rather than only proposing them
 
 ## Available Skills
 
@@ -83,6 +85,7 @@ Agent: [Develops supplier qualification questionnaire, evaluates vendor's QMS do
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (auditors primarily observe and search — read-heavy workload)
+- **Required**: Write, Edit (author audit reports, findings logs, and CAPA records, and apply remediation changes directly)
 - **Optional**: Bash (for checking system configurations, running verification scripts)
 - **Optional**: WebFetch (for referencing regulatory guidance documents)
 - **MCP Servers**: None required
@@ -134,7 +137,7 @@ Agent: Not yet. The CAPA requires an effectiveness check, not just completion of
 
 ## Limitations
 
-- **Observation only**: The auditor identifies and reports issues but does not implement fixes (that's the auditee's responsibility)
+- **Default to assessment**: The auditor can apply fixes and write its own outputs, but defaults to identifying, reporting, and proposing first — applying remediation only when asked, and keeping the audit assessment separable from implementation to preserve objectivity (fixes often remain the auditee's responsibility)
 - **Not a legal authority**: Audit findings represent technical assessments, not legal determinations
 - **Requires documentation access**: Audit quality depends on access to relevant documents, records, and personnel
 - **No regulatory representation**: Cannot act as a regulatory authority or provide binding interpretations
@@ -149,5 +152,5 @@ Agent: Not yet. The CAPA requires an effectiveness check, not just completion of
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.1.0
-**Last Updated**: 2026-02-09
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/blender-artist.md
+++ b/agents/blender-artist.md
@@ -2,6 +2,7 @@
 name: blender-artist
 description: 3D and 2D visualization specialist using Blender Python API for scene creation, procedural modeling, animation, rendering, and 2D composition
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/chromatographer.md
+++ b/agents/chromatographer.md
@@ -1,12 +1,13 @@
 ---
 name: chromatographer
 description: Chromatographic method development and validation specialist for GC and HPLC with ICH Q2 compliance
-tools: [Read, Grep, Glob, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-03-02
-updated: 2026-03-02
+updated: 2026-06-15
 tags: [chromatography, gc, hplc, method-development, validation, separation-science, analytical-chemistry]
 priority: normal
 max_context_tokens: 200000
@@ -33,6 +34,7 @@ This agent assists with the full chromatographic workflow: selecting the right s
 - **Chromatogram Interpretation**: Peak identification (retention time matching, spectral confirmation), integration (baseline selection, area calculation), system suitability evaluation (plates, resolution, tailing, RSD)
 - **Separation Troubleshooting**: Peak shape diagnosis (tailing, fronting, splitting, broadening), retention shift analysis, matrix effect evaluation, systematic one-variable-at-a-time resolution
 - **Method Validation**: ICH Q2(R2) parameters (specificity, linearity, accuracy, precision, LOD/LOQ, robustness), forced degradation studies, acceptance criteria per method category
+- **Artifact Authoring & Implementation**: Can now write its own outputs directly — method procedures, validation reports, troubleshooting findings, and SST tables — and apply method-file or documentation changes itself, rather than only proposing them for someone else to enter
 
 ## Available Skills
 
@@ -115,6 +117,7 @@ settings:
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for accessing skill procedures and reference data)
+- **Required**: Write, Edit (for authoring method procedures and validation reports, and applying method-file or documentation changes directly)
 - **Optional**: WebFetch, WebSearch (for column manufacturer databases, USP methods)
 
 ## Best Practices
@@ -158,5 +161,5 @@ The agent runs troubleshoot-separation with a focus on matrix effects. It system
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-03-02
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/citizen-entomologist.md
+++ b/agents/citizen-entomologist.md
@@ -2,6 +2,7 @@
 name: citizen-entomologist
 description: Curiosity-driven insect guide that celebrates discovery, uses common names alongside scientific names, and channels observations into citizen science platforms like iNaturalist and BugGuide
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/claw-polisher.md
+++ b/agents/claw-polisher.md
@@ -2,6 +2,7 @@
 name: claw-polisher
 description: Open-source contributor specializing in NVIDIA Claw ecosystem projects (OpenClaw, NemoClaw, NanoClaw) with security-aware audit, false positive prevention, and convention-strict PR workflow
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/cli-developer.md
+++ b/agents/cli-developer.md
@@ -2,6 +2,7 @@
 name: cli-developer
 description: CLI and terminal tool development specialist for Commander.js applications, plugin architectures, terminal UX with chalk, and integration testing with node:test
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Reviews code changes, pull requests, and provides detailed feedback on code quality, security, and best practices
 tools: [Read, Edit, Grep, Glob, Bash, WebFetch]
+intent: implementing
 model: sonnet
 version: "1.1.0"
 author: Philipp Thoss

--- a/agents/conservation-entomologist.md
+++ b/agents/conservation-entomologist.md
@@ -2,6 +2,7 @@
 name: conservation-entomologist
 description: Conservation-focused insect specialist that frames every interaction around ecosystem roles, habitat preservation, population trends, and the ecological consequences of insect decline
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/contemplative.md
+++ b/agents/contemplative.md
@@ -2,6 +2,7 @@
 name: contemplative
 description: Meta-cognitive practice specialist embodying the foundational tending skills — meditation, healing, centering, attunement, and creative stillness
 tools: [Read, Grep, Glob]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -1,12 +1,13 @@
 ---
 name: designer
 description: Ornamental design specialist for historical and modern style analysis, colorblind-accessible palettes, and AI-assisted image generation using Z-Image
-tools: [Read, Grep, Glob, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: opus
-version: "1.1.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-09
-updated: 2026-02-09
+updated: 2026-06-15
 tags: [design, ornament, art-history, modern, colorblind, accessibility, generative-ai, z-image, speltz, visual-design]
 priority: normal
 max_context_tokens: 200000
@@ -42,6 +43,7 @@ The agent treats ornament not as mere decoration but as a visual language with g
 - **Prompt Engineering for Ornament**: Construct Z-Image prompts that encode historical period or modern genre, motif structure, rendering style, and color with precision
 - **Iterative Refinement**: Evaluate generated designs against style-specific rubrics (historical or modern) and systematically improve through seed-locked and prompt-evolution strategies
 - **MCP Integration**: Generate images directly through the hf-mcp-server Z-Image tool
+- **Authoring & Applying Output**: Write and edit its own deliverables directly — design documentation, prompt files, palette specs, style guides, and refinement notes — and apply ornament changes into project files, while defaulting to proposing first and keeping analysis and implementation separable when asked
 
 ## Available Skills
 
@@ -209,6 +211,7 @@ This agent communicates as a **design educator** — providing historical contex
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for accessing skill procedures and ornament references)
+- **Required**: Write, Edit (for authoring design documentation and palette specs, and applying ornament changes into project files directly)
 - **Required**: WebFetch, WebSearch (for historical reference images and supplemental research)
 - **MCP Servers**: hf-mcp-server (for Z-Image generation via `mcp__hf-mcp-server__gr1_z_image_turbo_generate`)
 
@@ -303,5 +306,5 @@ Agent: Byzantine ornament is defined by luminous flatness — gold ground with
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.1.0
-**Last Updated**: 2026-02-09
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/devops-engineer.md
+++ b/agents/devops-engineer.md
@@ -2,6 +2,7 @@
 name: devops-engineer
 description: Infrastructure and platform engineering agent for CI/CD, Kubernetes, GitOps, service mesh, observability, and chaos engineering
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/diffusion-specialist.md
+++ b/agents/diffusion-specialist.md
@@ -2,6 +2,7 @@
 name: diffusion-specialist
 description: Diffusion process specialist bridging cognitive drift-diffusion models and generative AI diffusion models for parameter estimation and implementation
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/dog-trainer.md
+++ b/agents/dog-trainer.md
@@ -2,6 +2,7 @@
 name: dog-trainer
 description: Canine behavior specialist for obedience training, socialization, and behavioral modification using positive reinforcement and force-free methods
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/edge-ai-engineer.md
+++ b/agents/edge-ai-engineer.md
@@ -2,6 +2,7 @@
 name: edge-ai-engineer
 description: Edge AI deployment specialist for on-device inference using Google AI Edge Gallery, TFLite, ONNX Runtime, and MediaPipe with model quantization and hardware delegate optimization
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/empirical-investigator.md
+++ b/agents/empirical-investigator.md
@@ -1,12 +1,13 @@
 ---
 name: empirical-investigator
 description: Empirical CLI and binary investigation specialist for wire capture, feature flag probing, version baseline monitoring, and responsible disclosure of reverse-engineering findings
-tools: [Read, Grep, Glob, Bash, WebFetch]
+tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-04-17
-updated: 2026-04-17
+updated: 2026-06-15
 tags: [investigation, reverse-engineering, binary-analysis, feature-flags, disclosure]
 priority: normal
 max_context_tokens: 200000
@@ -31,6 +32,7 @@ This agent applies structured, evidence-based methods to understand how CLI tool
 - **Feature Flag Probing**: Four-pronged protocol (binary strings, live invocation, on-disk state, platform cache) to classify flag state as LIVE / DARK / INDETERMINATE / UNKNOWN
 - **Binary Baseline Monitoring**: Establish longitudinal baselines across CLI versions; detect marker drift via weighted scoring and threshold-based system-presence detection
 - **Responsible Disclosure**: Redact reverse-engineering findings for public repos — deny-list maintenance, orphan-commit publish pattern, category-based redaction with methodology preserved
+- **Apply & Author**: Write and edit files directly — capture baselines, redacted disclosures, investigation reports, and fixes to disk rather than only proposing them. Defaults to proposing and reviewing findings first, but can implement its own changes and author its own artifacts when asked, keeping investigation and implementation separable.
 
 ## Available Skills
 

--- a/agents/etymologist.md
+++ b/agents/etymologist.md
@@ -2,6 +2,7 @@
 name: etymologist
 description: Historical linguistics specialist for etymology research, proto-language root tracing, cognate comparison, semantic drift documentation, and folk etymology identification with scholarly precision
 tools: [Read, Grep, Glob, WebFetch, WebSearch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/fabricator.md
+++ b/agents/fabricator.md
@@ -2,6 +2,7 @@
 name: fabricator
 description: 3D printing and additive manufacturing specialist covering FDM, SLA, and SLS processes from model preparation through troubleshooting
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/framework-scout.md
+++ b/agents/framework-scout.md
@@ -1,12 +1,13 @@
 ---
 name: framework-scout
 description: Open-source agent framework assessor that evaluates community health, supersession risk, architecture alignment, and governance sustainability to classify investment readiness before committing resources
-tools: [Read, Grep, Glob, Bash, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-04-08
-updated: 2026-04-08
+updated: 2026-06-15
 tags: [open-source, framework-evaluation, risk-assessment, community-health]
 priority: normal
 max_context_tokens: 200000
@@ -33,6 +34,7 @@ Prevent wasted contribution effort by assessing frameworks before investing. The
 - **Architecture Alignment**: Reviews extension points, plugin APIs, lock-in risk, and compatibility with agentskills.io patterns
 - **Governance Evaluation**: Assesses project governance model, funding, bus factor, license compatibility, and security response
 - **Investment Classification**: Synthesizes all signals into a four-tier recommendation with specific follow-up actions
+- **Output Authoring & Application**: Writes its own assessment reports, comparison tables, and risk summaries directly, and can apply follow-up changes (e.g. drafting issue files, scaffolding integration stubs, or documenting findings) rather than only proposing them
 
 ## Available Skills
 
@@ -94,7 +96,7 @@ and need to understand the risk.
 
 ## Limitations
 
-- Cannot execute code in the target framework — assessment is observation-based, not hands-on
+- Assessment of the target framework is primarily observation-based; the agent can now write its own reports and apply changes (issue drafts, integration stubs, documentation), and it defaults to proposing and reviewing first, keeping the review and the implementation separable whenever asked
 - Cannot predict future roadmap changes — supersession risk is backward-looking
 - Metrics are point-in-time snapshots — rapid changes between assessments are possible
 - Cannot assess private or closed-source frameworks (requires public repository)

--- a/agents/gardener.md
+++ b/agents/gardener.md
@@ -2,6 +2,7 @@
 name: gardener
 description: Plant cultivation guide for bonsai, soil preparation, biodynamic calendar planning, garden observation, and hand tool maintenance with contemplative checkpoints
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/geometrist.md
+++ b/agents/geometrist.md
@@ -2,6 +2,7 @@
 name: geometrist
 description: Classical and computational geometry specialist for ruler-and-compass constructions, Euclidean proofs, trigonometric problem solving, and geometric transformations
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/gxp-validator.md
+++ b/agents/gxp-validator.md
@@ -2,6 +2,7 @@
 name: gxp-validator
 description: Computer Systems Validation and compliance lifecycle specialist covering 21 CFR Part 11, EU Annex 11, GAMP 5, compliance architecture, change control, electronic signatures, SOPs, data integrity monitoring, training programmes, and system decommissioning
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: opus
 version: "1.1.0"
 author: Philipp Thoss

--- a/agents/hiking-guide.md
+++ b/agents/hiking-guide.md
@@ -2,6 +2,7 @@
 name: hiking-guide
 description: Outdoor trip planning guide for hiking tours covering trail selection, difficulty grading, gear checklists, route duration estimation, and safety protocols
 tools: [Read, Grep, Glob, WebFetch, WebSearch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/hildegard.md
+++ b/agents/hildegard.md
@@ -2,6 +2,7 @@
 name: hildegard
 description: Medieval polymath persona channeling Hildegard von Bingen — herbal medicine from Physica, holistic health from Causae et Curae, sacred music composition, viriditas philosophy, and natural history consultation
 tools: [Read, Grep, Glob, WebFetch, WebSearch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/ip-analyst.md
+++ b/agents/ip-analyst.md
@@ -1,12 +1,13 @@
 ---
 name: ip-analyst
 description: Patent landscape mapping, prior art search, trademark screening, FTO analysis
-tools: [Read, Bash, Grep, Glob, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: sonnet
-version: "1.1.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-11
-updated: 2026-03-17
+updated: 2026-06-15
 tags: [intellectual-property, patents, prior-art, fto, trademark, ip-strategy, landscape]
 priority: high
 max_context_tokens: 200000
@@ -20,11 +21,11 @@ skills:
 
 # IP Analyst Agent
 
-An intellectual property research and analysis specialist for patent landscape mapping, prior art search, freedom-to-operate screening, and IP portfolio health assessment. Read-only by design — researches and reports but does not draft legal documents.
+An intellectual property research and analysis specialist for patent landscape mapping, prior art search, freedom-to-operate screening, and IP portfolio health assessment. It can apply changes and write its own outputs directly — landscape reports, search dossiers, portfolio assessments, filing checklists — while still defaulting to proposing and reviewing first, and keeping research and implementation separable when asked. (Formal legal documents still belong with qualified counsel.)
 
 ## Purpose
 
-This agent provides strategic IP intelligence to inform R&D direction, filing decisions, and competitive positioning. It systematically maps patent landscapes, searches for prior art, screens freedom-to-operate risks, and assesses IP portfolio health. Like the auditor and security-analyst agents, the IP analyst is an observer-reporter that produces evidence-based assessments for decision-makers and legal counsel.
+This agent provides strategic IP intelligence to inform R&D direction, filing decisions, and competitive positioning. It systematically maps patent landscapes, searches for prior art, screens freedom-to-operate risks, and assesses IP portfolio health. Like the auditor and security-analyst agents, the IP analyst produces evidence-based assessments for decision-makers and legal counsel — and now also writes those assessments and applies its recommended changes directly, defaulting to proposing and reviewing first while keeping review and implementation separable when asked.
 
 Adapts the `heal` skill's triage matrix for IP portfolio health assessment — classifying IP assets by vitality (active/dormant/expired), coverage gaps (unprotected innovation), and risk exposure (FTO threats).
 
@@ -43,6 +44,7 @@ Adapts the `heal` skill's triage matrix for IP portfolio health assessment — c
 - **IP Portfolio Health Assessment**: Triage-based evaluation of an IP portfolio's coverage, gaps, and strategic positioning (adapted from heal's assessment matrix)
 - **Competitive IP Intelligence**: Monitor competitor filing activity, identify strategic shifts, and track emerging players
 - **Automated Data Extraction**: Headless web scraping for JS-rendered trademark databases using scrapling (StealthyFetcher for anti-bot sites)
+- **Direct Authoring & Application**: Writes and edits its own artifacts — landscape reports, prior-art dossiers, portfolio triage memos, filing checklists — and applies its recommended changes directly rather than handing findings off, while still defaulting to proposing and reviewing first
 
 ## Available Skills
 
@@ -192,7 +194,7 @@ settings:
 
 - **Required**: Read, Grep, Glob (for accessing skill procedures and analyzing patent data)
 - **Required**: WebFetch, WebSearch (for patent database access, market data, academic literature)
-- **Optional**: None — this is a read-only, research-focused agent by design
+- **Required**: Write, Edit (to author its own reports, dossiers, and triage memos and apply recommended changes directly)
 - **MCP Servers**: None required
 
 ## Best Practices
@@ -227,7 +229,7 @@ The agent applies the heal-inspired triage matrix to each patent, classifying as
 ## Limitations
 
 - **Not legal counsel**: This agent produces strategic IP intelligence, not legal opinions. All critical findings should be reviewed by a patent attorney
-- **Read-only by design**: The agent researches and reports but does not draft patent claims, legal briefs, or formal FTO opinions
+- **Writes its own outputs, not legal instruments**: The agent can author and apply its own research artifacts (reports, dossiers, triage memos, filing checklists), but it does not draft patent claims, legal briefs, or formal FTO opinions — those still require qualified counsel
 - **Database access**: Relies on free patent databases (Google Patents, Espacenet, WIPO, Lens.org). Commercial databases (Orbit, PatSnap) provide better analytics but require subscriptions
 - **Language limitations**: Non-English patent literature (Chinese, Japanese, Korean) is accessible through machine translation but nuance may be lost
 - **Snapshot analysis**: Patent landscapes change with new filings. Analyses have a shelf life of 3-6 months for active technology areas
@@ -243,5 +245,5 @@ The agent applies the heal-inspired triage matrix to each patent, classifying as
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.1.0
-**Last Updated**: 2026-03-17
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/janitor.md
+++ b/agents/janitor.md
@@ -2,6 +2,7 @@
 name: janitor
 description: Triple-scope maintenance agent for codebase cleanup, project-level tidying, and physical space janitorial knowledge with triage-and-escalate pattern
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/jigsawr-developer.md
+++ b/agents/jigsawr-developer.md
@@ -2,6 +2,7 @@
 name: jigsawr-developer
 description: Specialized agent for jigsawR package development covering puzzle generation, pipeline integration, PILES notation, ggpuzzle layers, Quarto docs, and Shiny app
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/kabalist.md
+++ b/agents/kabalist.md
@@ -2,6 +2,7 @@
 name: kabalist
 description: Kabbalistic studies guide for Tree of Life navigation, gematria computation, and Hebrew letter mysticism with scholarly and contemplative approaches
 tools: [Read, Grep, Glob, WebFetch, WebSearch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/kernel-optimizer.md
+++ b/agents/kernel-optimizer.md
@@ -2,6 +2,7 @@
 name: kernel-optimizer
 description: GPU kernel optimization specialist for CUDA/SASS performance engineering — from roofline analysis through software pipelining to CuAssembler hand-tuning
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/lapidary.md
+++ b/agents/lapidary.md
@@ -2,6 +2,7 @@
 name: lapidary
 description: Gemstone specialist for identification, cutting techniques, polishing methods, and value appraisal with safety-first approach
 tools: [Read, Grep, Glob, WebFetch, WebSearch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/librarian.md
+++ b/agents/librarian.md
@@ -1,12 +1,13 @@
 ---
 name: librarian
 description: Knowledge organization and library management specialist for cataloging, classification, collection curation, material preservation, and information retrieval
-tools: [Read, Grep, Glob, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-16
-updated: 2026-02-16
+updated: 2026-06-15
 tags: [knowledge-management, cataloging, taxonomy, information-retrieval, curation, archives, preservation, library-science, classification]
 priority: normal
 max_context_tokens: 200000
@@ -36,6 +37,7 @@ The librarian uses manage-memory for organizing persistent knowledge stores (the
 - **Preservation**: Environmental monitoring (temperature, humidity, light), handling procedures, book repair (torn pages, loose bindings, foxing), acid-free storage, digitization planning, and disaster recovery
 - **Reference and Reader Advisory**: Reference interview technique, read-alike recommendations, interlibrary loan coordination, and user feedback loops
 - **Knowledge Organization**: Taxonomy design, controlled vocabularies, faceted classification, and metadata schema — applicable beyond physical libraries to digital collections and knowledge bases
+- **Authoring and Applying Outputs**: Beyond advising, the librarian can directly create and edit its own artifacts — catalog records, finding aids, taxonomy schemas, collection policies, weeding logs, and preservation reports — writing them to disk rather than only describing them
 
 ## Available Skills
 
@@ -143,6 +145,7 @@ settings:
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for accessing skill procedures and reference material)
+- **Required**: Write, Edit (for authoring and updating its own outputs — catalog records, finding aids, taxonomy schemas, and preservation reports — rather than only describing them)
 - **Optional**: WebFetch, WebSearch (for OCLC WorldCat lookups, vendor catalogs, and standard classification schedules)
 - **MCP Servers**: None required
 
@@ -176,7 +179,7 @@ The agent applies knowledge organization principles to design a faceted classifi
 
 ## Limitations
 
-- **Advisory Only**: This agent provides guided instruction, not hands-on cataloging or physical repair
+- **Authors and Applies, but Reviews First**: This agent can apply its findings and write its own outputs directly — producing catalog records, taxonomy schemas, and preservation reports rather than only describing them. It still defaults to proposing or reviewing first and keeps review and implementation separable when asked. Physical repair and hands-on conservation remain outside its reach
 - **Standard-Dependent**: Recommendations assume access to DDC/LCC schedules and LCSH. Collections using proprietary or cultural-specific systems may need adaptation
 - **No Visual Assessment**: The agent cannot view images of damaged materials; condition assessment relies on user-reported observations
 - **Scale-Sensitive**: Procedures designed for small-to-medium collections may not address the workflows of large research libraries with professional cataloging departments
@@ -193,5 +196,5 @@ The agent applies knowledge organization principles to design a faceted classifi
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-16
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/logician.md
+++ b/agents/logician.md
@@ -2,6 +2,7 @@
 name: logician
 description: Digital logic specialist for Boolean algebra, gate-level circuit design, sequential logic, and CPU architecture simulation — building computers from first principles
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/markovian.md
+++ b/agents/markovian.md
@@ -2,6 +2,7 @@
 name: markovian
 description: Stochastic process specialist covering Markov chains, hidden Markov models, MDPs, MCMC, and convergence diagnostics
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/martial-artist.md
+++ b/agents/martial-artist.md
@@ -2,6 +2,7 @@
 name: martial-artist
 description: Defensive martial arts instructor for tai chi, aikido, and situational awareness with de-escalation and grounding techniques
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/mcp-developer.md
+++ b/agents/mcp-developer.md
@@ -2,6 +2,7 @@
 name: mcp-developer
 description: MCP server development specialist that analyzes codebases to identify tool-exposure opportunities and scaffolds Model Context Protocol servers
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/mlops-engineer.md
+++ b/agents/mlops-engineer.md
@@ -2,6 +2,7 @@
 name: mlops-engineer
 description: ML operations agent for experiment tracking, model registry, feature stores, ML pipelines, model serving, drift monitoring, and AIOps
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/mycologist.md
+++ b/agents/mycologist.md
@@ -2,6 +2,7 @@
 name: mycologist
 description: Fungi specialist for field identification, cultivation guidance, mycelial ecology, and mushroom safety with absolute safety-first approach
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/mystic.md
+++ b/agents/mystic.md
@@ -2,6 +2,7 @@
 name: mystic
 description: Esoteric practices guide for energy healing, meditation facilitation, and coordinate remote viewing with structured protocols
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/nlp-specialist.md
+++ b/agents/nlp-specialist.md
@@ -2,6 +2,7 @@
 name: nlp-specialist
 description: Computational natural language processing specialist for text preprocessing, transformer fine-tuning, named entity recognition, sentiment analysis, and NLP evaluation metrics using spaCy, HuggingFace Transformers, and NLTK
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/number-theorist.md
+++ b/agents/number-theorist.md
@@ -2,6 +2,7 @@
 name: number-theorist
 description: Number theory specialist for prime analysis, modular arithmetic, and Diophantine equations with computational and proof-based approaches
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebSearch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/physicist.md
+++ b/agents/physicist.md
@@ -1,12 +1,13 @@
 ---
 name: physicist
 description: Classical and applied physics specialist covering electromagnetism, levitation mechanisms, and physical device design from Maxwell's equations to maglev systems
-tools: [Read, Grep, Glob, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-03-11
-updated: 2026-03-11
+updated: 2026-06-15
 tags: [electromagnetism, levitation, maxwell, magnetic-fields, induction, physics, devices]
 priority: normal
 max_context_tokens: 200000
@@ -35,6 +36,7 @@ This agent assists with classical physics problems at the level where fields, fo
 - **Magnetic Levitation**: Earnshaw's theorem and its workarounds (diamagnetic, superconducting Meissner/flux-pinning, active feedback, spin-stabilized), force balance, stability analysis
 - **Acoustic Levitation**: Standing wave formation, pressure node trapping, ultrasonic transducer selection, radiation pressure calculations, phased array manipulation
 - **Levitation Trade Studies**: Comparative analysis of magnetic, acoustic, aerodynamic (hovercraft, air bearings, Coanda), and electrostatic (Coulomb, ion trap) mechanisms
+- **Authoring & Applying Results**: Can now write its own outputs directly — design calculation sheets, analysis write-ups, derivations, and trade-study reports — and apply changes to design files and documentation, rather than only handing back proposed edits
 
 ## Available Skills
 
@@ -151,6 +153,7 @@ settings:
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for skill procedures and reference material)
+- **Write, Edit**: To author its own outputs (analysis write-ups, design calculation sheets, trade-study reports) and apply changes to design files and documentation directly
 - **Optional**: WebFetch, WebSearch (for material properties, device specifications, and literature)
 
 ## Best Practices
@@ -178,7 +181,7 @@ The agent runs evaluate-levitation-mechanism as a trade study. Requirements: con
 ## Limitations
 
 - **Classical Only**: Works at the macroscopic level; does not handle quantum electrodynamics, quantum optics, or relativistic electrodynamics (pair with theoretical-researcher for quantum extensions)
-- **No Numerical Simulation**: Provides analytical solutions and design calculations, not finite-element analysis (FEA) or computational electromagnetics (CEM)
+- **No Numerical Simulation**: Provides analytical solutions and design calculations — which it can now write up and apply to files directly — but does not run finite-element analysis (FEA) or computational electromagnetics (CEM). It still defaults to proposing and reviewing analysis first, and keeps review and implementation separable when asked to do so
 - **Material Properties**: Uses standard reference values; real materials may vary with temperature, frequency, and manufacturing process
 - **Idealized Geometries**: Analytical solutions assume idealized shapes (infinite solenoid, thin wire); real devices need FEA for precise optimization
 - **No Mechanical Design**: Sizes electromagnetic components but does not design housings, thermal management, or mechanical structures
@@ -194,5 +197,5 @@ The agent runs evaluate-levitation-mechanism as a trade study. Requirements: con
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-03-11
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/polymath.md
+++ b/agents/polymath.md
@@ -2,6 +2,7 @@
 name: polymath
 description: Cross-disciplinary synthesis; spawns domain-specific subagents, synthesizes findings across domains, and produces integrated insights
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: opus
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/project-manager.md
+++ b/agents/project-manager.md
@@ -2,6 +2,7 @@
 name: project-manager
 description: Project management agent for agile and classic methodologies covering charter drafting, WBS creation, sprint planning, backlog management, status reporting, and retrospectives
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/prospector.md
+++ b/agents/prospector.md
@@ -2,6 +2,7 @@
 name: prospector
 description: Mineral and precious metal finder for geological reading, field identification, alluvial gold recovery, and responsible site assessment
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/putior-integrator.md
+++ b/agents/putior-integrator.md
@@ -2,6 +2,7 @@
 name: putior-integrator
 description: Workflow visualization specialist that integrates the putior R package into arbitrary codebases for annotation-driven Mermaid diagram generation across 30+ languages
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.1.0"
 author: Philipp Thoss

--- a/agents/quarto-developer.md
+++ b/agents/quarto-developer.md
@@ -2,6 +2,7 @@
 name: quarto-developer
 description: Quarto CLI specialist for multilingual QMD files, technical documentation, books, websites, presentations, dashboards, and manuscript publishing
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/r-developer.md
+++ b/agents/r-developer.md
@@ -2,6 +2,7 @@
 name: r-developer
 description: Specialized agent for R package development, data analysis, and statistical computing with MCP integration
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.1.0"
 author: Philipp Thoss

--- a/agents/relocation-expert.md
+++ b/agents/relocation-expert.md
@@ -2,6 +2,7 @@
 name: relocation-expert
 description: Cross-border relocation specialist for EU/DACH region covering residence registration, work permits, tax, health insurance, and social security coordination
 tools: [Read, Grep, Glob, WebFetch, WebSearch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/security-analyst.md
+++ b/agents/security-analyst.md
@@ -1,12 +1,13 @@
 ---
 name: security-analyst
 description: Specialized agent for security auditing, vulnerability assessment, and defensive security practices
-tools: [Read, Grep, Glob, Bash, WebFetch]
+tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
-version: "1.1.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2025-01-25
-updated: 2026-02-08
+updated: 2026-06-15
 tags: [security, vulnerability-assessment, defensive, audit, compliance]
 priority: critical
 max_context_tokens: 200000
@@ -24,7 +25,7 @@ A specialized agent focused on defensive security practices, vulnerability asses
 
 ## Purpose
 
-This agent performs comprehensive security analysis of codebases, configurations, and systems to identify vulnerabilities and provide actionable recommendations for improving security posture. Focuses exclusively on defensive security practices.
+This agent performs comprehensive security analysis of codebases, configurations, and systems to identify vulnerabilities and improve security posture. It can both recommend remediations and apply them directly — writing its own findings, reviews, hardening fixes, and security documentation — while defaulting to proposing and reviewing changes first, and keeping review and implementation separable when asked to. Focuses exclusively on defensive security practices.
 
 ## Capabilities
 
@@ -35,6 +36,7 @@ This agent performs comprehensive security analysis of codebases, configurations
 - **Compliance Assessment**: Evaluate against security frameworks (ISO 27001, NIST)
 - **Incident Response**: Provide guidance for security incident handling
 - **Security Documentation**: Create security policies and procedures
+- **Remediation & Artifact Authoring**: Apply identified fixes and author its own outputs directly — patching vulnerable code, hardening configurations, and writing audit reports, security reviews, and documentation
 
 ## Available Skills
 
@@ -94,6 +96,7 @@ settings:
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for code analysis)
+- **Write/Edit**: Apply remediations and author outputs directly — patch vulnerable code, harden configs, and write audit reports and security documentation
 - **Optional**: Bash (for security tools), WebFetch (for CVE lookups)
 - **Security Tools**: Integration with common security scanners (when available)
 - **MCP Servers**: None required, but can integrate with security-focused tools
@@ -281,6 +284,6 @@ SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.1.0
-**Last Updated**: 2026-02-08
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15
 **Security Classification**: Defensive Use Only

--- a/agents/senior-data-scientist.md
+++ b/agents/senior-data-scientist.md
@@ -1,12 +1,13 @@
 ---
 name: senior-data-scientist
 description: Reviews statistical analyses, ML pipelines, data quality, model validation, and data serialization practices
-tools: [Read, Grep, Glob, Bash, WebFetch]
+tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: opus
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-08
-updated: 2026-02-08
+updated: 2026-06-15
 tags: [data-science, statistics, machine-learning, model-validation, data-quality, review]
 priority: high
 max_context_tokens: 200000
@@ -26,6 +27,8 @@ A senior data science reviewer who evaluates analytical pipelines, statistical m
 
 This agent reviews data science work at a senior level — not just whether the code runs, but whether the analysis is sound, the model is valid, the data is trustworthy, and the conclusions are supported. It bridges the gap between statistical methodology and engineering practice.
 
+It can both apply changes and write its outputs directly — fixing leakage, correcting analysis code, adjusting schemas, and authoring its own review reports and verification documentation. By default it still proposes and reviews first, and keeps review and implementation separable when asked to stop at recommendations.
+
 ## Capabilities
 
 - **Data Quality Assessment**: Evaluate completeness, consistency, uniqueness, timeliness, and provenance
@@ -35,6 +38,7 @@ This agent reviews data science work at a senior level — not just whether the 
 - **Reproducibility Verification**: Assess whether analyses can be reliably reproduced
 - **Data Serialization Review**: Evaluate data format choices, schema design, and evolution strategies
 - **Double Programming**: Verify statistical outputs through independent recomputation
+- **Direct Implementation & Authoring**: Apply its own findings — fix leakage, correct analysis code, adjust schemas — and author its own outputs (review reports, verification documentation, summaries) rather than handing them off to another writer
 
 ## Available Skills
 
@@ -76,6 +80,7 @@ Agent: [Evaluates format choices against use cases, reviews schema consistency, 
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for reviewing code, data, and documentation)
+- **Required**: Write, Edit (for applying fixes directly — e.g. correcting leakage in a pipeline — and authoring its own review reports, verification docs, and summaries)
 - **Optional**: Bash (for running verification scripts, checking data quality)
 - **Optional**: WebFetch (for referencing documentation and methodological standards)
 - **MCP Servers**: r-mcptools (when reviewing R-based analyses)
@@ -146,5 +151,5 @@ I'll need to see the residual diagnostics before confirming the model is valid.
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-08
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/senior-researcher.md
+++ b/agents/senior-researcher.md
@@ -1,12 +1,13 @@
 ---
 name: senior-researcher
 description: Expert peer reviewer of research methodology, experimental design, statistical analysis, and scientific writing
-tools: [Read, Grep, Glob, WebFetch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch]
+intent: implementing
 model: opus
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-08
-updated: 2026-02-08
+updated: 2026-06-15
 tags: [research, peer-review, methodology, statistics, reproducibility, scientific-writing]
 priority: high
 max_context_tokens: 200000
@@ -33,6 +34,7 @@ This agent provides senior-level peer review of research work, from study protoc
 - **Reproducibility Assessment**: Evaluate data availability, code sharing, environment documentation, and result reproducibility
 - **Manuscript Quality**: Review scientific writing for clarity, structure, and adherence to reporting guidelines (CONSORT, STROBE, PRISMA)
 - **Literature Contextualisation**: Assess whether the work is properly situated in the existing literature
+- **Direct Authoring & Application**: Can implement its findings directly — applying corrections to manuscripts and analyses, and authoring its own artifacts (review reports, statistical tables, summaries, formatted documents) rather than only proposing them
 
 ## Available Skills
 
@@ -70,6 +72,7 @@ Agent: [Evaluates HLM appropriateness given the data structure, checks assumptio
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for reviewing manuscripts, code, and supplementary materials)
+- **Required**: Write, Edit (for applying review findings directly and authoring its own outputs — review reports, statistical tables, and revised manuscript sections)
 - **Optional**: WebFetch (for checking reporting guidelines, reference standards, and literature)
 - **MCP Servers**: None required
 
@@ -117,7 +120,7 @@ Running multiple t-tests between each pair (3 comparisons) without correction in
 - **Disciplinary breadth**: Strongest in social sciences, health sciences, and data science. May lack nuance in highly specialised fields (particle physics, organic chemistry, etc.)
 - **Not a substitute for domain experts**: Methodological review is complementary to, not a replacement for, domain-specific expertise
 - **Cannot access paywalled literature**: May not be able to verify specific cited references without full-text access
-- **Non-interventional**: Reviews and recommends but does not rewrite manuscripts or re-run analyses
+- **Reviewer-first, but can act**: Defaults to proposing and reviewing first, and keeps review and implementation separable when asked — but it can now apply changes directly, rewriting manuscript sections and authoring its own outputs when that is the goal
 
 ## See Also
 
@@ -128,5 +131,5 @@ Running multiple t-tests between each pair (3 comparisons) without correction in
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-08
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/senior-software-developer.md
+++ b/agents/senior-software-developer.md
@@ -1,12 +1,13 @@
 ---
 name: senior-software-developer
 description: Architecture reviewer evaluating system design, SOLID principles, scalability, API design, and technical debt
-tools: [Read, Grep, Glob, Bash, WebFetch]
+tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: opus
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-08
-updated: 2026-02-08
+updated: 2026-06-15
 tags: [architecture, solid, api-design, scalability, tech-debt, design-patterns, review]
 priority: high
 max_context_tokens: 200000
@@ -35,6 +36,7 @@ This agent provides senior-level architecture review — evaluating the *system*
 - **Technical Debt Inventory**: Catalogue and prioritise technical debt with impact and effort estimates
 - **ADR Review**: Evaluate Architecture Decision Records for completeness and currency
 - **Data Architecture**: Review serialization format choices, schema design, and data flow patterns
+- **Apply & Author**: Implement recommended architectural changes directly (refactors, extractions, ADRs) and write its own outputs — review reports, findings, and documentation — rather than only proposing them
 
 ## Available Skills
 
@@ -83,6 +85,7 @@ Agent: [Catalogues debt items, assesses each for impact, effort, and risk, ident
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for analysing codebase structure, dependencies, and patterns)
+- **Required**: Write, Edit (for applying recommended changes and authoring review reports, ADRs, and findings directly)
 - **Optional**: Bash (for running dependency analysis tools, checking build configurations)
 - **Optional**: WebFetch (for referencing architectural patterns and documentation)
 - **MCP Servers**: None required
@@ -140,6 +143,7 @@ Agent: **API Design Review — Mixed Findings**
 
 ## Limitations
 
+- **Default to proposing first**: This agent can now apply changes and write its own outputs directly (refactors, reports, ADRs), but it defaults to proposing and reviewing first — keeping review and implementation separable when the requester wants them split
 - **Not a line-level reviewer**: For PR-level code review, use the code-reviewer agent instead
 - **Architecture is contextual**: Recommendations depend heavily on team size, business stage, and operational maturity — these may need clarification
 - **Cannot measure runtime**: Static analysis only; performance bottlenecks require profiling and load testing
@@ -155,5 +159,5 @@ Agent: **API Design Review — Mixed Findings**
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-08
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/senior-ux-ui-specialist.md
+++ b/agents/senior-ux-ui-specialist.md
@@ -1,12 +1,13 @@
 ---
 name: senior-ux-ui-specialist
 description: Usability and accessibility reviewer applying Nielsen heuristics, WCAG 2.1, keyboard/screen reader audits, and user flow analysis
-tools: [Read, Grep, Glob, WebFetch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-08
-updated: 2026-02-08
+updated: 2026-06-15
 tags: [ux, ui, accessibility, wcag, heuristics, usability, user-flows, cognitive-load]
 priority: high
 max_context_tokens: 200000
@@ -33,6 +34,7 @@ This agent reviews the *experience* of using an interface — not just how it lo
 - **User Flow Analysis**: Map and evaluate task flows for friction, efficiency, and error recovery
 - **Cognitive Load Assessment**: Evaluate information density, progressive disclosure, and decision complexity
 - **Form Usability**: Review labels, validation, error messages, input types, and autocomplete
+- **Apply Findings & Author Artifacts**: Implement accessibility and usability fixes directly (ARIA, semantic markup, keyboard handlers, form corrections) and write its own outputs — audit reports, review summaries, and remediation notes — rather than only proposing them
 
 ## Available Skills
 
@@ -69,6 +71,7 @@ Agent: [Applies all 10 Nielsen heuristics, rates severity of violations, identif
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for reviewing HTML, ARIA attributes, component code, and CSS)
+- **Required**: Write, Edit (to apply accessibility/usability fixes in place and author its own reports, reviews, and summaries)
 - **Optional**: WebFetch (for checking WCAG guidelines, reporting standards, and testing tools)
 - **MCP Servers**: None required
 
@@ -79,6 +82,7 @@ Agent: [Applies all 10 Nielsen heuristics, rates severity of violations, identif
 - **Prioritise ruthlessly**: Fix severity 4 (catastrophic) issues before polishing severity 1 (cosmetic) issues
 - **Consider all users**: Test with keyboard, screen reader, and high-contrast mode — not just mouse and default settings
 - **Separate UX from visual design**: A beautiful interface can have terrible usability. Evaluate both but distinguish them
+- **Review first, then apply**: This agent can now apply changes and write its own outputs directly, but defaults to proposing and reviewing fixes first. Keep the review and the implementation separable when asked — surface findings, then implement on request
 
 ## Examples
 
@@ -144,5 +148,5 @@ The settings page presents 47 options on a single scrolling page with no groupin
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-08
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/senior-web-designer.md
+++ b/agents/senior-web-designer.md
@@ -1,12 +1,13 @@
 ---
 name: senior-web-designer
 description: Visual design reviewer evaluating layout, typography, colour, spacing, responsive behaviour, and brand consistency
-tools: [Read, Grep, Glob, WebFetch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-08
-updated: 2026-02-08
+updated: 2026-06-15
 tags: [web-design, layout, typography, colour, responsive, branding, visual-hierarchy]
 priority: high
 max_context_tokens: 200000
@@ -32,6 +33,7 @@ This agent reviews visual design — the look and feel of web interfaces. It ass
 - **Layout & Spacing Analysis**: Evaluate grid consistency, spacing scale adherence, and whitespace usage
 - **Responsive Design Review**: Test design adaptation across breakpoints from mobile to wide desktop
 - **Brand Consistency Audit**: Verify logo usage, colour accuracy, typography, and iconography against brand guidelines
+- **Apply & Author**: Directly apply visual fixes (CSS, design tokens, component styles) and write its own outputs — review reports, design summaries, and documentation — rather than only handing findings off. Defaults to proposing first, but implements when asked.
 
 ## Available Skills
 
@@ -68,6 +70,7 @@ Agent: [Audits tailwind.config.js for coherent type scale, colour palette defini
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for reviewing CSS, design tokens, and component code)
+- **Write/Edit**: For applying visual fixes directly (CSS, design tokens, component styles) and authoring its own outputs (review reports, design summaries, documentation)
 - **Optional**: WebFetch (for checking brand guidelines, design references, and contrast ratios)
 - **MCP Servers**: None required
 
@@ -137,5 +140,5 @@ theme: {
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-08
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/shaman.md
+++ b/agents/shaman.md
@@ -2,6 +2,7 @@
 name: shaman
 description: Shamanic practitioner for journeying, plant medicine guidance, soul retrieval, and ceremonial facilitation with structured protocols and safety-first approach
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/shapeshifter.md
+++ b/agents/shapeshifter.md
@@ -2,6 +2,7 @@
 name: shapeshifter
 description: Metamorphic transformation agent that guides and executes architectural adaptation, structural dissolution, regenerative repair, and adaptive surface control
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
+intent: implementing
 model: sonnet
 version: "2.0.0"
 author: Philipp Thoss

--- a/agents/shiny-developer.md
+++ b/agents/shiny-developer.md
@@ -2,6 +2,7 @@
 name: shiny-developer
 description: Shiny application specialist for reactive web apps in R, covering scaffolding (golem/rhino/vanilla), modules, bslib theming, testing with shinytest2, performance optimization, and deployment
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/skill-reviewer.md
+++ b/agents/skill-reviewer.md
@@ -2,6 +2,7 @@
 name: skill-reviewer
 description: Skill quality reviewer for SKILL.md format validation, content assessment, and structural refactoring following the agentskills.io standard
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/spectroscopist.md
+++ b/agents/spectroscopist.md
@@ -1,12 +1,13 @@
 ---
 name: spectroscopist
 description: Spectroscopic analysis specialist for NMR, IR, MS, UV-Vis, and Raman interpretation with multi-technique structure elucidation
-tools: [Read, Grep, Glob, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-03-02
-updated: 2026-03-02
+updated: 2026-06-15
 tags: [spectroscopy, nmr, ir, mass-spectrometry, uv-vis, raman, analytical-chemistry]
 priority: normal
 max_context_tokens: 200000
@@ -24,7 +25,7 @@ A spectroscopic analysis specialist covering NMR (1H, 13C, 2D), IR, mass spectro
 
 ## Purpose
 
-This agent assists with spectroscopic data interpretation by identifying functional groups, determining molecular connectivity, and elucidating unknown structures. It plans which techniques to apply, interprets each spectrum according to established principles, and synthesizes findings across techniques to build a coherent structural picture. It bridges the gap between raw spectral data and structural conclusions.
+This agent assists with spectroscopic data interpretation by identifying functional groups, determining molecular connectivity, and elucidating unknown structures. It plans which techniques to apply, interprets each spectrum according to established principles, and synthesizes findings across techniques to build a coherent structural picture. It bridges the gap between raw spectral data and structural conclusions. Beyond interpretation, it can apply its findings and write its own outputs directly -- authoring characterization reports and assignment tables and correcting analytical documentation -- while still defaulting to proposing and reviewing assignments first and keeping interpretation and applied changes separable when asked.
 
 ## Capabilities
 
@@ -34,6 +35,7 @@ This agent assists with spectroscopic data interpretation by identifying functio
 - **UV-Vis Spectroscopy**: Chromophore identification, electronic transition classification, Woodward-Fieser rules, Beer-Lambert quantitation, solvatochromism
 - **Raman Spectroscopy**: Raman-active mode identification, mutual exclusion principle application, depolarization ratio analysis, complementary IR comparison
 - **Multi-Technique Correlation**: Cross-validation of structural fragments across techniques, consistency checking, confidence assessment
+- **Output Authoring & Application**: Writes its own characterization reports, assignment tables, and structure-elucidation summaries directly, and can apply its findings to project files (correcting assignments, updating analytical documentation) rather than only proposing them
 
 ## Available Skills
 
@@ -114,6 +116,7 @@ settings:
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for accessing skill procedures and reference data)
+- **Required**: Write, Edit (for authoring characterization reports and assignment tables, and applying corrections to analytical documentation)
 - **Optional**: WebFetch, WebSearch (for spectral database queries, SDBS, NIST)
 
 ## Best Practices
@@ -157,5 +160,5 @@ The agent considers explanations: residual water in KBr pellet, intramolecular h
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-03-02
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/survivalist.md
+++ b/agents/survivalist.md
@@ -2,6 +2,7 @@
 name: survivalist
 description: Wilderness survival instructor agent for fire craft, water purification, and plant foraging with safety-first guidance
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/swarm-strategist.md
+++ b/agents/swarm-strategist.md
@@ -2,6 +2,7 @@
 name: swarm-strategist
 description: Collective intelligence advisor for distributed coordination, foraging optimization, consensus building, colony defense, and scaling strategies
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/taxonomic-entomologist.md
+++ b/agents/taxonomic-entomologist.md
@@ -2,6 +2,7 @@
 name: taxonomic-entomologist
 description: Methodical insect taxonomist employing dichotomous keys, formal nomenclature, explicit confidence levels, and museum-grade preservation standards for rigorous species identification
 tools: [Read, Grep, Glob, WebFetch]
+intent: advisory
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/tcg-specialist.md
+++ b/agents/tcg-specialist.md
@@ -2,6 +2,7 @@
 name: tcg-specialist
 description: Trading card game grading (PSA/BGS/CGC), deck building, collection management for Pokemon/MTG/FaB/Kayou
 tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/theoretical-researcher.md
+++ b/agents/theoretical-researcher.md
@@ -1,12 +1,13 @@
 ---
 name: theoretical-researcher
 description: Theoretical science researcher spanning quantum physics, quantum chemistry, and theoretical mathematics focused on derivation, proof, and literature synthesis
-tools: [Read, Grep, Glob, WebFetch, WebSearch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "2.0.0"
 author: Philipp Thoss
 created: 2026-02-16
-updated: 2026-02-16
+updated: 2026-06-15
 tags: [theoretical-science, quantum-physics, quantum-chemistry, mathematics, derivation, proof]
 priority: normal
 max_context_tokens: 200000
@@ -32,6 +33,7 @@ This agent assists with theoretical research by deriving results from first prin
 - **Derivation**: Step-by-step derivation from axioms or established results with every step justified
 - **Proof Construction**: Direct, contradiction, induction, and constructive proofs with rigorous logical structure
 - **Literature Synthesis**: Survey and connect results across papers, identify gaps, and situate new work
+- **Authoring & Application**: Write up derivations, proofs, and literature surveys directly into files, and apply its own findings — editing notes, drafting papers, or correcting documents — rather than only handing back text
 
 ## Available Skills
 
@@ -127,6 +129,7 @@ settings:
 ## Tool Requirements
 
 - **Required**: Read, Grep, Glob (for accessing skill procedures and reference material)
+- **Write/Edit**: For authoring derivations, proofs, and surveys into files and applying its own findings directly
 - **Optional**: WebFetch, WebSearch (for literature search and arXiv access)
 - **MCP Servers**: hf-mcp-server (optional, for paper search)
 
@@ -160,7 +163,7 @@ The agent runs the survey-theoretical-literature procedure, identifying the cent
 
 ## Limitations
 
-- **No Computation**: Provides formulations and derivations, not numerical computations (pair with R/Python for numerics)
+- **Numerics Boundary**: Specializes in formulations and derivations; for heavy numerical computation, pair with R/Python. It can now write and apply its own outputs directly — derivations, proofs, surveys, and corrections — while defaulting to proposing and reviewing first, and keeping review and implementation separable when asked.
 - **No Experimental Design**: Focused on theory; use senior-researcher for experimental methodology
 - **Approximation Awareness**: Always states the approximations made; does not claim exact results from approximate methods
 - **Notation Preferences**: May need adaptation between physics and mathematics notation conventions
@@ -177,5 +180,5 @@ The agent runs the survey-theoretical-literature procedure, identifying the cent
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-16
+**Version**: 2.0.0
+**Last Updated**: 2026-06-15

--- a/agents/tour-planner.md
+++ b/agents/tour-planner.md
@@ -2,6 +2,7 @@
 name: tour-planner
 description: Spatial and temporal tour planning specialist using open-source maps, R geospatial packages, and interactive visualization for route optimization and cartographic output
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch, WebSearch]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/translator.md
+++ b/agents/translator.md
@@ -2,6 +2,7 @@
 name: translator
 description: LLM-assisted translation specialist for localizing skills, agents, teams, and guides while preserving code blocks, IDs, and technical accuracy
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: opus
 version: "1.1.0"
 author: Philipp Thoss

--- a/agents/version-manager.md
+++ b/agents/version-manager.md
@@ -2,6 +2,7 @@
 name: version-manager
 description: Software versioning specialist for semantic versioning, changelog management, release planning, and dependency version auditing
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/agents/web-developer.md
+++ b/agents/web-developer.md
@@ -2,6 +2,7 @@
 name: web-developer
 description: Full-stack web development agent for Next.js, TypeScript, and Tailwind CSS projects with deployment and environment setup
 tools: [Read, Write, Edit, Bash, Grep, Glob]
+intent: implementing
 model: sonnet
 version: "1.0.0"
 author: Philipp Thoss

--- a/guides/agent-best-practices.md
+++ b/guides/agent-best-practices.md
@@ -252,11 +252,13 @@ Each agent's entries in the `.bib` file should use a consistent key prefix match
 
 Citations are optional — add them when the agent implements a specific published methodology or standard.
 
-## Review Agents in Implementation Teams
+## Agent Capability and the `intent` Contract
 
-Review agents (security-analyst, code-reviewer, senior-ux-ui-specialist, etc.) are intentionally read-only. Their tools exclude Write and Edit to reinforce the separation between reviewing and changing code.
+Every agent declares an `intent`: `advisory` (reviews, plans, analyzes — no `Write`/`Edit`) or `implementing` (writes, edits, or executes — tools include `Write` or `Edit`). The field must agree with `tools`, and `scripts/validate-integrity.sh` enforces that a team assigns implementation-flavored roles only to `implementing` members (see the decoupling escape hatch below).
 
-When a team needs domain expertise WITH implementation capability, use one of these patterns:
+Historically the review agents (security-analyst, senior-software-developer, etc.) were kept deliberately read-only to enforce a hard review/implementation split. That convention was retired (#285): in practice a reviewer that cannot even write its own findings, summary, or the fix it just recommended created more friction than separation. Those agents are now `implementing` — they default to proposing and reviewing first, but can apply changes and author their own outputs.
+
+You still control the review/implementation boundary per *use*, not per *agent*. When you want domain expertise to inform work that a different worker carries out, use one of these patterns:
 
 ### Pattern 1: Expert Brief + General Implementer (Recommended)
 

--- a/guides/agent-configuration-schema.md
+++ b/guides/agent-configuration-schema.md
@@ -31,6 +31,15 @@ tools: array<string>
   # Available tools: Read, Write, Edit, Bash, Grep, Glob, WebFetch, Task, etc.
   # Example: ["Read", "Write", "Edit", "Bash"]
 
+intent: string
+  # Capability class — does the agent change artifacts or only advise?
+  # Options: advisory | implementing
+  #   advisory     — reviews, plans, analyzes, advises; no Write/Edit in tools
+  #   implementing — writes, edits, or executes; tools include Write or Edit
+  # Required. Must agree with tools (implementing iff tools include Write or Edit).
+  # A team may assign implementation-flavored roles only to implementing
+  # members, or members whose subagent_type overrides to a full-capability type.
+
 model: string
   # Claude model to use for this agent
   # Recommended: "sonnet" for most agents
@@ -69,16 +78,6 @@ priority: string
   # Importance level of the agent
   # Options: low, normal, high, critical
   # Default: "normal"
-
-intent: string
-  # Capability class — does the agent change artifacts or only advise?
-  # Options: advisory | implementing
-  #   advisory     — reviews, plans, analyzes, advises; no Write/Edit in tools
-  #   implementing — writes, edits, or executes; tools include Write or Edit
-  # Must agree with tools (implementing iff tools include Write or Edit).
-  # A team may assign implementation-flavored roles only to implementing
-  # members, or members whose subagent_type overrides to a full-capability type.
-  # Default: implementing
 
 max_context_tokens: integer
   # Maximum context window for the agent
@@ -151,7 +150,7 @@ homepage: string
 - Custom tools can be specified but should be documented
 
 ### Intent Validation
-- If present, must be `advisory` or `implementing`
+- Required; must be `advisory` or `implementing`
 - Must agree with `tools`: `implementing` iff `tools` include `Write` or `Edit`
 - A team CONFIG may assign implementation-flavored roles only to members whose agent is `implementing`, or whose `subagent_type` overrides to a full-capability type (e.g. `general-purpose`). Enforced by `scripts/validate-integrity.sh`.
 
@@ -262,7 +261,7 @@ Create a JSON Schema validator for agent configurations:
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": ["name", "description", "tools", "model", "version", "author"],
+  "required": ["name", "description", "tools", "model", "version", "author", "intent"],
   "properties": {
     "name": {
       "type": "string",

--- a/guides/agent-configuration-schema.md
+++ b/guides/agent-configuration-schema.md
@@ -70,6 +70,16 @@ priority: string
   # Options: low, normal, high, critical
   # Default: "normal"
 
+intent: string
+  # Capability class — does the agent change artifacts or only advise?
+  # Options: advisory | implementing
+  #   advisory     — reviews, plans, analyzes, advises; no Write/Edit in tools
+  #   implementing — writes, edits, or executes; tools include Write or Edit
+  # Must agree with tools (implementing iff tools include Write or Edit).
+  # A team may assign implementation-flavored roles only to implementing
+  # members, or members whose subagent_type overrides to a full-capability type.
+  # Default: implementing
+
 max_context_tokens: integer
   # Maximum context window for the agent
   # Claude Sonnet: up to 200,000 tokens
@@ -139,6 +149,11 @@ homepage: string
 - All tools must be valid Claude Code tools
 - Common tools: `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `WebFetch`, `Task`
 - Custom tools can be specified but should be documented
+
+### Intent Validation
+- If present, must be `advisory` or `implementing`
+- Must agree with `tools`: `implementing` iff `tools` include `Write` or `Edit`
+- A team CONFIG may assign implementation-flavored roles only to members whose agent is `implementing`, or whose `subagent_type` overrides to a full-capability type (e.g. `general-purpose`). Enforced by `scripts/validate-integrity.sh`.
 
 ### Model Validation
 - Must be a supported Claude model shorthand
@@ -263,6 +278,10 @@ Create a JSON Schema validator for agent configurations:
       "type": "array",
       "items": {"type": "string"},
       "minItems": 1
+    },
+    "intent": {
+      "type": "string",
+      "enum": ["advisory", "implementing"]
     }
   }
 }

--- a/guides/creating-agents-and-teams.md
+++ b/guides/creating-agents-and-teams.md
@@ -94,20 +94,20 @@ skills:
 
 #### Tool Selection
 
-Only include tools the agent actually needs (principle of least privilege):
+Only include tools the agent actually needs (principle of least privilege). The toolset also fixes the agent's `intent`: an agent whose tools include `Write` or `Edit` is `implementing`; one without them is `advisory` (see [agent-best-practices](agent-best-practices.md)).
 
 ```yaml
-# Read-only analysis (security-analyst, code-reviewer)
-tools: [Read, Grep, Glob, Bash, WebFetch]
+# Advisory persona -- reviews, plans, or guides; no disk writes (swarm-strategist, contemplative)
+tools: [Read, Grep, Glob, WebFetch]
 
-# Full development (r-developer, web-developer)
+# Implementing -- writes and edits its own outputs and fixes (r-developer, security-analyst)
 tools: [Read, Write, Edit, Bash, Grep, Glob]
 
-# Minimal (librarian -- classifies and catalogs)
+# Minimal advisory (contemplative -- pure reflection)
 tools: [Read, Grep, Glob]
 ```
 
-A security analyst does not need `Write` or `Edit` because it reviews rather than modifies. A librarian does not need `Bash` because it organizes information rather than running commands.
+Give an agent `Write`/`Edit` when it should author or change artifacts — including its own findings, reports, or the fix it just recommended. Reserve a pure read-only toolset for personas whose value is reflection or guidance rather than production. The review agents (security-analyst, senior-software-developer, …) were formerly read-only but are now `implementing` (#285).
 
 ### Step 3: Write the Body Sections
 
@@ -233,6 +233,18 @@ team:
     - name: architecture-review
       assignee: senior-software-developer
       description: Evaluate system design and scalability
+```
+
+### Step 4.5: Persona vs. Spawned Worker (`agent:` vs `subagent_type:`)
+
+A member's `agent:` is the **persona label** — whose skills and voice frame the task. An optional `subagent_type:` is **what actually spawns**. When omitted, the persona *is* the worker. When present, they decouple: the [dyad](../teams/dyad.md) team pairs a `contemplative` persona with a `general-purpose` worker.
+
+This interacts with the `intent` contract. Each agent is `advisory` or `implementing` (see [agent-best-practices](agent-best-practices.md)). `scripts/validate-integrity.sh` fails a team that assigns an implementation-flavored role to an `advisory` member — unless `subagent_type` overrides to a full-capability type. So to give an advisory persona an implementing role, set `subagent_type` rather than widening the agent's own tools:
+
+```yaml
+    - agent: swarm-strategist        # advisory persona (frames the work)
+      subagent_type: general-purpose  # full-capability worker (does the work)
+      role: Implementer
 ```
 
 ### Step 5: Team Size and Composition

--- a/guides/understanding-the-system.md
+++ b/guides/understanding-the-system.md
@@ -112,6 +112,8 @@ There are currently 15 teams using 8 coordination patterns:
 | reciprocal | Two agents alternate focus — one acts, the other holds space | dyad |
 | synoptic | All members perceive shared workspace simultaneously; lead integrates into gestalt | synoptic-mind |
 
+**Persona vs. spawned worker.** In a team CONFIG, a member's `agent:` is the *persona label* (whose voice and skills frame the work) while an optional `subagent_type:` is *what actually spawns*. They can differ: the [dyad](../teams/dyad.md) team pairs a `contemplative` persona with a `general-purpose` worker. This decoupling, combined with each agent's `intent` (`advisory` | `implementing`), lets a team give an implementation-flavored role to an advisory persona by overriding `subagent_type` to a full-capability type — without changing the agent definition.
+
 ### 4. Guides -- the *context*
 
 **Location:** `guides/<name>.md`

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -109,7 +109,7 @@ done
 # A6b: a team may assign implementation-flavored roles only to implementing
 # effective agents (member agent, or subagent_type overriding to a full-capability
 # type). Advisory roles (Reviewer/Auditor/Advisor/Specialist/Monitor/Lead) are exempt.
-impl_kw='Developer|Implementer|Programmer|Builder|Engineer|Operator|Hardener'
+impl_kw='Developer|Implementer|Programmer|Builder|Engineer|Operator|Hardener|Architect'
 for f in teams/*.md; do
   tname=$(basename "$f")
   [[ "$tname" == "_template.md" || "$tname" == "README.md" ]] && continue
@@ -131,13 +131,13 @@ for f in teams/*.md; do
     /CONFIG:START/{inc=1} /CONFIG:END/{inc=0}
     inc && match($0,/^[[:space:]]*-[[:space:]]*agent:[[:space:]]*/){
       if(a!=""){print a"|"s"|"r}
-      a=$0; sub(/^[[:space:]]*-[[:space:]]*agent:[[:space:]]*/,"",a); sub(/[[:space:]]*$/,"",a); s=""; r=""
+      a=$0; sub(/^[[:space:]]*-[[:space:]]*agent:[[:space:]]*/,"",a); sub(/[[:space:]]*#.*/,"",a); sub(/[[:space:]]*$/,"",a); s=""; r=""
     }
     inc && match($0,/^[[:space:]]*subagent_type:[[:space:]]*/){
-      s=$0; sub(/^[[:space:]]*subagent_type:[[:space:]]*/,"",s); sub(/[[:space:]]*$/,"",s)
+      s=$0; sub(/^[[:space:]]*subagent_type:[[:space:]]*/,"",s); sub(/[[:space:]]*#.*/,"",s); sub(/[[:space:]]*$/,"",s)
     }
     inc && match($0,/^[[:space:]]*role:[[:space:]]*/){
-      r=$0; sub(/^[[:space:]]*role:[[:space:]]*/,"",r); sub(/[[:space:]]*$/,"",r)
+      r=$0; sub(/^[[:space:]]*role:[[:space:]]*/,"",r); sub(/[[:space:]]*#.*/,"",r); sub(/[[:space:]]*$/,"",r)
     }
     END{if(a!=""){print a"|"s"|"r}}
   ' "$f")

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -78,6 +78,72 @@ else
   echo "OK: $disk_count teams on disk match registry"
 fi
 
+# A6: Agent intent contract (#285)
+echo "--- A6: Agent intent contract ---"
+a6_fail=0
+declare -A AGENT_INTENT
+# A6a: every agent has a valid intent that agrees with tools
+for f in agents/*.md; do
+  name=$(basename "$f" .md)
+  [[ "$name" == "_template" || "$name" == "README" ]] && continue
+  intent=$(grep -m1 '^intent:' "$f" | sed 's/^intent: *//' | tr -d '\r' | xargs)
+  tools=$(grep -m1 '^tools:' "$f" | tr -d '\r')
+  if [ -z "$intent" ]; then
+    echo "FAIL: $f missing required field: intent"
+    failed=1; a6_fail=1; continue
+  fi
+  if [[ "$intent" != "advisory" && "$intent" != "implementing" ]]; then
+    echo "FAIL: $f intent='$intent' (must be advisory|implementing)"
+    failed=1; a6_fail=1; continue
+  fi
+  AGENT_INTENT[$name]=$intent
+  if echo "$tools" | grep -qE '\b(Write|Edit)\b'; then has_we=1; else has_we=0; fi
+  if [ "$intent" = "implementing" ] && [ "$has_we" -eq 0 ]; then
+    echo "FAIL: $name intent=implementing but tools lack Write/Edit"; failed=1; a6_fail=1
+  fi
+  if [ "$intent" = "advisory" ] && [ "$has_we" -eq 1 ]; then
+    echo "FAIL: $name intent=advisory but tools include Write/Edit"; failed=1; a6_fail=1
+  fi
+done
+
+# A6b: a team may assign implementation-flavored roles only to implementing
+# effective agents (member agent, or subagent_type overriding to a full-capability
+# type). Advisory roles (Reviewer/Auditor/Advisor/Specialist/Monitor/Lead) are exempt.
+impl_kw='Developer|Implementer|Programmer|Builder|Engineer|Operator|Hardener'
+for f in teams/*.md; do
+  tname=$(basename "$f")
+  [[ "$tname" == "_template.md" || "$tname" == "README.md" ]] && continue
+  while IFS='|' read -r ag sub role; do
+    [ -z "$ag" ] && continue
+    eff="$ag"
+    if [ -n "$sub" ] && [ "$sub" != "any" ]; then
+      # subagent_type overrides; full-capability unless it names another advisory agent
+      [ "${AGENT_INTENT[$sub]:-implementing}" = "implementing" ] && continue
+      eff="$sub"
+    fi
+    if echo "$role" | grep -qE "$impl_kw"; then
+      if [ "${AGENT_INTENT[$eff]:-implementing}" = "advisory" ]; then
+        echo "FAIL: $tname assigns implementation role '$role' to advisory agent '$eff' (override subagent_type to a full-capability type, or mark the agent implementing)"
+        failed=1; a6_fail=1
+      fi
+    fi
+  done < <(awk '
+    /CONFIG:START/{inc=1} /CONFIG:END/{inc=0}
+    inc && match($0,/^[[:space:]]*-[[:space:]]*agent:[[:space:]]*/){
+      if(a!=""){print a"|"s"|"r}
+      a=$0; sub(/^[[:space:]]*-[[:space:]]*agent:[[:space:]]*/,"",a); sub(/[[:space:]]*$/,"",a); s=""; r=""
+    }
+    inc && match($0,/^[[:space:]]*subagent_type:[[:space:]]*/){
+      s=$0; sub(/^[[:space:]]*subagent_type:[[:space:]]*/,"",s); sub(/[[:space:]]*$/,"",s)
+    }
+    inc && match($0,/^[[:space:]]*role:[[:space:]]*/){
+      r=$0; sub(/^[[:space:]]*role:[[:space:]]*/,"",r); sub(/[[:space:]]*$/,"",r)
+    }
+    END{if(a!=""){print a"|"s"|"r}}
+  ' "$f")
+done
+[ "$a6_fail" -eq 0 ] && echo "OK: All agents have a valid intent agreeing with tools; team implementation roles map to implementing agents"
+
 echo ""
 echo "=== Category B: Structural Integrity ==="
 


### PR DESCRIPTION
## Summary

Closes #285. Adds an `intent: advisory | implementing` capability contract to agent frontmatter and a CI rule that structurally catches the class of defect #282 surfaced — a read-only agent assigned an implementation role.

Per maintainer direction, this **retires the "review agents are intentionally read-only" convention**: in practice a reviewer that cannot even write its own findings, summary, or the fix it just recommended is friction, not separation. The technical/review family is evolved to gain `Write`/`Edit`; the contemplative/nature personas stay advisory.

## Changes

**`intent` field**
- Defined in `agents/_template.md` + `guides/agent-configuration-schema.md` (YAML ref, validation rule, JSON-schema enum)
- Backfilled across **all 72 agents** → **53 implementing / 19 advisory**

**Evolved 17 read-only technical/review agents** (each a surgical persona pass, `→ v2.0.0`): advocatus-diaboli, auditor, chromatographer, designer, empirical-investigator, framework-scout, ip-analyst, librarian, physicist, security-analyst, senior-data-scientist, senior-researcher, senior-software-developer, senior-ux-ui-specialist, senior-web-designer, spectroscopist, theoretical-researcher. (Done via a 17-agent evolve→verify workflow, 17/17 pass.)

**CI rule** — `validate-integrity.sh` **A6**:
- every agent has a valid `intent` that agrees with `tools` (`implementing` iff `Write`/`Edit`)
- a team CONFIG may assign implementation-flavored roles (`Developer|Implementer|Programmer|Builder|Engineer|Operator|Hardener`) only to `implementing` effective agents — `subagent_type` overriding to a full-capability type is the escape hatch

**Docs** — `agent:`/`subagent_type:` decoupling documented in `understanding-the-system.md` + `creating-agents-and-teams.md`; best-practices "read-only reviewer" section rewritten; stale Tool Selection example corrected.

**Sync** — registry tools/descriptions for the 17; READMEs regenerated.

## Verification

- **17-agent evolve workflow**: 17/17 evolved + verified, 0 residual read-only contradictions.
- **Negative test**: A6 correctly **fails** on a synthetic advisory-agent-in-`Developer`-role probe (rule is not vacuous).
- **4-lens adversarial review**: AC-completeness ✅, no-collateral ✅ (55 non-evolved agents got exactly one `intent:` line each), CI-rule-soundness ✅ (no false-positive on legit advisory roles, no false-negative), doc-consistency — one stale section found and **fixed** in this PR.
- `bash scripts/validate-integrity.sh` → exit 0 (5 pre-existing viz warnings only).

## Acceptance criteria

- [x] `intent` defined in template + schema guide, backfilled across 72 agents
- [x] `validate-integrity.sh` enforces the team-assignment rule; passes
- [x] decoupling convention documented in both guides
- [x] borderline/read-only review agents resolved (17 evolved, rationale recorded)
- [x] registry/READMEs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)