### PR TITLE
chore(readmes): generate Directory Map + plugin counts from registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ claude plugin marketplace add ~/.claude-marketplace
 claude plugin install agent-almanac@local
 ```
 
-Auto-discovers all 352 skills and 72 agents. Teams require activation via [TeamCreate](guides/creating-agents-and-teams.md). Windows / macOS variants in the [Installation guide](guides/installation.md#phase-1--plugin-install-claude-code-native).
+<!-- AUTO:START:plugin-discovery -->
+Auto-discovers all 355 skills and 72 agents. Teams require activation via [TeamCreate](guides/creating-agents-and-teams.md). Windows / macOS variants in the [Installation guide](guides/installation.md#phase-1--plugin-install-claude-code-native).
+<!-- AUTO:END:plugin-discovery -->
 
 ### Path 3 — Global CLI (cross-framework)
 
@@ -113,20 +115,22 @@ Requires R 4.5.x or Docker; per-OS R paths in the [Installation guide](guides/in
 
 ## Directory Map
 
+<!-- AUTO:START:dirmap -->
 ```
 agent-almanac/
   .claude-plugin/  Plugin manifest for Claude Code plugin installation
-  skills/          352 executable procedures across 64 domains
-  agents/           72 specialist personas
-  teams/            17 multi-agent compositions with 8 coordination patterns
-  guides/           27 human-readable reference docs
-  viz/              Interactive force-graph explorer with R-generated icons
-  tests/            30 test scenarios for validation
-  i18n/             Translations (10 locales: de, zh-CN, ja, es, caveman, caveman-lite, caveman-ultra, wenyan, wenyan-lite, wenyan-ultra)
-  cli/              Universal installer CLI (npm install -g agent-almanac)
-  scripts/          Build and CI automation
-  sessions/         Tending session archives
+  skills/          355 executable procedures across 64 domains
+  agents/          72 specialist personas
+  teams/           17 multi-agent compositions with 8 coordination patterns
+  guides/          28 human-readable reference docs
+  viz/             Interactive force-graph explorer with R-generated icons
+  tests/           30 test scenarios for validation
+  i18n/            Translations (10 locales: de, zh-CN, ja, es, caveman-lite, caveman, caveman-ultra, wenyan-lite, wenyan, wenyan-ultra)
+  cli/             Universal installer CLI (npm install -g agent-almanac)
+  scripts/         Build and CI automation
+  sessions/        Tending session archives
 ```
+<!-- AUTO:END:dirmap -->
 
 ## Guides
 
@@ -196,11 +200,13 @@ See [i18n/README.md](i18n/README.md) for the translation contributor guide.
 
 Agent-almanac is packaged as a Claude Code plugin at `.claude-plugin/plugin.json`. When installed, Claude Code auto-discovers all skills and agents:
 
+<!-- AUTO:START:plugin-table -->
 | Component | Discovery | Count |
 |-----------|-----------|-------|
-| Skills | `skills/*/SKILL.md` | 350 |
+| Skills | `skills/*/SKILL.md` | 355 |
 | Agents | `agents/*.md` | 72 |
 | Teams | Bundled but not auto-discovered | 17 |
+<!-- AUTO:END:plugin-table -->
 
 Teams are not a plugin-native content type — they require activation via `TeamCreate` (see [Creating Agents and Teams](guides/creating-agents-and-teams.md)).
 

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -54,6 +54,15 @@ const totalTeams = teamsRegistry.total_teams || 0;
 const totalGuides = guidesRegistry.total_guides || 0;
 const totalTests = testsRegistry.total_tests || 0;
 const totalDomains = Object.keys(domains).length;
+const totalCoordinationPatterns = new Set(
+  teams.map((t) => t.coordination).filter(Boolean)
+).size;
+const i18nConfigPath = resolve(ROOT, 'i18n/_config.yml');
+const supportedLocales = existsSync(i18nConfigPath)
+  ? yaml.load(readFileSync(i18nConfigPath, 'utf8')).supported_locales || []
+  : [];
+const localeCodes = supportedLocales.map((l) => l.code);
+const totalLocales = localeCodes.length;
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -130,6 +139,41 @@ function generateStats() {
     `- **Interactive visualization** — force-graph explorer with ${totalSkills} R-generated skill icons and 9 color themes`,
   ];
   return lines.join('\n');
+}
+
+// Directory Map tree (root README) — every count derived from registries.
+function generateDirMap() {
+  const rows = [
+    ['.claude-plugin/', 'Plugin manifest for Claude Code plugin installation'],
+    ['skills/', `${totalSkills} executable procedures across ${totalDomains} domains`],
+    ['agents/', `${totalAgents} specialist personas`],
+    ['teams/', `${totalTeams} multi-agent compositions with ${totalCoordinationPatterns} coordination patterns`],
+    ['guides/', `${totalGuides} human-readable reference docs`],
+    ['viz/', 'Interactive force-graph explorer with R-generated icons'],
+    ['tests/', `${totalTests} test scenarios for validation`],
+    ['i18n/', `Translations (${totalLocales} locales: ${localeCodes.join(', ')})`],
+    ['cli/', 'Universal installer CLI (npm install -g agent-almanac)'],
+    ['scripts/', 'Build and CI automation'],
+    ['sessions/', 'Tending session archives'],
+  ];
+  const body = rows.map(([p, d]) => `  ${p.padEnd(15)}  ${d}`).join('\n');
+  return ['```', 'agent-almanac/', body, '```'].join('\n');
+}
+
+// Plugin install discovery sentence (root README).
+function generatePluginDiscovery() {
+  return `Auto-discovers all ${totalSkills} skills and ${totalAgents} agents. Teams require activation via [TeamCreate](guides/creating-agents-and-teams.md). Windows / macOS variants in the [Installation guide](guides/installation.md#phase-1--plugin-install-claude-code-native).`;
+}
+
+// Plugin Packaging discovery table (root README).
+function generatePluginTable() {
+  return [
+    '| Component | Discovery | Count |',
+    '|-----------|-----------|-------|',
+    `| Skills | \`skills/*/SKILL.md\` | ${totalSkills} |`,
+    `| Agents | \`agents/*.md\` | ${totalAgents} |`,
+    `| Teams | Bundled but not auto-discovered | ${totalTeams} |`,
+  ].join('\n');
 }
 
 function generateSkillsIntro(linkPrefix) {
@@ -562,6 +606,9 @@ run(
   'README.md',
   processFile(resolve(ROOT, 'README.md'), {
     stats: generateStats,
+    'plugin-discovery': generatePluginDiscovery,
+    dirmap: generateDirMap,
+    'plugin-table': generatePluginTable,
     guides: generateGuidesSection,
     translations: generateTranslationsSection,
   })


### PR DESCRIPTION
## Problem

`scripts/generate-readmes.js` keeps the `AUTO:`-marked sections of `README.md` in sync with the registries, but three count-bearing blocks lived **outside** any marker and were hand-maintained — so they silently drifted:

- Quick Start plugin-discovery sentence — `352 skills` (actual 355)
- Directory Map — `352 skills`, `27 guides` (actual 355 / 28)
- Plugin Packaging table — `350 skills` (actual 355)

(Surfaced by dogfooding the new `review-changes` workflow over a diff in #297.)

## Fix

Wrap all three blocks in `AUTO:START`/`AUTO:END` markers and add generators that derive every number from source:

| Number | Source |
|---|---|
| skills / agents / teams / guides / tests | the five `_registry.yml` totals |
| domains | `skills/_registry.yml` domain keys |
| coordination patterns | distinct `coordination:` values in `teams/_registry.yml` |
| locales + codes | `i18n/_config.yml` `supported_locales` |

No count in these blocks is typed by hand anymore. They refresh on every `npm run update-readmes` and through the existing update-readmes CI auto-commit — the same mechanism already trusted for the stats/guides/translations sections.

## Verification

- `npm run update-readmes` → corrects 352→355, 350→355, 27→28; `sessions/` and all static descriptions preserved.
- `npm run check-readmes` → idempotent, "All files are up to date."
- Diff is 2 files: the generator + the (now generated) README blocks.

## Notes / follow-up

A few hand-maintained numbers remain out of scope here and could be folded in later: `viz/README.md` "5 locales" (viz UI chrome, a different locale set from content i18n) and the pattern list in `production-coordination-patterns.md` frontmatter (prose, not a count block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
