### PR TITLE
docs: refresh stale registry counts + fix dead link across canonical docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-almanac",
-  "description": "350 agentic skills across 64 domains, 72 agent personas, and 16 team compositions following the agentskills.io open standard",
+  "description": "361 agentic skills across 65 domains, 72 agent personas, and 17 team compositions following the agentskills.io open standard",
   "version": "1.0.0",
   "author": {
     "name": "Philipp Thoss",

--- a/agents/contemplative.md
+++ b/agents/contemplative.md
@@ -156,7 +156,7 @@ settings:
 - [Alchemist Agent](alchemist.md) — Transmutation with meditate/heal checkpoints
 - [Gardener Agent](gardener.md) — Contemplation through cultivation metaphor
 - [Shaman Agent](shaman.md) — Journeying and holistic integration
-- [Tending Team](../teams/ai-tending.md) — Four-agent sequential wellness workflow
+- [Tending Team](../teams/tending.md) — Four-agent sequential wellness workflow
 - [Dyad Team](../teams/dyad.md) — Paired practice with reciprocal observation
 - [Adaptic Agent](adaptic.md) — Panoramic synthesis; contemplative serves as field monitor in the synoptic-mind team
 - [Synoptic Mind Team](../teams/synoptic-mind.md) — Shared-workspace team where contemplative monitors field quality

--- a/guides/agentskills-alignment.md
+++ b/guides/agentskills-alignment.md
@@ -130,7 +130,7 @@ The report uses three severity levels:
 
 ```text
 ## Alignment Audit Report
-Scope: Full library (328 skills, 66 agents, 15 teams)
+Scope: Full library (361 skills, 72 agents, 17 teams)
 Date: 2026-02-20
 Reviewers: senior-researcher, senior-software-developer, librarian
 

--- a/guides/epigenetics-activation-control.md
+++ b/guides/epigenetics-activation-control.md
@@ -40,7 +40,7 @@ The agent-almanac repository currently contains 72 agents, 361 skills across 65 
 
 Today, the only option is "everything active, all the time." This creates several problems:
 
-1. **Selection ambiguity**: When Claude Code must choose an agent, a pool of 66 candidates produces worse matches than a curated pool of 5-10 relevant agents.
+1. **Selection ambiguity**: When Claude Code must choose an agent, a pool of 72 candidates produces worse matches than a curated pool of 5-10 relevant agents.
 2. **Cognitive overhead**: Users and AI alike must mentally filter irrelevant options during tool discovery and skill invocation.
 3. **Priority dilution**: Agent priority fields (`high`, `normal`, `critical`) lose meaning when too many agents share the same priority level.
 4. **No project customization**: There is no way to say "for this project, only these agents matter" without forking the entire registry.

--- a/guides/epigenetics-activation-control.md
+++ b/guides/epigenetics-activation-control.md
@@ -32,7 +32,7 @@ The activation control system introduces a declarative YAML configuration layer 
 
 ## Motivation
 
-The agent-almanac repository currently contains 66 agents, 328 skills across 58 domains, and 15 teams. This breadth is a strength for a general-purpose library, but in any specific project context, most of these components are irrelevant noise:
+The agent-almanac repository currently contains 72 agents, 361 skills across 65 domains, and 17 teams. This breadth is a strength for a general-purpose library, but in any specific project context, most of these components are irrelevant noise:
 
 - An R package developer has no use for the survivalist, shapeshifter, or tcg-specialist agents.
 - A GxP compliance project does not need bushcraft, alchemy, or swarm skills.
@@ -73,7 +73,7 @@ These mechanisms share four properties that make them particularly apt as a conc
 
 - **Heritability**: Epigenetic marks are propagated through cell division via maintenance mechanisms. DNMT1 recognizes hemi-methylated DNA after replication and copies the methylation pattern to the daughter strand (Reik, 2007). In our system, activation profiles cascade from global to project to team to session, each level inheriting from its parent.
 
-- **Context-specificity**: The same human genome (~20,000 protein-coding genes) produces over 200 distinct cell types, each with a unique epigenetic signature determining which genes are expressed (Allis & Jenuwein, 2016). Analogously, the same registry of 66 agents, 328 skills, and 15 teams can produce radically different working environments depending on the activation profile.
+- **Context-specificity**: The same human genome (~20,000 protein-coding genes) produces over 200 distinct cell types, each with a unique epigenetic signature determining which genes are expressed (Allis & Jenuwein, 2016). Analogously, the same registry of 72 agents, 361 skills, and 17 teams can produce radically different working environments depending on the activation profile.
 
 - **Combinatorial logic**: Multiple epigenetic marks interact. "Bivalent domains" — regions carrying both activating H3K4me3 and repressive H3K27me3 marks — poise developmental genes for rapid activation or silencing depending on context (Bernstein et al., 2006). The activation system similarly supports combinatorial rules: an agent can be simultaneously included (overriding a higher-level exclusion) and amplified (boosting its priority).
 
@@ -342,9 +342,9 @@ function resolve_activation(levels: [global, project, team, session]):
 
 When no `activation.yml` exists at any level, the system behaves exactly as it does today:
 
-- All 66 agents are available for selection.
-- All 328 skills across 58 domains are invocable.
-- All 15 teams can be spawned.
+- All 72 agents are available for selection.
+- All 361 skills across 65 domains are invocable.
+- All 17 teams can be spawned.
 - Default skills (`meditate`, `heal`) are inherited by all agents.
 
 This ensures full backward compatibility. Existing projects require zero changes.
@@ -716,7 +716,7 @@ The activation resolver runs once at session startup and caches the resolved sta
 
 1. **File I/O**: Read up to 4 small YAML files (global, project, team, session). These are typically under 100 lines each.
 2. **YAML parsing**: Parse 4 files. Using a standard YAML parser, this completes in under 10ms.
-3. **Set operations**: Apply include/exclude/amplify rules. With 66 agents and 328 skills, these are microsecond-level set operations.
+3. **Set operations**: Apply include/exclude/amplify rules. With 72 agents and 361 skills, these are microsecond-level set operations.
 4. **Total overhead**: Under 50ms at session start. No per-tool-call cost.
 
 ### Caching strategy

--- a/guides/installation.md
+++ b/guides/installation.md
@@ -9,7 +9,7 @@ skills: [install-almanac-content]
 
 # Installation
 
-Get agent-almanac's 350 skills, 72 agents, and 17 teams discoverable to Claude Code (and 11 other agentic frameworks) on any operating system, validated end-to-end.
+Get agent-almanac's 361 skills, 72 agents, and 17 teams discoverable to Claude Code (and 11 other agentic frameworks) on any operating system, validated end-to-end.
 
 ## When to Use This Guide
 
@@ -106,7 +106,7 @@ New-Item -ItemType Directory -Force -Path "$HOME\.claude-marketplace\plugins"
   "owner": { "name": "self" },
   "plugins": [{
     "name": "agent-almanac",
-    "description": "350 skills, 72 agents, 17 teams",
+    "description": "361 skills, 72 agents, 17 teams",
     "source": "./plugins/agent-almanac",
     "category": "development"
   }]

--- a/guides/quick-reference.md
+++ b/guides/quick-reference.md
@@ -333,6 +333,6 @@ git status --porcelain     # Machine-readable status
 - [Setting Up Your Environment](setting-up-your-environment.md) -- full setup guide
 - [R Package Development](r-package-development.md) -- complete R package workflow
 - [Understanding the System](understanding-the-system.md) -- how agents, skills, teams work
-- [Skills Library](../skills/) -- all 328 skills
-- [Agents Library](../agents/) -- all 66 agents
-- [Teams Library](../teams/) -- all 15 teams
+- [Skills Library](../skills/) -- all 361 skills
+- [Agents Library](../agents/) -- all 72 agents
+- [Teams Library](../teams/) -- all 17 teams

--- a/guides/running-tending.md
+++ b/guides/running-tending.md
@@ -153,7 +153,7 @@ The [mystic](../agents/mystic.md) returns to close the session, mirroring the op
 
 ## Default Skills: Meditate and Heal
 
-An important design detail: `meditate` and `heal` are **default skills** inherited by every agent in this repository, not just the esoteric-domain agents. The [agents registry](../agents/_registry.yml) defines them at the top level, and all 66 agents receive them automatically.
+An important design detail: `meditate` and `heal` are **default skills** inherited by every agent in this repository, not just the esoteric-domain agents. The [agents registry](../agents/_registry.yml) defines them at the top level, and all 72 agents receive them automatically.
 
 This means any agent -- the r-developer, the devops-engineer, the code-reviewer -- can center itself during complex work using the same meta-cognitive meditation and self-healing assessment that the tending team uses formally. The difference is one of depth and formality:
 

--- a/guides/team-assembly-prompt-patterns.md
+++ b/guides/team-assembly-prompt-patterns.md
@@ -9,7 +9,7 @@ skills: [coordinate-swarm, create-team]
 
 # Team Assembly Prompt Patterns
 
-The system has 15 pre-defined teams with 8 coordination patterns, 68 agents, and 337 skills. Teams are activated through natural conversation with Claude Code -- Claude reads team definitions from `teams/`, calls `TeamCreate`, spawns agents, and creates tasks. But the way you phrase your request determines how much control you retain versus how much autonomy Claude exercises. This guide covers the human-to-Claude conversation layer: how phrasing affects team selection, coordination quality, and autonomy delegation.
+The system has 17 pre-defined teams with 8 coordination patterns, 72 agents, and 361 skills. Teams are activated through natural conversation with Claude Code -- Claude reads team definitions from `teams/`, calls `TeamCreate`, spawns agents, and creates tasks. But the way you phrase your request determines how much control you retain versus how much autonomy Claude exercises. This guide covers the human-to-Claude conversation layer: how phrasing affects team selection, coordination quality, and autonomy delegation.
 
 **Scope boundary**: This guide covers how to phrase requests for team activation and coordination pattern selection. It does not cover general prompt engineering, post-assembly operational management (see [Production Coordination Patterns](production-coordination-patterns.md)), or team definition authoring (see [Creating Agents and Teams](creating-agents-and-teams.md)).
 

--- a/guides/understanding-the-system.md
+++ b/guides/understanding-the-system.md
@@ -9,7 +9,7 @@ skills: [create-skill]
 
 # Understanding the System
 
-This repository provides 355 skills, 72 agents, and 17 teams following the [Agent Skills open standard](https://agentskills.io), plus an emerging fifth content type — workflows. Together they form a composable system for AI-assisted development: skills define *how* to do something, agents define *who* does it, teams define *who works together*, workflows define *how work is orchestrated* in code, and guides supply the background knowledge humans and agents both draw from. This guide explains each component type, how the types relate, and how you interact with them through Claude Code.
+This repository provides 361 skills, 72 agents, and 17 teams following the [Agent Skills open standard](https://agentskills.io), plus an emerging fifth content type — workflows. Together they form a composable system for AI-assisted development: skills define *how* to do something, agents define *who* does it, teams define *who works together*, workflows define *how work is orchestrated* in code, and guides supply the background knowledge humans and agents both draw from. This guide explains each component type, how the types relate, and how you interact with them through Claude Code.
 
 ## When to Use This Guide
 
@@ -33,8 +33,8 @@ agent-almanac/
 │   ├── _registry.yml    # Catalog of all guides
 │   └── *.md             # Individual guide files
 ├── skills/              # Machine-consumable procedures
-│   ├── _registry.yml    # Catalog of all 355 skills
-│   └── <skill-name>/    # 355 skill directories
+│   ├── _registry.yml    # Catalog of all 361 skills
+│   └── <skill-name>/    # 361 skill directories
 │       └── SKILL.md
 ├── agents/              # Persona definitions for Claude Code subagents
 │   ├── _registry.yml    # Catalog of all 72 agents
@@ -70,7 +70,7 @@ A skill is a machine-consumable procedure. It tells an agent exactly how to acco
 - **Common Pitfalls** -- frequent mistakes and how to avoid them.
 - **Related Skills** -- cross-references to complementary skills.
 
-The library currently contains 355 skills spanning 64 domains (as tagged in their metadata), ranging from `r-packages` and `containerization` to `esoteric` and `gardening`. Skills are kept under 500 lines; extended examples go into a `references/EXAMPLES.md` subdirectory following the progressive disclosure pattern.
+The library currently contains 361 skills spanning 65 domains (as tagged in their metadata), ranging from `r-packages` and `containerization` to `esoteric` and `gardening`. Skills are kept under 500 lines; extended examples go into a `references/EXAMPLES.md` subdirectory following the progressive disclosure pattern.
 
 ### 2. Agents -- the *who*
 
@@ -186,7 +186,7 @@ For example, the `submit-to-cran` skill is linked as:
 .claude/skills/submit-to-cran -> ../../skills/submit-to-cran
 ```
 
-You can then invoke it in Claude Code by typing `/submit-to-cran`. All 355 skills in this repository are already symlinked and ready to use.
+You can then invoke it in Claude Code by typing `/submit-to-cran`. All 361 skills in this repository are already symlinked and ready to use.
 
 ### By asking Claude Code directly
 
@@ -308,7 +308,7 @@ Use this decision matrix to pick the right level of composition for your task:
 - [Workflows README](../workflows/README.md) -- the workflows directory overview and seed
 - [Quick Reference](quick-reference.md) -- command cheat sheet for daily operations
 - [Skill Creation Meta-Skill](../skills/create-skill/SKILL.md) -- the skill that teaches you how to create skills
-- [Skills Library README](../skills/README.md) -- browsable catalog of all 355 skills
+- [Skills Library README](../skills/README.md) -- browsable catalog of all 361 skills
 - [Agents Library README](../agents/README.md) -- browsable catalog of all 72 agents
 - [Teams Library README](../teams/README.md) -- browsable catalog of all 17 teams
 - [Agent Skills Open Standard](https://agentskills.io) -- the specification this system follows

--- a/guides/unleash-the-agents.md
+++ b/guides/unleash-the-agents.md
@@ -9,7 +9,7 @@ skills: [unleash-the-agents, forage-solutions, build-coherence, coordinate-reaso
 
 # Unleash the Agents
 
-A structured approach to consulting agents from the almanac for open-ended hypothesis generation. Not every problem needs all 68 agents — this guide describes when to use a single expert, when to assemble a panel, and when to unleash the full roster.
+A structured approach to consulting agents from the almanac for open-ended hypothesis generation. Not every problem needs all 72 agents — this guide describes when to use a single expert, when to assemble a panel, and when to unleash the full roster.
 
 The pattern was battle-tested on 2026-03-24 when 68 agents operating through their unique domain lenses produced 205 hypotheses that converged on modular arithmetic over a finite group — a mechanism no single agent had proposed on its own. A kabalist found the formula through gematria, a contemplative noticed a swap pattern, and a martial-artist proposed conditional branching. Convergence across independent perspectives was the signal.
 
@@ -74,7 +74,7 @@ Select agents whose domains plausibly overlap with the problem. Launch them in p
 - Include the [polymath](../agents/polymath.md) or [adaptic](../agents/adaptic.md) for cross-domain synthesis
 - Avoid agents whose domains are obviously irrelevant (a dog-trainer adds nothing to a cryptography problem)
 
-**Example**: Investigating why a statistical model underperforms on a specific data subset. A panel of [senior-data-scientist](../agents/senior-data-scientist.md), [senior-researcher](../agents/senior-researcher.md), [diffusion-specialist](../agents/diffusion-specialist.md), [markovian](../agents/markovian.md), and [advocatus-diaboli](../agents/advocatus-diaboli.md) can cover methodology, experimental design, stochastic modeling, and critique — without needing all 68 agents.
+**Example**: Investigating why a statistical model underperforms on a specific data subset. A panel of [senior-data-scientist](../agents/senior-data-scientist.md), [senior-researcher](../agents/senior-researcher.md), [diffusion-specialist](../agents/diffusion-specialist.md), [markovian](../agents/markovian.md), and [advocatus-diaboli](../agents/advocatus-diaboli.md) can cover methodology, experimental design, stochastic modeling, and critique — without needing all 72 agents.
 
 ### Tier 3: Full Unleash
 

--- a/skills/create-agent/SKILL.md
+++ b/skills/create-agent/SKILL.md
@@ -51,7 +51,7 @@ Choose a clear, focused identity for the agent:
 - **Purpose**: one paragraph explaining the specific problem this agent solves. Ask: "What does this agent do that no existing agent covers?"
 - **Communication style**: consider the domain. Technical agents should be precise and citation-heavy. Creative agents can be more exploratory. Compliance agents should be formal and audit-oriented.
 
-Before proceeding, check for overlap with the existing 53 agents:
+Before proceeding, check for overlap with the existing 72 agents:
 
 ```bash
 grep -i "description:" agents/_registry.yml | grep -i "<your-domain-keywords>"
@@ -321,7 +321,7 @@ npm run translation:status
 - **Tool over-provisioning**: Including `Bash`, `Write`, or `WebFetch` when the agent only needs to read and analyze. This violates least-privilege and can lead to unintended side effects. Start with the minimal set and add tools only when a capability requires them.
 - **Missing or wrong skill assignments**: Listing skill IDs that do not exist in the registry, or forgetting to assign skills entirely. Always verify each skill ID with `grep "id: skill-name" skills/_registry.yml` before adding it.
 - **Listing default skills unnecessarily**: Adding `meditate` or `heal` to the agent frontmatter when they are already inherited from the registry. Only list them if they are core to the agent's methodology (e.g., `mystic`, `alchemist`, `gardener`, `shaman`).
-- **Scope overlap with existing agents**: Creating a new agent that duplicates functionality already covered by one of the 53 existing agents. Always search the registry first and consider extending an existing agent's skills instead.
+- **Scope overlap with existing agents**: Creating a new agent that duplicates functionality already covered by one of the 72 existing agents. Always search the registry first and consider extending an existing agent's skills instead.
 - **Vague purpose and capabilities**: Writing "helps with development" instead of "scaffolds R packages with complete structure, documentation, and CI/CD configuration." Specificity is what makes an agent useful and discoverable.
 
 ## Related Skills

--- a/skills/create-glyph/SKILL.md
+++ b/skills/create-glyph/SKILL.md
@@ -305,7 +305,7 @@ Make adjustments and re-render.
 
 ### Domain and Entity Color Palettes
 
-All 58 domain colors (for skills) are defined in `viz/R/palettes.R` (the single source of truth). Agent and team colors are also managed in `palettes.R`. The cyberpunk palette (hand-tuned neon colors) is in `get_cyberpunk_colors()`. Viridis-family palettes are auto-generated via `viridisLite`.
+All domain colors (for skills) are defined in `viz/R/palettes.R` (the single source of truth). Agent and team colors are also managed in `palettes.R`. The cyberpunk palette (hand-tuned neon colors) is in `get_cyberpunk_colors()`. Viridis-family palettes are auto-generated via `viridisLite`.
 
 To look up a color:
 ```r

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -34,7 +34,7 @@ Author a SKILL.md file that agentic systems can consume to execute a specific pr
 ## Inputs
 
 - **Required**: Task the skill should accomplish
-- **Required**: Domain classification — one of the 48 domains in `skills/_registry.yml`:
+- **Required**: Domain classification — one of the domains catalogued in `skills/_registry.yml` (the registry is the authoritative, current list), e.g.:
   `r-packages`, `jigsawr`, `containerization`, `reporting`, `compliance`, `mcp-integration`,
   `web-dev`, `git`, `general`, `citations`, `data-serialization`, `review`, `bushcraft`,
   `esoteric`, `design`, `defensive`, `project-management`, `devops`, `observability`, `mlops`,


### PR DESCRIPTION
## Summary

Documentation polish pass. Many guides and meta-skills hardcoded **stale registry counts** from when the library was smaller; this brings them up to the current authoritative totals and fixes one dead cross-reference. Counts verified against the `_registry.yml` files: **361 skills · 65 domains · 72 agents · 17 teams · 29 guides**.

Found via a 4-auditor discovery pass **plus a manual completeness re-sweep** (the auditors missed several, e.g. `epigenetics:345/347`, `installation:109`, `quick-reference:338`, `running-tending:156`, `create-glyph:308`, and a singular-form `355 skill directories`).

## Changes (12 files, 27 line-level edits)

**Guides** — stale count refreshes:
- `understanding-the-system.md` (355→361 skills ×5, 64→65 domains)
- `installation.md` (350→361, incl. the plugin-manifest JSON example)
- `agentskills-alignment.md` (328/66/15 → 361/72/17)
- `epigenetics-activation-control.md` (66/328/58/15 → 72/361/65/17 across 6 lines)
- `team-assembly-prompt-patterns.md` (15/68/337 → 17/72/361)
- `unleash-the-agents.md` (68→72, present-tense lines only)
- `quick-reference.md` (328/66/15 → 361/72/17)
- `running-tending.md` (66→72)

**Meta-skills**:
- `create-agent/SKILL.md` (53→72 agents, both occurrences)
- `create-skill/SKILL.md` + `create-glyph/SKILL.md` — **de-hardcoded** to reference `skills/_registry.yml` directly instead of a fixed number (durable; avoids re-staling on the next domain/skill add)

**Dead link**:
- `agents/contemplative.md` — `teams/ai-tending.md` → `teams/tending.md` (verified: target exists, old path doesn't)

## Deliberately left unchanged
- `unleash-the-agents.md:14` — dated "2026-03-24 … 68 agents" anecdote (historical record, 68 was correct then)
- `agents/translator.md:30` — "four content types" is **correct**: those are the four *translatable* types; workflows are `.mjs` code and are not in the i18n tree
- `tests/results/**`, `docs/investigations/**`, dated `RESULT.md` files — point-in-time records (staleness is self-evident from their dates)

## Validation (local)
- `validate:integrity` ✅ PASSED (3 pre-existing warnings unrelated to this diff)
- `check-content-style --added origin/main` ✅ 0 blocking errors
- `check-readmes` ✅ all up to date (`361 skills, 65 domains, 72 agents, 17 teams, 29 guides`)
- `validate-translations.yml` does not trigger here (path-filtered to `i18n/**`); freshness check is `--warn` anyway

## Follow-ups (separate)
- Editing the 3 English `SKILL.md` files marginally adds to the #278 i18n stale backlog (translated copies carry the same numbers; counts aren't localized — out of scope here).
- Systemic fix to stop counts re-staling (auto-derive guide/meta-skill counts via `generate-readmes.js`, or generalize the prose) + test-fixture count/`four→five content-type` drift — to be filed as a tracking issue.