### PR TITLE
feat(workflows): add workflows as the fifth content type — Phase 1 (#288)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 <!-- AUTO:START:overview -->
-A documentation-only repository containing 29 guides, a skills library of 355 agentic skills, 72 agent definitions, and 17 team compositions following the [Agent Skills open standard](https://agentskills.io). There is no build system, no tests, and no compiled code — all content is markdown and YAML.
+A documentation-first repository containing 29 guides, a skills library of 355 agentic skills, 72 agent definitions, 17 team compositions, and a curated set of code-driven workflow orchestration scripts, following the [Agent Skills open standard](https://agentskills.io). Almost all content is markdown and YAML; workflows are self-contained `.mjs` scripts run by Claude Code's Workflow tool.
 
-The guides serve as the human entry point to the agentic system: practical workflows explaining when, why, and how to interact with agents, teams, and skills through Claude Code.
+The guides serve as the human entry point to the agentic system: practical walkthroughs explaining when, why, and how to interact with agents, teams, skills, and workflows through Claude Code.
 <!-- AUTO:END:overview -->
 
 ## Architecture
 
-### Four Content Types
+### Five Content Types
 
 1. **Guides** (`guides/` directory): Human-readable documentation organized into five categories (workflow, infrastructure, reference, design, investigation). Each guide has YAML frontmatter (`title`, `description`, `category`, `agents`, `teams`, `skills`) and follows a standard template (`guides/_template.md`). Guides serve as the human entry point to the agentic system.
 
@@ -22,7 +22,9 @@ The guides serve as the human entry point to the agentic system: practical workf
 
 4. **Teams** (`teams/` directory): Predefined multi-agent compositions for complex workflows. Each team is a markdown file with YAML frontmatter (`name`, `description`, `lead`, `members[]`, `coordination`) and an embedded machine-readable configuration block. Teams define *who works together* — coordinated groups of agents with assigned roles and a defined coordination pattern.
 
-These four types complement each other: skills define *how* (procedure, validation, recovery), agents define *who* (persona, tools, style), teams define *who works together* (composition, roles, coordination), and guides provide the background knowledge all draw from.
+5. **Workflows** (`workflows/` directory): Code-driven orchestration scripts run by Claude Code's Workflow tool. Each workflow is a self-contained `workflows/<name>.mjs` file with a top-of-file sidecar frontmatter comment block (the catalog source of truth, the analogue of the other types' YAML frontmatter), a pure-literal `export const meta`, and an async body using the injected `agent()` / `pipeline()` / `parallel()` / `phase()` / `log()` primitives. Where a **team** is a declarative roster the lead coordinates at runtime, a **workflow** fixes its phases and fan-out in code — its *control flow* is deterministic and rereadable, while the `agent()` outputs remain nondeterministic. Discovered from `.claude/workflows/<name>.mjs`, invocable as `Workflow({ name })` or `/<name>`. The library ships one reviewed seed (`review-changes`); the registry, CLI install, and validation are deferred (Phase 2).
+
+These five types complement each other: skills define *how* (procedure, validation, recovery), agents define *who* (persona, tools, style), teams define *who works together* (composition, roles, coordination), workflows define *how work is orchestrated* (code-driven control flow), and guides provide the background knowledge all draw from.
 
 ### Registries
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ When adding or removing skills, agents, teams, or guides, the corresponding regi
 
 ### Plugin Packaging
 
-The repository is packaged as a Claude Code plugin via `.claude-plugin/plugin.json`. When installed, Claude Code auto-discovers skills (`skills/*/SKILL.md`) and agents (`agents/*.md`). Teams are bundled but not auto-discovered — they require activation via `TeamCreate` and the CLAUDE.md activation instruction. The plugin can be installed via a local marketplace (see README.md for setup). Validation: `claude plugin validate /path/to/agent-almanac`.
+The repository is packaged as a Claude Code plugin via `.claude-plugin/plugin.json`. When installed, Claude Code auto-discovers skills (`skills/*/SKILL.md`) and agents (`agents/*.md`). Teams are bundled but not auto-discovered — they require activation via `TeamCreate` and the CLAUDE.md activation instruction. Workflows (`workflows/*.mjs`) are likewise bundled but not auto-installed — until the Phase-2 CLI adapter lands, install one by copying its `.mjs` into `.claude/workflows/` by hand. The plugin can be installed via a local marketplace (see README.md for setup). Validation: `claude plugin validate /path/to/agent-almanac`.
 
 ### Cross-References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 <!-- AUTO:START:overview -->
-A documentation-only repository containing 28 guides, a skills library of 355 agentic skills, 72 agent definitions, and 17 team compositions following the [Agent Skills open standard](https://agentskills.io). There is no build system, no tests, and no compiled code — all content is markdown and YAML.
+A documentation-only repository containing 29 guides, a skills library of 355 agentic skills, 72 agent definitions, and 17 team compositions following the [Agent Skills open standard](https://agentskills.io). There is no build system, no tests, and no compiled code — all content is markdown and YAML.
 
 The guides serve as the human entry point to the agentic system: practical workflows explaining when, why, and how to interact with agents, teams, and skills through Claude Code.
 <!-- AUTO:END:overview -->
@@ -30,7 +30,7 @@ These four types complement each other: skills define *how* (procedure, validati
 - `skills/_registry.yml` is the machine-readable catalog of all 355 skills across 64 domains: r-packages (10), jigsawr (5), containerization (10), reporting (4), compliance (17), mcp-integration (6), web-dev (4), git (7), general (23), citations (3), data-serialization (2), review (11), bushcraft (4), esoteric (29), design (5), defensive (6), project-management (6), devops (13), observability (13), edge-computing (1), mlops (12), workflow-visualization (6), swarm (9), morphic (7), alchemy (4), tcg (3), intellectual-property (4), web-scraping (2), gardening (5), shiny (7), animal-training (2), mycology (2), prospecting (2), crafting (1), library-science (3), linguistics (1), travel (6), relocation (3), a2a-protocol (3), geometry (3), number-theory (3), stochastic-processes (3), theoretical-science (3), diffusion (4), hildegard (5), maintenance (5), blender (3), visualization (4), 3d-printing (3), lapidary (4), entomology (5), versioning (4), spectroscopy (6), chromatography (5), gpu-optimization (2), digital-logic (4), electromagnetism (4), levitation (3), i18n (1), synoptic (4), tensegrity (1), cli (4), open-source (2), investigation (9).
 - `agents/_registry.yml` is the machine-readable catalog of all 72 agents.
 - `teams/_registry.yml` is the machine-readable catalog of all 17 teams.
-- `guides/_registry.yml` is the machine-readable catalog of all 28 guides across 5 categories.
+- `guides/_registry.yml` is the machine-readable catalog of all 29 guides across 5 categories.
 
 When adding or removing skills, agents, teams, or guides, the corresponding registry must be updated to stay in sync.
 <!-- AUTO:END:registries -->

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A library of executable skills, specialist agents, and pre-built teams for [Clau
 - **355 skills** across 64 domains — structured, executable procedures
 - **72 agents** — specialized Claude Code personas covering development, review, compliance, and more
 - **17 teams** — predefined multi-agent compositions for complex workflows
-- **28 guides** — human-readable workflow, infrastructure, and reference documentation
+- **29 guides** — human-readable workflow, infrastructure, and reference documentation
 - **Interactive visualization** — force-graph explorer with 355 R-generated skill icons and 9 color themes
 <!-- AUTO:END:stats -->
 
@@ -138,6 +138,7 @@ New here? Start with [Understanding the System](guides/understanding-the-system.
 - [Understanding the System](guides/understanding-the-system.md) — Entry point: what skills, agents, and teams are, how they compose, and how to invoke them
 - [Creating Skills](guides/creating-skills.md) — Authoring, evolving, and reviewing skills following the agentskills.io standard
 - [Creating Agents and Teams](guides/creating-agents-and-teams.md) — Designing agent personas, composing teams, and choosing coordination patterns
+- [Creating Workflows](guides/creating-workflows.md) — Authoring code-driven orchestration workflows — the meta contract, the agent/parallel/pipeline/phase primitives, and the capability rule
 - [Running a Code Review](guides/running-a-code-review.md) — Multi-agent code review using review teams for R packages and web projects
 - [Managing a Scrum Sprint](guides/managing-a-scrum-sprint.md) — Running Scrum sprints with the scrum-team: planning, dailies, review, and retro
 - [Visualizing Workflows with putior](guides/visualizing-workflows-with-putior.md) — End-to-end putior workflow visualization from annotation to themed Mermaid diagrams
@@ -178,16 +179,16 @@ New here? Start with [Understanding the System](guides/understanding-the-system.
 <!-- AUTO:START:translations -->
 | Locale | Language | Skills | Agents | Teams | Guides | Total |
 |---|---|---|---|---|---|---|
-| de | Deutsch | 352/355 | 3/72 | 1/17 | 4/28 | 360/472 (76.3%) |
-| zh-CN | 简体中文 | 352/355 | 3/72 | 1/17 | 4/28 | 360/472 (76.3%) |
-| ja | 日本語 | 352/355 | 3/72 | 1/17 | 4/28 | 360/472 (76.3%) |
-| es | Español | 352/355 | 3/72 | 1/17 | 4/28 | 360/472 (76.3%) |
-| caveman-lite | Caveman Lite | 352/355 | 0/72 | 0/17 | 0/28 | 352/472 (74.6%) |
-| caveman | Caveman | 352/355 | 0/72 | 0/17 | 0/28 | 352/472 (74.6%) |
-| caveman-ultra | Caveman Ultra | 352/355 | 0/72 | 0/17 | 0/28 | 352/472 (74.6%) |
-| wenyan-lite | 文言文輕 | 352/355 | 0/72 | 0/17 | 0/28 | 352/472 (74.6%) |
-| wenyan | 文言文 | 352/355 | 0/72 | 0/17 | 0/28 | 352/472 (74.6%) |
-| wenyan-ultra | 文言文極 | 352/355 | 0/72 | 0/17 | 0/28 | 352/472 (74.6%) |
+| de | Deutsch | 352/355 | 3/72 | 1/17 | 4/29 | 360/473 (76.1%) |
+| zh-CN | 简体中文 | 352/355 | 3/72 | 1/17 | 4/29 | 360/473 (76.1%) |
+| ja | 日本語 | 352/355 | 3/72 | 1/17 | 4/29 | 360/473 (76.1%) |
+| es | Español | 352/355 | 3/72 | 1/17 | 4/29 | 360/473 (76.1%) |
+| caveman-lite | Caveman Lite | 352/355 | 0/72 | 0/17 | 0/29 | 352/473 (74.4%) |
+| caveman | Caveman | 352/355 | 0/72 | 0/17 | 0/29 | 352/473 (74.4%) |
+| caveman-ultra | Caveman Ultra | 352/355 | 0/72 | 0/17 | 0/29 | 352/473 (74.4%) |
+| wenyan-lite | 文言文輕 | 352/355 | 0/72 | 0/17 | 0/29 | 352/473 (74.4%) |
+| wenyan | 文言文 | 352/355 | 0/72 | 0/17 | 0/29 | 352/473 (74.4%) |
+| wenyan-ultra | 文言文極 | 352/355 | 0/72 | 0/17 | 0/29 | 352/473 (74.4%) |
 <!-- AUTO:END:translations -->
 
 See [i18n/README.md](i18n/README.md) for the translation contributor guide.

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,6 +1,6 @@
 # Guides
 
-28 guides serving as the human entry point to the agentic system — practical workflows for agents, teams, and skills, plus infrastructure setup and reference material.
+29 guides serving as the human entry point to the agentic system — practical workflows for agents, teams, and skills, plus infrastructure setup and reference material.
 
 ## Workflow
 
@@ -14,6 +14,9 @@ Authoring, evolving, and reviewing skills following the agentskills.io standard.
 
 ### [Creating Agents and Teams](creating-agents-and-teams.md)
 Designing agent personas, composing teams, and choosing coordination patterns.
+
+### [Creating Workflows](creating-workflows.md)
+Authoring code-driven orchestration workflows — the meta contract, the agent/parallel/pipeline/phase primitives, and the capability rule.
 
 ### [Running a Code Review](running-a-code-review.md)
 Multi-agent code review using review teams for R packages and web projects.

--- a/guides/_registry.yml
+++ b/guides/_registry.yml
@@ -2,9 +2,9 @@
 # Machine-readable catalog of all guide documents in this library.
 # Keep in sync with the actual guide files on disk.
 
-total_guides: 28
+total_guides: 29
 version: "1.0"
-last_updated: "2026-05-04"
+last_updated: "2026-06-15"
 
 categories:
   workflow:
@@ -46,6 +46,15 @@ guides:
     agents: [skill-reviewer]
     teams: []
     skills: [create-skill]
+
+  - id: creating-workflows
+    path: guides/creating-workflows.md
+    title: "Creating Workflows"
+    description: "Authoring code-driven orchestration workflows — the meta contract, the agent/parallel/pipeline/phase primitives, and the capability rule"
+    category: workflow
+    agents: [code-reviewer, security-analyst]
+    teams: []
+    skills: [review-codebase, review-pull-request]
 
   - id: running-a-code-review
     path: guides/running-a-code-review.md

--- a/guides/creating-agents-and-teams.md
+++ b/guides/creating-agents-and-teams.md
@@ -33,7 +33,7 @@ To create a new skill (the procedure an agent follows), see `skills/create-skill
 
 ## Prerequisites
 
-Familiarity with the four content types (guides, skills, agents, teams), how `_registry.yml` files catalog each type, and basic YAML frontmatter syntax. Review [CLAUDE.md](../CLAUDE.md) for an architectural overview.
+Familiarity with the five content types — skills, agents, teams, guides, and the newer workflows — how `_registry.yml` files catalog the first four (workflows have no registry yet), and basic YAML frontmatter syntax. Review [CLAUDE.md](../CLAUDE.md) for an architectural overview.
 
 ## Workflow Overview
 

--- a/guides/creating-agents-and-teams.md
+++ b/guides/creating-agents-and-teams.md
@@ -247,6 +247,8 @@ This interacts with the `intent` contract. Each agent is `advisory` or `implemen
       role: Implementer
 ```
 
+See also [Creating Workflows](creating-workflows.md) for deterministic, code-driven orchestration — a workflow expresses this same persona-vs-spawn decoupling natively by naming the `agentType` per `agent()` call.
+
 ### Step 5: Team Size and Composition
 
 - **3-5 members** recommended. Fewer than 3 rarely justifies a team. More than 5 increases coordination overhead.

--- a/guides/creating-agents-and-teams.md
+++ b/guides/creating-agents-and-teams.md
@@ -247,7 +247,7 @@ This interacts with the `intent` contract. Each agent is `advisory` or `implemen
       role: Implementer
 ```
 
-See also [Creating Workflows](creating-workflows.md) for deterministic, code-driven orchestration — a workflow expresses this same persona-vs-spawn decoupling natively by naming the `agentType` per `agent()` call.
+See also [Creating Workflows](creating-workflows.md) for code-driven orchestration whose *control flow* is deterministic and rereadable (the `agent()` outputs are not) — a workflow expresses this same persona-vs-spawn decoupling natively by naming the `agentType` per `agent()` call.
 
 ### Step 5: Team Size and Composition
 

--- a/guides/creating-workflows.md
+++ b/guides/creating-workflows.md
@@ -1,0 +1,160 @@
+---
+title: "Creating Workflows"
+description: "Authoring code-driven orchestration workflows — the meta contract, the agent/parallel/pipeline/phase primitives, and the capability rule"
+category: workflow
+agents: [code-reviewer, security-analyst]
+teams: []
+skills: [review-codebase, review-pull-request]
+---
+
+# Creating Workflows
+
+A workflow is the fifth content type: a self-contained `.mjs` orchestration script run by Claude Code's Workflow tool. This guide explains how to author one — the `meta` contract, the injected orchestration primitives, the `args` and `budget` globals, how to invoke and install a workflow, and the capability rule that governs which agent types a stage may spawn.
+
+A workflow's **control flow** — its phases, fan-out, loops, and verification structure — is fixed in JavaScript and is deterministic and rereadable. The **outputs** of its `agent()` calls are LLM subagents and remain nondeterministic. Hold that distinction throughout: never call a workflow "deterministic" without qualifying that it is the control flow, not the results, that is fixed.
+
+## When to Use This Guide
+
+- You have a repeatable, parameterized procedure that coordinates several agents and want to capture it as a reusable artifact.
+- You are deciding between writing a [team](creating-agents-and-teams.md) and writing a workflow.
+- You need a review or research procedure to run the same way every time, with the fan-out and verification logic auditable in code.
+- You are adding a seed to `workflows/` and need the authoring conventions.
+
+## Prerequisites
+
+- Claude Code on a paid plan with the Workflow tool available (~v2.1.154+); confirm with `/workflows`.
+- Familiarity with the four existing content types — see [Understanding the System](understanding-the-system.md).
+- Comfort reading plain JavaScript (no TypeScript, no Node APIs — see the constraints below).
+
+## Teams vs Workflows
+
+Both coordinate multiple agents; they differ in *where the coordination logic lives*.
+
+- A **team** is a declarative roster. The lead decides handoffs turn by turn at runtime via `TeamCreate` — coordination is model-driven and adaptive.
+- A **workflow** is a script. The phases and fan-out are fixed by `agent()` / `pipeline()` / `phase()` calls — coordination is code-driven, with deterministic control flow.
+
+Choose a **team** for adaptive, judgment-based collaboration where the right next step depends on what the last step found. Choose a **workflow** for a repeatable, auditable, parameterized procedure whose shape you already know. The two are complementary: the [production coordination patterns](production-coordination-patterns.md) (barrier synchronization, silence budgets, health checks) are runtime-health layers that apply to *both*.
+
+## Workflow Overview
+
+A workflow file is a bare `workflows/<name>.mjs`. It has two parts: a metadata header and an async body.
+
+```js
+// ---
+// name: review-changes
+// description: Classify → adversarially verify → synthesize a code review over changed files
+// phases: Classify, Verify, Synthesize
+// ---
+export const meta = {
+  name: 'review-changes',
+  description: 'Classify → adversarially verify → synthesize a code review over changed files',
+  phases: [
+    { title: 'Classify', detail: 'one agent per changed file' },
+    { title: 'Verify', detail: 'adversarial refuters per finding' },
+    { title: 'Synthesize', detail: 'consolidate survivors' },
+  ],
+}
+
+// body — runs inside an async wrapper; use top-level await and return directly
+phase('Classify')
+const files = args?.files ?? ['example.js']
+const findings = await pipeline(files, classify, verify)
+return { findings }
+```
+
+### The `meta` contract
+
+`export const meta` must be a **pure literal** — no variables, function calls, spreads, or template interpolation. Required fields are `name` and `description`; `phases` (one entry per `phase()` call) is optional but recommended. The `name` **must equal the filename stem** — that is the `Workflow({ name })` and `/<name>` discovery contract.
+
+### Sidecar frontmatter
+
+The `// --- … ---` comment block at the very top mirrors `meta` and is the **catalog source of truth** — the analogue of the YAML frontmatter on skills, agents, teams, and guides. It lets the repo's grep+count tooling read a workflow's metadata without a JavaScript parser. Keep the sidecar `name`/`description` in agreement with `meta`, and keep the sidecar `phases:` list a superset of every title passed to `phase()`.
+
+### Orchestration primitives
+
+These globals are injected — do not import them:
+
+| Primitive | Use |
+|---|---|
+| `agent(prompt, opts)` | Spawn one subagent. With `{ schema }` it returns a validated object; without, its final text. `opts`: `label`, `phase`, `schema`, `agentType`, `model`, `isolation`. |
+| `pipeline(items, ...stages)` | The default. Each item flows through every stage independently — no barrier between stages. |
+| `parallel(thunks)` | A barrier: run thunks concurrently and await all. Use only when a stage needs every prior result at once. |
+| `phase(title)` | Open a named progress group. Inside `pipeline`/`parallel` stages, prefer the per-call `phase:` option to avoid races on the global state. |
+| `log(message)` | Emit a progress line to the user. |
+| `workflow(name, args)` | Run another workflow inline as a sub-step (one level deep). |
+
+Two ambient globals carry input and budget:
+
+- `args` — whatever the caller passed as `Workflow({ args })`; `undefined` if none. Default it so the workflow runs with no input.
+- `budget` — the turn's token target: `budget.total` (or `null`), `budget.spent()`, `budget.remaining()`. Use it to scale fan-out depth or to bound a loop.
+
+`pipeline()` is the default multi-stage primitive because it has no barrier between stages — item A can reach the last stage while item B is still in the first, so wall-clock is the slowest single chain rather than the sum of per-stage maxima. Reach for `parallel()` only when a stage genuinely needs all prior-stage results together (deduplication, an early-exit count, or a synthesis step).
+
+### Structured output and adversarial verification
+
+Passing a JSON Schema as `{ schema }` forces the subagent to return a validated object, so you never parse free text. The canonical quality pattern is a `pipeline()` whose verify stage is a nested `parallel()` of adversarial refuters that default to "refuted" unless they can independently reproduce a finding — this is what filters the false positives that plague naive multi-agent review. The [`review-changes`](../workflows/review-changes.mjs) seed is built on exactly this classify → refute → synthesize spine.
+
+## Capability Contract (relates to #285)
+
+A workflow spawns subagents with `agent(prompt, { agentType })`, where `agentType` names the subagent type — the workflow's direct expression of the `agent:` (persona) vs `subagent_type:` (spawn) decoupling that [Creating Agents and Teams](creating-agents-and-teams.md) documents for teams. The script names the exact spawn type per call.
+
+The same `intent` rule from #285 applies: an agent type is **`implementing`** when its tools include `Write` or `Edit`, otherwise **`advisory`**. A stage that **mutates artifacts** — uses `Write`/`Edit`/`Bash` to change files, or runs under `isolation: 'worktree'` — must target an `implementing` agent type. A read-only analysis stage targets an `advisory` type. `review-changes` is entirely read-only, so every stage targets the advisory `Explore` type; a stage that wrote a patch would target an implementing type such as `general-purpose`.
+
+## Invoking and Installing
+
+A workflow installed at `.claude/workflows/<name>.mjs` is invocable two ways:
+
+```js
+Workflow({ name: 'review-changes' })                              // as a tool call
+Workflow({ name: 'review-changes', args: { files: ['a.js'] } })  // parameterized
+```
+
+```text
+/review-changes        # as a slash command
+```
+
+`.claude/workflows/` is user-writable and the Workflow save-flow writes there, so a curated install must namespace its files (for example `almanac-<name>.mjs`) to avoid shadowing a user's own workflow. The CLI install adapter for this is deferred (Phase 2) — for now, copy a reviewed `.mjs` into `.claude/workflows/` by hand.
+
+## Validating a Workflow Script
+
+Workflow scripts use a top-level `return`, which the runtime accepts (it wraps the body in an async function) but which is **illegal in a raw ES module** — so plain `node --check workflows/<name>.mjs` reports `Illegal return statement` on a valid workflow. Validate the runtime dialect by wrapping the body as the runtime does, then syntax-checking:
+
+```bash
+{ echo '(async()=>{'; \
+  sed 's/^[[:space:]]*export const meta/const meta/' workflows/<name>.mjs; \
+  echo '})()'; } | node --check -
+```
+
+The authoritative check is running it: `Workflow({ name: '<name>' })`.
+
+## Hard Constraints
+
+The runtime enforces these — violating them breaks the run:
+
+- **Plain JavaScript only.** No TypeScript syntax (`: string[]`, interfaces, generics).
+- **No `Date.now()`, `Math.random()`, or argless `new Date()`** — they would break workflow resume. Pass timestamps via `args`; vary randomness by agent index or label.
+- **No filesystem or Node API.** Standard JS built-ins (`JSON`, `Math`, `Array`) only; agents do the file and shell work.
+- The body runs in an async context — use top-level `await` and a top-level `return` directly.
+
+## Vendor-API Caveat
+
+The Workflow **run model** is generally available on paid Claude Code plans (~v2.1.154+). The **script-authoring surface** — the injected primitives and the `args` / `budget` globals — is an evolving vendor API. Everything in this guide reflects Claude Code **v2.1.x** behavior and is **subject to change**; it is documentation, never CI-enforced. Only Claude Code has the Workflow tool; other frameworks have no equivalent and skip workflows entirely.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| `Illegal return statement` from `node --check` | Raw ESM check rejects the top-level `return` that the runtime accepts | Use the wrap-then-check recipe above |
+| `meta must be a pure literal` | `meta` references a variable or call | Inline every value into the `export const meta` object literal |
+| Workflow not found by name | `meta.name` ≠ filename stem, or not installed in `.claude/workflows/` | Make the triple (filename ↔ sidecar `name:` ↔ `meta.name`) identical and install the file |
+| A mutating stage is rejected / misbehaves | Stage targets an advisory `agentType` but needs to write | Target an `implementing` agent type for any Write/Edit/Bash or `worktree` stage |
+| `Date.now is not a function` | Used a forbidden non-deterministic call | Pass the value via `args`; vary by index/label instead |
+
+## Related Resources
+
+- [Understanding the System](understanding-the-system.md) -- where workflows sit among the Five Pillars and the canonical Teams-vs-Workflows boundary
+- [Creating Agents and Teams](creating-agents-and-teams.md) -- the `agent:`/`subagent_type:` decoupling and the `intent` contract workflows reuse
+- [Production Coordination Patterns](production-coordination-patterns.md) -- runtime-health layers that apply to both teams and workflows
+- [`review-changes`](../workflows/review-changes.mjs) -- the seed workflow this guide references
+- [`workflows/_template.mjs`](../workflows/_template.mjs) -- the copy-and-rename scaffold
+- [Workflows README](../workflows/README.md) -- the directory overview and authoring convention

--- a/guides/creating-workflows.md
+++ b/guides/creating-workflows.md
@@ -23,7 +23,7 @@ A workflow's **control flow** — its phases, fan-out, loops, and verification s
 ## Prerequisites
 
 - Claude Code on a paid plan with the Workflow tool available (~v2.1.154+); confirm with `/workflows`.
-- Familiarity with the four existing content types — see [Understanding the System](understanding-the-system.md).
+- Familiarity with the four other content types — see [Understanding the System](understanding-the-system.md).
 - Comfort reading plain JavaScript (no TypeScript, no Node APIs — see the constraints below).
 
 ## Teams vs Workflows
@@ -64,7 +64,7 @@ return { findings }
 
 ### The `meta` contract
 
-`export const meta` must be a **pure literal** — no variables, function calls, spreads, or template interpolation. Required fields are `name` and `description`; `phases` (one entry per `phase()` call) is optional but recommended. The `name` **must equal the filename stem** — that is the `Workflow({ name })` and `/<name>` discovery contract.
+`export const meta` must be a **pure literal** — no variables, function calls, spreads, or template interpolation. Required fields are `name` and `description`; `phases` (one entry per phase the workflow uses — whether opened by a global `phase()` call or assigned via a stage's `phase:` option) is optional but recommended. The `name` **must equal the filename stem** — that is the `Workflow({ name })` and `/<name>` discovery contract.
 
 ### Sidecar frontmatter
 

--- a/guides/creating-workflows.md
+++ b/guides/creating-workflows.md
@@ -76,7 +76,7 @@ These globals are injected — do not import them:
 
 | Primitive | Use |
 |---|---|
-| `agent(prompt, opts)` | Spawn one subagent. With `{ schema }` it returns a validated object; without, its final text. `opts`: `label`, `phase`, `schema`, `agentType`, `model`, `isolation`. |
+| `agent(prompt, opts)` | Spawn one subagent. With `{ schema }` it returns a validated object; without, its final text — or `null` if the subagent is skipped or dies, so `filter(Boolean)` before aggregating. `opts`: `label`, `phase`, `schema`, `agentType`, `model`, `effort`, `isolation`. |
 | `pipeline(items, ...stages)` | The default. Each item flows through every stage independently — no barrier between stages. |
 | `parallel(thunks)` | A barrier: run thunks concurrently and await all. Use only when a stage needs every prior result at once. |
 | `phase(title)` | Open a named progress group. Inside `pipeline`/`parallel` stages, prefer the per-call `phase:` option to avoid races on the global state. |
@@ -93,6 +93,8 @@ Two ambient globals carry input and budget:
 ### Structured output and adversarial verification
 
 Passing a JSON Schema as `{ schema }` forces the subagent to return a validated object, so you never parse free text. The canonical quality pattern is a `pipeline()` whose verify stage is a nested `parallel()` of adversarial refuters that default to "refuted" unless they can independently reproduce a finding — this is what filters the false positives that plague naive multi-agent review. The [`review-changes`](../workflows/review-changes.mjs) seed is built on exactly this classify → refute → synthesize spine.
+
+One subtlety the seed bakes in: `agent()` returns `null` when a subagent is skipped or dies, so gate survival on a **majority of affirmative confirmations** (`refuted === false`) — `Math.floor(n / 2) + 1` of them — never on the mere *absence* of a refutation. Counting refutations and surviving when "few enough refuted" inverts the fail-safe: a dead or null refuter would then let an unverified finding survive on absent evidence. Give each refuter the same evidence the classifier had (point it at the diff, not just the file) so it can fairly confirm change-specific findings.
 
 ## Capability Contract (relates to #285)
 

--- a/guides/production-coordination-patterns.md
+++ b/guides/production-coordination-patterns.md
@@ -11,7 +11,7 @@ skills: [coordinate-swarm, build-consensus, create-team, test-team-coordination,
 
 This guide documents six coordination patterns that emerge when multi-agent systems run in production over hours, days, or indefinitely. The existing seven patterns (hub-and-spoke, sequential, parallel, adaptive, timeboxed, wave-parallel, reciprocal) define *how agents relate to each other*. The patterns in this guide define *how long-running agent systems stay healthy* -- they layer on top of any base coordination pattern to handle the realities of sustained operation: agents that stall, budgets that burn, waves that cannot proceed at full strength, and failures that must escalate.
 
-These patterns draw from parallel computing, distributed systems engineering, and hard-won lessons from early adopters running multi-agent stacks in production.
+These patterns draw from parallel computing, distributed systems engineering, and hard-won lessons from early adopters running multi-agent stacks in production. They are runtime-health layers that apply to *both* model-driven [teams](creating-agents-and-teams.md) and code-driven [workflows](creating-workflows.md) — the base coordination they harden can be either.
 
 ## When to Use This Guide
 

--- a/guides/understanding-the-synoptic-mind.md
+++ b/guides/understanding-the-synoptic-mind.md
@@ -20,7 +20,7 @@ The synoptic mind is an approach to multi-domain problems that holds all relevan
 
 ## Prerequisites
 
-- Familiarity with the four content types (skills, agents, teams, guides) described in [Understanding the System](understanding-the-system.md)
+- Familiarity with the five content types (skills, agents, teams, workflows, guides) described in [Understanding the System](understanding-the-system.md)
 - Familiarity with the existing seven coordination patterns, especially hub-and-spoke and adaptive
 - Optional: experience with the tending team or meditate skill, which the synoptic cycle builds on
 
@@ -266,7 +266,7 @@ Do not use it when:
 
 ### Guides
 
-- [Understanding the System](understanding-the-system.md) -- the four content types and all eight coordination patterns
+- [Understanding the System](understanding-the-system.md) -- the five content types and all eight coordination patterns
 - [Running Tending](running-tending.md) -- the meta-cognitive wellness workflow that shares the meditate foundation
 - [Extracting Project Essence](extracting-project-essence.md) -- multi-perspective analysis; related conceptual approach
 - [Epigenetics-Inspired Activation Control](epigenetics-activation-control.md) -- design guide using biological metaphor; related design-category document

--- a/guides/understanding-the-system.md
+++ b/guides/understanding-the-system.md
@@ -9,7 +9,7 @@ skills: [create-skill]
 
 # Understanding the System
 
-This repository provides 328 skills, 66 agents, and 15 teams following the [Agent Skills open standard](https://agentskills.io). Together they form a composable system for AI-assisted development: skills define *how* to do something, agents define *who* does it, teams define *who works together*, and guides supply the background knowledge humans and agents both draw from. This guide explains each component type, how the types relate, and how you interact with them through Claude Code.
+This repository provides 355 skills, 72 agents, and 17 teams following the [Agent Skills open standard](https://agentskills.io), plus an emerging fifth content type — workflows. Together they form a composable system for AI-assisted development: skills define *how* to do something, agents define *who* does it, teams define *who works together*, workflows define *how work is orchestrated* in code, and guides supply the background knowledge humans and agents both draw from. This guide explains each component type, how the types relate, and how you interact with them through Claude Code.
 
 ## When to Use This Guide
 
@@ -33,24 +33,28 @@ agent-almanac/
 │   ├── _registry.yml    # Catalog of all guides
 │   └── *.md             # Individual guide files
 ├── skills/              # Machine-consumable procedures
-│   ├── _registry.yml    # Catalog of all 328 skills
-│   └── <skill-name>/    # 328 skill directories
+│   ├── _registry.yml    # Catalog of all 355 skills
+│   └── <skill-name>/    # 355 skill directories
 │       └── SKILL.md
 ├── agents/              # Persona definitions for Claude Code subagents
-│   ├── _registry.yml    # Catalog of all 66 agents
+│   ├── _registry.yml    # Catalog of all 72 agents
 │   └── *.md             # Individual agent files
 ├── teams/               # Multi-agent compositions
-│   ├── _registry.yml    # Catalog of all 15 teams
+│   ├── _registry.yml    # Catalog of all 17 teams
 │   └── *.md             # Individual team files
+├── workflows/           # Code-driven orchestration scripts
+│   ├── _template.mjs    # Scaffold for new workflows
+│   └── *.mjs            # Individual workflow files
 ├── .claude/
 │   ├── agents -> ../agents   # Symlink for Claude Code discovery
-│   └── skills/               # Symlinks to individual skills
+│   ├── skills/               # Symlinks to individual skills
+│   └── workflows/            # Installed workflow scripts (Claude Code-only)
 └── scripts/             # Automation (README generation, CI)
 ```
 
-## The Four Pillars
+## The Five Pillars
 
-The system has four content types. Each lives in its own top-level directory and serves a distinct role.
+The system has five content types. Each lives in its own top-level directory and serves a distinct role.
 
 ### 1. Skills -- the *how*
 
@@ -66,7 +70,7 @@ A skill is a machine-consumable procedure. It tells an agent exactly how to acco
 - **Common Pitfalls** -- frequent mistakes and how to avoid them.
 - **Related Skills** -- cross-references to complementary skills.
 
-The library currently contains 328 skills spanning 58 domains (as tagged in their metadata), ranging from `r-packages` and `containerization` to `esoteric` and `gardening`. Skills are kept under 500 lines; extended examples go into a `references/EXAMPLES.md` subdirectory following the progressive disclosure pattern.
+The library currently contains 355 skills spanning 64 domains (as tagged in their metadata), ranging from `r-packages` and `containerization` to `esoteric` and `gardening`. Skills are kept under 500 lines; extended examples go into a `references/EXAMPLES.md` subdirectory following the progressive disclosure pattern.
 
 ### 2. Agents -- the *who*
 
@@ -81,7 +85,7 @@ An agent is a persona definition for a Claude Code subagent. It specifies who ha
 - **Examples** -- sample invocations.
 - **Limitations** -- what the agent cannot or should not do.
 
-There are currently 66 agents. Examples include `r-developer` (R package development), `security-analyst` (security auditing), `mystic` (meta-cognitive meditation), and `shapeshifter` (adaptive role assumption). Two default skills -- `meditate` and `heal` -- are inherited by every agent automatically through the agents registry; individual agents do not need to list them.
+There are currently 72 agents. Examples include `r-developer` (R package development), `security-analyst` (security auditing), `mystic` (meta-cognitive meditation), and `shapeshifter` (adaptive role assumption). Two default skills -- `meditate` and `heal` -- are inherited by every agent automatically through the agents registry; individual agents do not need to list them.
 
 Claude Code discovers agents from the `.claude/agents/` directory, which in this repository is a symlink to `agents/`.
 
@@ -99,7 +103,7 @@ A team is a multi-agent composition. It defines a group of agents with assigned 
 - **Configuration** -- a machine-readable YAML block between `<!-- CONFIG:START -->` and `<!-- CONFIG:END -->` markers.
 - **Usage Scenarios** and **Limitations**.
 
-There are currently 15 teams using 8 coordination patterns:
+There are currently 17 teams using 8 coordination patterns:
 
 | Pattern | Description | Used by |
 |---|---|---|
@@ -114,17 +118,31 @@ There are currently 15 teams using 8 coordination patterns:
 
 **Persona vs. spawned worker.** In a team CONFIG, a member's `agent:` is the *persona label* (whose voice and skills frame the work) while an optional `subagent_type:` is *what actually spawns*. They can differ: the [dyad](../teams/dyad.md) team pairs a `contemplative` persona with a `general-purpose` worker. This decoupling, combined with each agent's `intent` (`advisory` | `implementing`), lets a team give an implementation-flavored role to an advisory persona by overriding `subagent_type` to a full-capability type — without changing the agent definition.
 
-### 4. Guides -- the *context*
+### 4. Workflows -- the *orchestration*
+
+**Location:** `workflows/<name>.mjs`
+
+A workflow is a code-driven orchestration script run by Claude Code's Workflow tool. Where a team is a declarative roster the lead coordinates at runtime, a workflow fixes its phases, fan-out, and verification logic in JavaScript. Every workflow file has:
+
+- A **sidecar frontmatter** comment block (`// --- … ---`) mirroring the runtime metadata — the catalog source of truth, the analogue of the other types' YAML frontmatter.
+- A pure-literal **`export const meta`** with `name` (equal to the filename stem), `description`, and `phases`.
+- An **async body** using the injected primitives `agent()`, `pipeline()`, `parallel()`, `phase()`, and `log()`, plus the `args` and `budget` globals.
+
+Claude Code discovers workflows from `.claude/workflows/<name>.mjs`, invocable as `Workflow({ name })` or the `/<name>` slash command. The library ships one reviewed seed, `review-changes`; the full registry, CLI install, and validation are deferred (Phase 2). See [Creating Workflows](creating-workflows.md).
+
+> **Teams vs Workflows.** Teams are declarative, model-driven coordination — the lead decides handoffs at runtime via `TeamCreate`. Workflows are code-driven orchestration with deterministic *control flow* — the `.mjs` script fixes the phases and fan-out via `agent()` / `pipeline()` / `phase()`. The control flow is deterministic and rereadable; the `agent()` outputs are not. Choose a team for adaptive, judgment-based coordination; choose a workflow for a repeatable, auditable, parameterized procedure.
+
+### 5. Guides -- the *context*
 
 **Location:** `guides/<name>.md`
 
 A guide is a human-readable reference document. Guides provide the background knowledge that agents and skills draw from: environment setup, development best practices, workflow walkthroughs, and design rationale. Guides use YAML frontmatter with `title`, `description`, `category`, and cross-references to related `agents`, `teams`, and `skills`.
 
-There are currently 19 guides across 4 categories: workflow, infrastructure, reference, and design.
+There are currently 29 guides across 5 categories: workflow, infrastructure, reference, design, and investigation.
 
 ## How They Compose
 
-The four pillars work together in practice. Consider two examples at different scales.
+The five pillars work together in practice. Consider two examples at different scales.
 
 ### Example 1: Team-level composition
 
@@ -168,7 +186,7 @@ For example, the `submit-to-cran` skill is linked as:
 .claude/skills/submit-to-cran -> ../../skills/submit-to-cran
 ```
 
-You can then invoke it in Claude Code by typing `/submit-to-cran`. All 328 skills in this repository are already symlinked and ready to use.
+You can then invoke it in Claude Code by typing `/submit-to-cran`. All 355 skills in this repository are already symlinked and ready to use.
 
 ### By asking Claude Code directly
 
@@ -233,6 +251,7 @@ Four YAML registry files serve as the machine-readable catalogs for the system:
 | Skills | `skills/_registry.yml` | Lists all skills with id, path, complexity, language, and description |
 | Agents | `agents/_registry.yml` | Lists all agents with id, path, tags, tools, and skill assignments |
 | Teams | `teams/_registry.yml` | Lists all teams with id, path, lead, members, and coordination pattern |
+| Workflows | `workflows/` | Workflow scripts, discovered by filename from `.claude/workflows/`; no `_registry.yml` yet (deferred to Phase 2) |
 | Tests | `tests/_registry.yml` | Lists test scenarios with target, coordination pattern, and acceptance criteria |
 
 Registries must stay in sync with files on disk. When you add or remove a skill, agent, or team, update its registry and the `total_*` count.
@@ -261,12 +280,14 @@ Use this decision matrix to pick the right level of composition for your task:
 | Multi-perspective review or complex workflow | Full team | "Activate the r-package-review team" |
 | Fixed-iteration project work | Scrum team | "Use the scrum-team for a two-week sprint" |
 | Unknown or highly variable task | Opaque team | "Use the opaque-team to figure out the best approach" |
+| Repeatable, auditable procedure coordinating many agents | Workflow | `/review-changes` or `Workflow({ name: 'review-changes' })` |
 
 **Rules of thumb:**
 
 - If you can describe the task as a single procedure with clear inputs and outputs, use a skill.
 - If the task needs judgment, context, or a specific communication style, use an agent.
 - If the task benefits from multiple viewpoints or handoffs between specialists, use a team.
+- If the coordination is fixed and you want it repeatable, auditable, and parameterized, codify it as a workflow.
 - If you find yourself repeating the same instructions across sessions, codify them as a new skill.
 
 ## Troubleshooting
@@ -283,9 +304,11 @@ Use this decision matrix to pick the right level of composition for your task:
 
 - [Creating Skills](creating-skills.md) -- how to author, evolve, and review skills
 - [Creating Agents and Teams](creating-agents-and-teams.md) -- how to design agent personas and compose teams
+- [Creating Workflows](creating-workflows.md) -- how to author code-driven orchestration workflows
+- [Workflows README](../workflows/README.md) -- the workflows directory overview and seed
 - [Quick Reference](quick-reference.md) -- command cheat sheet for daily operations
 - [Skill Creation Meta-Skill](../skills/create-skill/SKILL.md) -- the skill that teaches you how to create skills
-- [Skills Library README](../skills/README.md) -- browsable catalog of all 328 skills
-- [Agents Library README](../agents/README.md) -- browsable catalog of all 66 agents
-- [Teams Library README](../teams/README.md) -- browsable catalog of all 15 teams
+- [Skills Library README](../skills/README.md) -- browsable catalog of all 355 skills
+- [Agents Library README](../agents/README.md) -- browsable catalog of all 72 agents
+- [Teams Library README](../teams/README.md) -- browsable catalog of all 17 teams
 - [Agent Skills Open Standard](https://agentskills.io) -- the specification this system follows

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -215,9 +215,9 @@ function generateTeamsTable(linkPrefix) {
 }
 
 function generateOverview() {
-  return `A documentation-only repository containing ${totalGuides} guides, a skills library of ${totalSkills} agentic skills, ${totalAgents} agent definitions, and ${totalTeams} team compositions following the [Agent Skills open standard](https://agentskills.io). There is no build system, no tests, and no compiled code — all content is markdown and YAML.
+  return `A documentation-first repository containing ${totalGuides} guides, a skills library of ${totalSkills} agentic skills, ${totalAgents} agent definitions, ${totalTeams} team compositions, and a curated set of code-driven workflow orchestration scripts, following the [Agent Skills open standard](https://agentskills.io). Almost all content is markdown and YAML; workflows are self-contained \`.mjs\` scripts run by Claude Code's Workflow tool.
 
-The guides serve as the human entry point to the agentic system: practical workflows explaining when, why, and how to interact with agents, teams, and skills through Claude Code.`;
+The guides serve as the human entry point to the agentic system: practical walkthroughs explaining when, why, and how to interact with agents, teams, skills, and workflows through Claude Code.`;
 }
 
 function generateRegistries() {

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,67 @@
+# Workflows
+
+Workflows are the **fifth content type** in agent-almanac — code-driven orchestration scripts run by Claude Code's Workflow tool. Where a **team** is a declarative roster whose lead coordinates handoffs at runtime, a **workflow** is a script whose *control flow* — phases, fan-out, loops, adversarial verification — is fixed in JavaScript. The control flow is deterministic and rereadable; the outputs of the script's `agent()` calls are LLM subagents and remain nondeterministic. See [Creating Workflows](../guides/creating-workflows.md) for the authoring guide and [Understanding the System](../guides/understanding-the-system.md) for where workflows sit among the Five Pillars.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| [`_template.mjs`](_template.mjs) | Copy-and-rename scaffold: sidecar frontmatter, `export const meta`, `phase()`, a `pipeline()` fan-out, and an `agent({ schema })` call, with the hard constraints inline. |
+| [`review-changes.mjs`](review-changes.mjs) | The seed workflow — a classify → adversarially-verify → synthesize code review over changed files. |
+
+This directory ships **exactly one** reviewed seed (Phase 1). A larger seed library, a `workflows/_registry.yml`, CLI install, and registry-sync validation are deliberately deferred behind a promotion gate (see [#288](https://github.com/pjt222/agent-almanac/issues/288)).
+
+## Authoring convention
+
+A workflow is a bare `workflows/<name>.mjs` file (mirroring `agents/`, not the directory-per-item `skills/` layout). It carries a **sidecar frontmatter** comment block at the very top:
+
+```js
+// ---
+// name: review-changes
+// description: Classify → adversarially verify → synthesize a code review over changed files
+// phases: Classify, Verify, Synthesize
+// ---
+export const meta = {
+  name: 'review-changes',
+  description: 'Classify → adversarially verify → synthesize a code review over changed files',
+  phases: [ /* … */ ],
+}
+```
+
+The runtime `export const meta` literal is required by the Workflow tool; the **sidecar comment is the catalog source of truth**, the analogue of YAML frontmatter on the other four content types, so the existing grep+count tooling can read the metadata without a JavaScript parser. Keep the two in agreement, and keep `meta.name` equal to the filename stem — that triple equality (filename ↔ sidecar `name:` ↔ `meta.name`) is the `Workflow({ name })` / `/<name>` discovery contract.
+
+## Invoking
+
+Once a workflow is installed into `.claude/workflows/<name>.mjs`, invoke it either way:
+
+```js
+// As a tool call (optionally parameterized via args)
+Workflow({ name: 'review-changes' })
+Workflow({ name: 'review-changes', args: { files: ['src/auth.js', 'R/score.R'] } })
+```
+
+```text
+/review-changes        # as a slash command
+```
+
+`review-changes` with no `args` derives its file list from the working-tree diff (`git diff --name-only HEAD`); pass `args.files` to scope it explicitly.
+
+## Validating a workflow script
+
+Workflow scripts use a top-level `return`, which is valid in the Workflow runtime (the body is wrapped in an async function) but **illegal in a raw ES module** — so plain `node --check workflows/<name>.mjs` reports `Illegal return statement` on a perfectly valid workflow. Validate the runtime dialect by wrapping the body the way the runtime does, then syntax-checking:
+
+```bash
+{ echo '(async()=>{'; \
+  sed 's/^[[:space:]]*export const meta/const meta/' workflows/<name>.mjs; \
+  echo '})()'; } | node --check -
+```
+
+The authoritative check is running it: `Workflow({ name: '<name>' })`.
+
+## Vendor-API caveat
+
+The Workflow **run model** is generally available on paid Claude Code plans (~v2.1.154+). The **script-authoring surface** — the injected globals `agent()` / `parallel()` / `pipeline()` / `phase()` / `log()` / `workflow()` and the `args` / `budget` objects — is an evolving vendor API. The conventions here reflect Claude Code **v2.1.x** behavior and are **subject to change**; they are documentation, never CI-enforced. Only Claude Code has the Workflow tool — other frameworks have no equivalent and skip workflows entirely.
+
+## Capability contract (relates to [#285](https://github.com/pjt222/agent-almanac/issues/285))
+
+A workflow spawns subagents via `agent(prompt, { agentType })`. A stage that **mutates artifacts** (Write/Edit/Bash, or `isolation: 'worktree'`) must target an **`implementing`** agent type; a read-only analysis stage targets an **`advisory`** type. This is the workflow analogue of #285's team-assignment rule, and the script expresses it natively by naming the spawn type per call. `review-changes` is entirely read-only, so every stage targets the advisory `Explore` type.

--- a/workflows/_template.mjs
+++ b/workflows/_template.mjs
@@ -116,7 +116,9 @@ const results = await pipeline(
     ).then((verdict) => ({ ...finding, verdict })),
 )
 
-// pipeline() drops a thrown item to null — filter before using the results.
+// pipeline() drops a thrown item to null, and agent() itself returns null if a
+// subagent is skipped or dies — filter() first, and gate on `verdict?.confirmed`
+// so an absent result never counts as a confirmation.
 const confirmed = results.filter(Boolean).filter((r) => r.verdict?.confirmed)
 
 log(`${confirmed.length}/${results.filter(Boolean).length} findings confirmed`)

--- a/workflows/_template.mjs
+++ b/workflows/_template.mjs
@@ -46,8 +46,9 @@ export const meta = {
   name: '_template',
   // One line, shown in the permission dialog when the workflow runs.
   description: 'Scaffold for a new agent-almanac workflow — copy, rename, replace',
-  // One entry per phase() call. Titles must match the phase() strings exactly
-  // and must all appear in the sidecar `phases:` list.
+  // One entry per phase the workflow uses — whether opened by a global phase()
+  // call or assigned via a stage's `phase:` option. Titles must match those
+  // strings exactly and all appear in the sidecar `phases:` list.
   phases: [
     { title: 'Scan', detail: 'fan out one reader per item' },
     { title: 'Verify', detail: 'independently confirm each finding' },

--- a/workflows/_template.mjs
+++ b/workflows/_template.mjs
@@ -1,0 +1,143 @@
+// ---
+// name: _template
+// description: Scaffold for a new agent-almanac workflow — copy, rename, replace
+// phases: Scan, Verify
+// ---
+//
+// ============================================================================
+// AGENT-ALMANAC WORKFLOW TEMPLATE
+// ----------------------------------------------------------------------------
+// A workflow is a self-contained orchestration script run by Claude Code's
+// Workflow tool. Its CONTROL FLOW (phases, fan-out, loops) is fixed in code and
+// rereadable; the OUTPUTS of its agent() calls are LLM subagents and remain
+// nondeterministic. Never describe a workflow as "deterministic" unqualified —
+// the control flow is deterministic, the agent() results are not.
+//
+// To author a new workflow:
+//   1. Copy this file to  workflows/<your-name>.mjs
+//   2. Rename in THREE places that must stay identical — the sidecar `name:`
+//      above, the meta.name literal below, and the filename stem. That triple
+//      equality is the Workflow({ name }) / "/<your-name>" discovery contract.
+//   3. Replace the meta block, phases, and body with your orchestration.
+//   4. Syntax-check it (see "Validating" at the bottom of this file).
+//
+// SIDECAR FRONTMATTER (the `// --- … ---` block at the very top) is the catalog
+// source of truth — the analogue of YAML frontmatter on the other four content
+// types. It mirrors the runtime `export const meta` literal so the existing
+// grep+count tooling can read the metadata without a JS parser. Keep the two in
+// agreement: same name, same description, and the sidecar `phases:` list ⊇ every
+// title passed to phase().
+//
+// HARD CONSTRAINTS (the runtime enforces these — violating them breaks the run):
+//   • Plain JavaScript only. NO TypeScript (no `: string[]`, interfaces, generics).
+//   • Date.now(), Math.random(), and argless `new Date()` are UNAVAILABLE — they
+//     would break workflow resume. Pass timestamps via `args`; vary randomness by
+//     agent index/label instead.
+//   • No filesystem or Node API. Standard JS built-ins (JSON, Math, Array) only.
+//   • The body runs inside an async wrapper — use top-level `await` and a
+//     top-level `return` directly (both are part of the Workflow dialect).
+//
+// INJECTED GLOBALS (no import needed): agent, parallel, pipeline, phase, log,
+// workflow, args, budget. Documented in guides/creating-workflows.md.
+// ============================================================================
+
+export const meta = {
+  // MUST equal the filename stem and the sidecar `name:` above.
+  name: '_template',
+  // One line, shown in the permission dialog when the workflow runs.
+  description: 'Scaffold for a new agent-almanac workflow — copy, rename, replace',
+  // One entry per phase() call. Titles must match the phase() strings exactly
+  // and must all appear in the sidecar `phases:` list.
+  phases: [
+    { title: 'Scan', detail: 'fan out one reader per item' },
+    { title: 'Verify', detail: 'independently confirm each finding' },
+  ],
+}
+
+// `args` is whatever the caller passed as Workflow({ args }); undefined if none.
+// Default it so the workflow is runnable with no input.
+const items =
+  Array.isArray(args?.items) && args.items.length ? args.items : ['example-a', 'example-b']
+
+// A JSON Schema turns agent() into structured output: the subagent is forced to
+// call StructuredOutput and agent() returns the validated object (no parsing).
+const FINDING_SCHEMA = {
+  type: 'object',
+  required: ['item', 'summary', 'confidence'],
+  properties: {
+    item: { type: 'string' },
+    summary: { type: 'string' },
+    confidence: { type: 'number' }, // 0..1
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['confirmed', 'reason'],
+  properties: {
+    confirmed: { type: 'boolean' },
+    reason: { type: 'string' },
+  },
+}
+
+// phase() opens a named progress group; later agent() calls fall under it.
+// INSIDE pipeline()/parallel() stages, prefer the per-call `phase:` option
+// (used below) to avoid races on the global phase() state.
+phase('Scan')
+
+// pipeline() is the DEFAULT multi-stage primitive: each item flows through every
+// stage independently with NO barrier between stages (item A can be in Verify
+// while item B is still in Scan). Wall-clock = slowest single chain, not the sum.
+// Reach for parallel() only when a stage genuinely needs ALL prior results at once.
+const results = await pipeline(
+  items,
+
+  // Stage 1 — Scan: one agent per item emits a schema-validated finding.
+  // This is read-only analysis, so it targets an ADVISORY agent type. A stage
+  // that MUTATES artifacts (Write/Edit/Bash, or isolation: 'worktree') must
+  // target an `implementing` agent type — the workflow analogue of the #285
+  // team-assignment rule (advisory vs implementing capability contract).
+  (item) =>
+    agent(`Examine "${item}" and report one finding.`, {
+      label: `scan:${item}`,
+      phase: 'Scan',
+      schema: FINDING_SCHEMA,
+      // agentType: 'Explore', // optional: name a specific advisory subagent type
+    }),
+
+  // Stage 2 — Verify: adversarially confirm stage 1's finding. Default to
+  // confirmed=false unless the verifier can independently reproduce the issue —
+  // this is what kills the false-positive flood in naive multi-agent review.
+  (finding, item) =>
+    agent(
+      `Independently verify this finding about "${item}": ${finding?.summary}. ` +
+        `Default to confirmed=false unless you can reproduce it.`,
+      { label: `verify:${item}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+    ).then((verdict) => ({ ...finding, verdict })),
+)
+
+// pipeline() drops a thrown item to null — filter before using the results.
+const confirmed = results.filter(Boolean).filter((r) => r.verdict?.confirmed)
+
+log(`${confirmed.length}/${results.filter(Boolean).length} findings confirmed`)
+
+// A workflow's return value is handed back to the caller of Workflow().
+return { confirmed, total: results.filter(Boolean).length }
+
+// ============================================================================
+// Validating
+// ----------------------------------------------------------------------------
+// Workflow scripts use a top-level `return`, which is valid in the Workflow
+// runtime (the body is wrapped in an async function) but ILLEGAL in a raw ES
+// module — so plain `node --check workflows/<name>.mjs` reports "Illegal return
+// statement" on a perfectly valid workflow. Validate the runtime dialect by
+// wrapping the body the way the runtime does, then syntax-checking:
+//
+//   { echo '(async()=>{'; \
+//     sed 's/^[[:space:]]*export const meta/const meta/' workflows/<name>.mjs; \
+//     echo '})()'; } | node --check -
+//
+// The authoritative check is running it: Workflow({ name: '<name>' }). The
+// authoring globals above are an evolving vendor surface (observed in Claude
+// Code v2.1.x, subject to change) — never CI-enforced.
+// ============================================================================

--- a/workflows/_template.mjs
+++ b/workflows/_template.mjs
@@ -101,8 +101,8 @@ const results = await pipeline(
     agent(`Examine "${item}" and report one finding.`, {
       label: `scan:${item}`,
       phase: 'Scan',
+      agentType: 'Explore', // advisory: Read/Grep/Glob/Bash, no Write/Edit — honors the contract above
       schema: FINDING_SCHEMA,
-      // agentType: 'Explore', // optional: name a specific advisory subagent type
     }),
 
   // Stage 2 — Verify: adversarially confirm stage 1's finding. Default to
@@ -112,7 +112,7 @@ const results = await pipeline(
     agent(
       `Independently verify this finding about "${item}": ${finding?.summary}. ` +
         `Default to confirmed=false unless you can reproduce it.`,
-      { label: `verify:${item}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+      { label: `verify:${item}`, phase: 'Verify', agentType: 'Explore', schema: VERDICT_SCHEMA },
     ).then((verdict) => ({ ...finding, verdict })),
 )
 

--- a/workflows/review-changes.mjs
+++ b/workflows/review-changes.mjs
@@ -1,0 +1,174 @@
+// ---
+// name: review-changes
+// description: Classify → adversarially verify → synthesize a code review over changed files
+// phases: Classify, Verify, Synthesize
+// ---
+//
+// review-changes — the flagship seed workflow.
+//
+// It captures a review spine that a *team* cannot express structurally: a
+// staged, per-item fan-out where every candidate finding must survive an
+// independent adversarial verification before it reaches the report. The
+// classify→refute→synthesize logic lives in this script's control flow, not in
+// a lead agent's turn-by-turn judgment — that is what makes it a workflow.
+//
+// It pairs with the review-codebase / review-pull-request *skills*: a skill says
+// how one reviewer works; this workflow deterministically coordinates many.
+//
+// Capability contract (#285): every stage here is read-only analysis, so each
+// agent() targets an ADVISORY agent type (Explore — Read/Grep/Glob/Bash, no
+// Write/Edit). If a future stage were to write a patch, it would have to target
+// an `implementing` agent type instead. The script names the spawn type per
+// call — the cleanest expression of the agent-persona vs subagent_type decoupling.
+//
+// Invoke:  Workflow({ name: 'review-changes' })            // diff vs HEAD
+//          Workflow({ name: 'review-changes', args: { files: ['a.js','b.R'] } })
+//          /review-changes                                  // slash command
+//
+// Validating this file: see workflows/_template.mjs — top-level `return` is valid
+// Workflow dialect but illegal raw ESM, so use the wrap-then-`node --check` recipe.
+
+export const meta = {
+  name: 'review-changes',
+  description: 'Classify → adversarially verify → synthesize a code review over changed files',
+  phases: [
+    { title: 'Classify', detail: 'one advisory agent per changed file emits candidate findings' },
+    { title: 'Verify', detail: 'parallel adversarial refuters per finding; default refuted' },
+    { title: 'Synthesize', detail: 'consolidate only surviving findings into a severity report' },
+  ],
+}
+
+// Adversarial verifiers per candidate finding. A finding is killed when a
+// majority of refuters can independently refute it — the false-positive filter.
+const REFUTERS = 3
+const KILL_THRESHOLD = Math.ceil(REFUTERS / 2) // >= this many "refuted" votes kills it
+
+const FILES_SCHEMA = {
+  type: 'object',
+  required: ['files'],
+  properties: { files: { type: 'array', items: { type: 'string' } } },
+}
+
+const CANDIDATES_SCHEMA = {
+  type: 'object',
+  required: ['file', 'findings'],
+  properties: {
+    file: { type: 'string' },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'severity', 'mechanism', 'evidence'],
+        properties: {
+          title: { type: 'string' },
+          severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low', 'info'] },
+          mechanism: { type: 'string' }, // how the bug triggers
+          evidence: { type: 'string' }, // file:line or quoted code
+        },
+      },
+    },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['refuted', 'reason'],
+  properties: {
+    refuted: { type: 'boolean' }, // true = could NOT confirm the finding (default)
+    reason: { type: 'string' },
+  },
+}
+
+const REPORT_SCHEMA = {
+  type: 'object',
+  required: ['report'],
+  properties: {
+    report: { type: 'string' }, // markdown, grouped by severity
+    bySeverity: { type: 'object' },
+  },
+}
+
+phase('Classify')
+
+// 1. Resolve the changed-file list. args.files wins; otherwise one read-only
+//    agent derives it from the working tree (the script itself has no shell).
+let files = Array.isArray(args?.files) && args.files.length ? args.files : null
+if (!files) {
+  const disc = await agent(
+    'Run `git diff --name-only HEAD` (fall back to `git diff --name-only` if HEAD is unborn) ' +
+      'and return the changed, non-deleted file paths. Read-only — do not modify anything.',
+    { label: 'discover-files', phase: 'Classify', agentType: 'Explore', schema: FILES_SCHEMA },
+  )
+  files = (disc?.files ?? []).filter(Boolean)
+}
+
+if (!files.length) {
+  log('No changed files to review.')
+  return { findings: [], reviewed: 0, report: 'No changed files to review.' }
+}
+log(`Reviewing ${files.length} changed file(s)`)
+
+// 2-3. Pipeline, NO barrier between stages: file A can be in Verify while file B
+//      is still in Classify. Synthesis (below) is the one genuine barrier.
+const perFile = await pipeline(
+  files,
+
+  // Classify — one advisory agent per file proposes candidate findings.
+  (file) =>
+    agent(
+      `Review the changed file "${file}". Read it and its diff (\`git diff -- ${file}\`). ` +
+        `Report concrete candidate findings (bugs, security issues, correctness risks) with ` +
+        `a precise mechanism and file:line evidence. Do not modify anything.`,
+      { label: `classify:${file}`, phase: 'Classify', agentType: 'Explore', schema: CANDIDATES_SCHEMA },
+    ),
+
+  // Verify — each candidate faces a parallel() fan-out of adversarial refuters
+  // that DEFAULT to refuted=true unless they can independently reproduce it.
+  (cand, file) =>
+    parallel(
+      (cand?.findings ?? []).map((f) => () =>
+        parallel(
+          Array.from({ length: REFUTERS }, (_unused, i) => () =>
+            agent(
+              `Adversarially verify this finding in "${file}" (refuter ${i + 1}/${REFUTERS}): ` +
+                `${f.title} — ${f.mechanism}. Evidence cited: ${f.evidence}. ` +
+                `Read the file yourself. Set refuted=true UNLESS you can independently ` +
+                `reproduce or confirm the issue; when in doubt, refuted=true.`,
+              { label: `refute:${file}#${i}`, phase: 'Verify', agentType: 'Explore', schema: VERDICT_SCHEMA },
+            ),
+          ),
+        ).then((votes) => {
+          const refutedVotes = votes.filter(Boolean).filter((v) => v.refuted).length
+          return { ...f, file, survived: refutedVotes < KILL_THRESHOLD, refutedVotes }
+        }),
+      ),
+    ),
+)
+
+// One barrier: synthesis needs ALL survivors together.
+const surviving = perFile
+  .filter(Boolean)
+  .flat()
+  .filter(Boolean)
+  .filter((x) => x.survived)
+
+log(`${surviving.length} finding(s) survived adversarial verification`)
+
+if (!surviving.length) {
+  return { findings: [], reviewed: files.length, report: 'No findings survived adversarial verification.' }
+}
+
+phase('Synthesize')
+const synth = await agent(
+  `Consolidate these verified review findings into a single markdown report grouped by ` +
+    `severity (critical → info). Keep each entry's file:line evidence and mechanism. ` +
+    `Findings JSON:\n${JSON.stringify(surviving, null, 2)}`,
+  { label: 'synthesize', phase: 'Synthesize', schema: REPORT_SCHEMA },
+)
+
+return {
+  findings: surviving,
+  reviewed: files.length,
+  report: synth?.report ?? '',
+  bySeverity: synth?.bySeverity ?? {},
+}

--- a/workflows/review-changes.mjs
+++ b/workflows/review-changes.mjs
@@ -117,8 +117,10 @@ const perFile = await pipeline(
   (file) =>
     agent(
       `Review the changed file "${file}". Read it and its diff (\`git diff -- ${file}\`). ` +
-        `Report concrete candidate findings (bugs, security issues, correctness risks) with ` +
-        `a precise mechanism and file:line evidence. Do not modify anything.`,
+        `Report concrete candidate findings (bugs, security issues, correctness risks). ` +
+        `Return file="${file}"; for each finding give a title, a severity ` +
+        `(critical|high|medium|low|info), the triggering mechanism, and file:line evidence. ` +
+        `Do not modify anything.`,
       { label: `classify:${file}`, phase: 'Classify', agentType: 'Explore', schema: CANDIDATES_SCHEMA },
     ),
 
@@ -133,7 +135,8 @@ const perFile = await pipeline(
               `Adversarially verify this finding in "${file}" (refuter ${i + 1}/${REFUTERS}): ` +
                 `${f.title} — ${f.mechanism}. Evidence cited: ${f.evidence}. ` +
                 `Read the file yourself. Set refuted=true UNLESS you can independently ` +
-                `reproduce or confirm the issue; when in doubt, refuted=true.`,
+                `reproduce or confirm the issue; when in doubt, refuted=true. ` +
+                `Always include a brief reason for the verdict.`,
               { label: `refute:${file}#${i}`, phase: 'Verify', agentType: 'Explore', schema: VERDICT_SCHEMA },
             ),
           ),
@@ -163,7 +166,7 @@ const synth = await agent(
   `Consolidate these verified review findings into a single markdown report grouped by ` +
     `severity (critical → info). Keep each entry's file:line evidence and mechanism. ` +
     `Findings JSON:\n${JSON.stringify(surviving, null, 2)}`,
-  { label: 'synthesize', phase: 'Synthesize', schema: REPORT_SCHEMA },
+  { label: 'synthesize', phase: 'Synthesize', agentType: 'Explore', schema: REPORT_SCHEMA },
 )
 
 return {

--- a/workflows/review-changes.mjs
+++ b/workflows/review-changes.mjs
@@ -13,7 +13,7 @@
 // a lead agent's turn-by-turn judgment — that is what makes it a workflow.
 //
 // It pairs with the review-codebase / review-pull-request *skills*: a skill says
-// how one reviewer works; this workflow deterministically coordinates many.
+// how one reviewer works; this workflow coordinates many with deterministic control flow.
 //
 // Capability contract (#285): every stage here is read-only analysis, so each
 // agent() targets an ADVISORY agent type (Explore — Read/Grep/Glob/Bash, no

--- a/workflows/review-changes.mjs
+++ b/workflows/review-changes.mjs
@@ -38,10 +38,12 @@ export const meta = {
   ],
 }
 
-// Adversarial verifiers per candidate finding. A finding is killed when a
-// majority of refuters can independently refute it — the false-positive filter.
+// Adversarial verifiers per candidate finding. A finding SURVIVES only when a
+// majority of refuters independently CONFIRM it (refuted === false). Default-refuted
+// votes — and null/dead refuters — do NOT count as confirmation, so a finding dies on
+// absent or minority evidence. That burden-of-proof gate is the false-positive filter.
 const REFUTERS = 3
-const KILL_THRESHOLD = Math.ceil(REFUTERS / 2) // >= this many "refuted" votes kills it
+const CONFIRM_QUORUM = Math.floor(REFUTERS / 2) + 1 // strict majority for any REFUTERS; >= this many confirms to survive
 
 const FILES_SCHEMA = {
   type: 'object',
@@ -134,15 +136,19 @@ const perFile = await pipeline(
             agent(
               `Adversarially verify this finding in "${file}" (refuter ${i + 1}/${REFUTERS}): ` +
                 `${f.title} — ${f.mechanism}. Evidence cited: ${f.evidence}. ` +
-                `Read the file yourself. Set refuted=true UNLESS you can independently ` +
+                `Read the file yourself and, if needed, run \`git diff -- ${file}\` to see what changed. ` +
+                `Set refuted=true UNLESS you can independently ` +
                 `reproduce or confirm the issue; when in doubt, refuted=true. ` +
                 `Always include a brief reason for the verdict.`,
               { label: `refute:${file}#${i}`, phase: 'Verify', agentType: 'Explore', schema: VERDICT_SCHEMA },
             ),
           ),
         ).then((votes) => {
+          // Gate on affirmative confirmations, not refutations: a null/dead refuter
+          // must not let a finding survive on absent evidence (default-refuted intent).
+          const confirmedVotes = votes.filter((v) => v && v.refuted === false).length
           const refutedVotes = votes.filter(Boolean).filter((v) => v.refuted).length
-          return { ...f, file, survived: refutedVotes < KILL_THRESHOLD, refutedVotes }
+          return { ...f, file, survived: confirmedVotes >= CONFIRM_QUORUM, confirmedVotes, refutedVotes }
         }),
       ),
     ),


### PR DESCRIPTION
Ships **Phase 1** of the Five Pillars initiative (#288): `workflows` as a first-class fifth content type — code-driven orchestration scripts run by Claude Code's Workflow tool — at near-zero ongoing cost. The heavy catalog machinery (registry, CLI, validation CI) stays **deferred** behind the #288 promotion gate.

Closes #290 · Closes #291 · Closes #292 · part of #288 · #289 already satisfied (labels exist)

## What landed

| Issue | Deliverable |
|---|---|
| **#289** | `workflows` + `new-workflow` labels — already created at filing |
| **#290** | `workflows/` dir + `_template.mjs` (sidecar frontmatter convention, pure-literal `meta`, `phase()` + `pipeline()` + `agent({ schema })`) |
| **#292** | `review-changes.mjs` seed (classify → adversarial-verify → synthesize, nested `parallel()` refuters defaulting to refuted) + `workflows/README.md` |
| **#291** | `creating-workflows.md` guide + Four→Five Pillars in `understanding-the-system.md` + one-line cross-refs + registry entry |

## The pillar boundary

A **team** is a declarative roster the lead coordinates at runtime (`TeamCreate`). A **workflow** is a script whose *control flow* — phases, fan-out, verification — is fixed in JS. The control flow is deterministic and rereadable; the `agent()` **outputs** are LLM subagents and remain non-deterministic. Every doc states this explicitly — no bare "deterministic."

## Empirical finding: the AC's `node --check` gate was wrong

The issues specified `node --check` as the syntax gate, but idiomatic workflows use a top-level `return` (per the official Workflow API), which is **illegal in raw ESM** — `node --check` rejects valid workflows with `Illegal return statement`. I probed the **live Workflow runtime** with a tiny no-agent workflow: it accepts top-level `return` and surfaced the value. So I author idiomatic workflows and validate them the dialect-accurate way (wrap the body as the runtime does, then `node --check`), documented in both `.mjs` files and the guide:

```bash
{ echo '(async()=>{'; sed 's/^[[:space:]]*export const meta/const meta/' workflows/<name>.mjs; echo '})()'; } | node --check -
```

## Verification (adversarial)

- **AC-verify workflow** — 4 independent `Explore` verifiers, defaulting to "unmet unless proven," checked every AC for #290/#291/#292 plus a cross-cutting consistency lens against the files on disk: **0 fail, 0 unmet AC**.
- **Dogfood** — ran the actual `review-changes` seed (39 agents, full classify→refute→synthesize spine) over the changed files; it produced a severity-grouped report and found **zero issues in any new file** (`_template.mjs`, `review-changes.mjs`, `workflows/README.md`, `creating-workflows.md`).
- Local gates: `validate:integrity` PASSED, `check-readmes` up to date, content-style clean.

## In-scope cleanup

The dogfood flagged stale skills/agents/teams counts in `understanding-the-system.md` (the canonical doc this PR rewrites) — refreshed to current (355/72/17/29).

## Pre-existing drift flagged for follow-up (not fixed here)

The dogfood also surfaced count drift **outside** this feature's scope, in files this PR doesn't substantively edit:
- `README.md` Directory Map (`352 skills`, `27 guides`) and Plugin Packaging (`350 skills`) — hand-maintained numbers **outside** the `AUTO:` markers, so `update-readmes` never corrects them. Candidate for bringing under generation.
- `production-coordination-patterns.md` frontmatter lists 5 of 6 patterns (omits "escalation cascades").

Worth a small `docs(maintenance)` follow-up issue.

## Out of scope (deferred, tracked)

Phase 2 — #293 (CLI install into `.claude/workflows/`) and #294 (`workflows/_registry.yml` + validation + `create-workflow` meta-skill) — remain untouched behind the #288 gate (~8–10 workflows **and** a real install request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
