### PR TITLE
perf(i18n): batch git freshness checks — translation scripts usable again (#305)

### DIFF
--- a/i18n/caveman-lite/translation_status.yml
+++ b/i18n/caveman-lite/translation_status.yml
@@ -1,5 +1,5 @@
 locale: caveman-lite
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352

--- a/i18n/caveman-ultra/translation_status.yml
+++ b/i18n/caveman-ultra/translation_status.yml
@@ -1,5 +1,5 @@
 locale: caveman-ultra
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352

--- a/i18n/caveman/translation_status.yml
+++ b/i18n/caveman/translation_status.yml
@@ -1,5 +1,5 @@
 locale: caveman
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352

--- a/i18n/de/translation_status.yml
+++ b/i18n/de/translation_status.yml
@@ -1,11 +1,11 @@
 locale: de
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352
     total: 361
     pct: 97.5
-    stale: 134
+    stale: 137
     stubs: 6
   agents:
     translated: 3
@@ -23,11 +23,11 @@ coverage:
     translated: 3
     total: 29
     pct: 10.3
-    stale: 1
+    stale: 2
     stubs: 1
   total:
     translated: 359
     total: 479
     pct: 74.9
-    stale: 139
+    stale: 143
     stubs: 7

--- a/i18n/es/translation_status.yml
+++ b/i18n/es/translation_status.yml
@@ -1,11 +1,11 @@
 locale: es
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352
     total: 361
     pct: 97.5
-    stale: 137
+    stale: 140
     stubs: 6
   agents:
     translated: 3
@@ -23,11 +23,11 @@ coverage:
     translated: 3
     total: 29
     pct: 10.3
-    stale: 1
+    stale: 2
     stubs: 1
   total:
     translated: 359
     total: 479
     pct: 74.9
-    stale: 142
+    stale: 146
     stubs: 7

--- a/i18n/ja/translation_status.yml
+++ b/i18n/ja/translation_status.yml
@@ -1,11 +1,11 @@
 locale: ja
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352
     total: 361
     pct: 97.5
-    stale: 120
+    stale: 123
     stubs: 6
   agents:
     translated: 3
@@ -23,11 +23,11 @@ coverage:
     translated: 3
     total: 29
     pct: 10.3
-    stale: 1
+    stale: 2
     stubs: 1
   total:
     translated: 359
     total: 479
     pct: 74.9
-    stale: 125
+    stale: 129
     stubs: 7

--- a/i18n/wenyan-lite/translation_status.yml
+++ b/i18n/wenyan-lite/translation_status.yml
@@ -1,5 +1,5 @@
 locale: wenyan-lite
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352

--- a/i18n/wenyan-ultra/translation_status.yml
+++ b/i18n/wenyan-ultra/translation_status.yml
@@ -1,5 +1,5 @@
 locale: wenyan-ultra
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352

--- a/i18n/wenyan/translation_status.yml
+++ b/i18n/wenyan/translation_status.yml
@@ -1,5 +1,5 @@
 locale: wenyan
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352

--- a/i18n/zh-CN/translation_status.yml
+++ b/i18n/zh-CN/translation_status.yml
@@ -1,11 +1,11 @@
 locale: zh-CN
-last_updated: '2026-06-17'
+last_updated: '2026-07-11'
 coverage:
   skills:
     translated: 352
     total: 361
     pct: 97.5
-    stale: 127
+    stale: 130
     stubs: 6
   agents:
     translated: 3
@@ -23,11 +23,11 @@ coverage:
     translated: 3
     total: 29
     pct: 10.3
-    stale: 1
+    stale: 2
     stubs: 1
   total:
     translated: 359
     total: 479
     pct: 74.9
-    stale: 132
+    stale: 136
     stubs: 7

--- a/scripts/check-translation-freshness.js
+++ b/scripts/check-translation-freshness.js
@@ -14,7 +14,7 @@
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { resolve, dirname, basename, join } from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
+import { createFreshnessChecker, buildLatestCommitMap } from './lib/git-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -40,42 +40,13 @@ function extractLocale(filePath) {
   return match ? match[1] : null;
 }
 
-/**
- * Get the latest git short hash for a source file.
- */
-function getLatestCommit(filePath) {
-  try {
-    const result = execSync(
-      `git log -1 --format=%h -- "${filePath}"`,
-      { cwd: ROOT, encoding: 'utf8' }
-    ).trim();
-    return result || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Check if a source commit is an ancestor of the latest commit for the file.
- * Returns true if source has changed since the translation was made.
- */
-function isStale(sourceCommit, latestCommit) {
-  if (!sourceCommit || !latestCommit) return false;
-  if (sourceCommit === latestCommit) return false;
-  try {
-    // Check if source_commit is an ancestor of latest (meaning file changed after translation)
-    execSync(
-      `git merge-base --is-ancestor ${sourceCommit} ${latestCommit}`,
-      { cwd: ROOT, encoding: 'utf8' }
-    );
-    // If the command succeeds, sourceCommit IS an ancestor of latestCommit,
-    // meaning the file has been updated since translation
-    return true;
-  } catch {
-    // Command fails if not an ancestor or if commits are the same
-    return false;
-  }
-}
+// Batched staleness (#305): one `git log <source_commit>..HEAD` per DISTINCT
+// source_commit, plus one streaming pass for the path -> latest-hash map used
+// in the STALE message — instead of two git spawns per translated file.
+const freshness = createFreshnessChecker(ROOT);
+const toRelPath = (absPath) => absPath.slice(ROOT.length + 1);
+console.log('Building latest-commit map (one git pass)...');
+const latestCommitMap = buildLatestCommitMap(ROOT);
 
 /**
  * Resolve the English source path for a translated file.
@@ -129,6 +100,9 @@ for (const locale of locales) {
       }
 
       checkedCount++;
+      if (checkedCount % 500 === 0) {
+        console.log(`  ...checked ${checkedCount} files (${freshness.distinctCommits()} distinct source commits resolved)`);
+      }
       const sourceCommit = extractSourceCommit(translatedFile);
       const sourcePath = resolveSourcePath(locale, contentType, translatedFile);
 
@@ -143,8 +117,8 @@ for (const locale of locales) {
         continue;
       }
 
-      const latestCommit = getLatestCommit(sourcePath);
-      if (isStale(sourceCommit, latestCommit)) {
+      if (freshness.isStale(sourceCommit, toRelPath(sourcePath))) {
+        const latestCommit = latestCommitMap.get(toRelPath(sourcePath)) || 'unknown';
         staleCount++;
         staleFiles.push({
           file: translatedFile.replace(ROOT + '/', ''),

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -14,6 +14,7 @@ import { resolve, dirname, join, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import * as yaml from 'js-yaml';
+import { createFreshnessChecker } from './lib/git-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -92,44 +93,22 @@ function stripFrontmatter(content) {
 /**
  * Detect untranslated stub: scaffold copies English source byte-for-byte
  * and only injects frontmatter fields. If body equals source body, it's a stub.
+ * Source bodies are cached — every locale compares against the same sources.
  */
+const sourceBodyCache = new Map();
 function isUntranslatedStub(translatedFile, sourcePath) {
   if (!existsSync(sourcePath)) return false;
   const tBody = stripFrontmatter(readFileSync(translatedFile, 'utf8')).trim();
-  const sBody = stripFrontmatter(readFileSync(sourcePath, 'utf8')).trim();
-  return tBody === sBody;
+  if (!sourceBodyCache.has(sourcePath)) {
+    sourceBodyCache.set(sourcePath, stripFrontmatter(readFileSync(sourcePath, 'utf8')).trim());
+  }
+  return tBody === sourceBodyCache.get(sourcePath);
 }
 
-/**
- * Get latest commit for a source file.
- */
-function getLatestCommit(filePath) {
-  try {
-    return execSync(
-      `git log -1 --format=%h -- "${filePath}"`,
-      { cwd: ROOT, encoding: 'utf8' }
-    ).trim() || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Check if translation is stale.
- */
-function isStale(sourceCommit, latestCommit) {
-  if (!sourceCommit || !latestCommit) return false;
-  if (sourceCommit === latestCommit) return false;
-  try {
-    execSync(
-      `git merge-base --is-ancestor ${sourceCommit} ${latestCommit}`,
-      { cwd: ROOT, encoding: 'utf8' }
-    );
-    return true;
-  } catch {
-    return false;
-  }
-}
+// Batched staleness (#305): one `git log <source_commit>..HEAD` per DISTINCT
+// source_commit instead of per-file `git log -1` + `merge-base` spawns.
+const freshness = createFreshnessChecker(ROOT);
+const toRelPath = (absPath) => absPath.slice(ROOT.length + 1);
 
 /**
  * Resolve English source path.
@@ -182,8 +161,7 @@ function countTranslations(locale, contentType) {
 
     const sourceCommit = extractSourceCommit(translatedFile);
     if (existsSync(sourcePath) && sourceCommit) {
-      const latestCommit = getLatestCommit(sourcePath);
-      if (isStale(sourceCommit, latestCommit)) {
+      if (freshness.isStale(sourceCommit, toRelPath(sourcePath))) {
         stale++;
       }
     }
@@ -212,6 +190,7 @@ for (const locale of locales) {
   const totalSource = sourceCounts.total;
 
   for (const contentType of contentTypes) {
+    const startedAt = Date.now();
     const { translated, stale, stubs } = countTranslations(locale, contentType);
     const total = sourceCounts[contentType];
     const pct = total > 0 ? Math.round((translated / total) * 1000) / 10 : 0;
@@ -219,6 +198,7 @@ for (const locale of locales) {
     totalTranslated += translated;
     totalStale += stale;
     totalStubs += stubs;
+    console.log(`  scan ${locale}/${contentType}: ${translated} translated, ${stale} stale, ${stubs} stubs (${Date.now() - startedAt}ms)`);
   }
 
   const totalPct = totalSource > 0

--- a/scripts/lib/git-freshness.js
+++ b/scripts/lib/git-freshness.js
@@ -1,0 +1,102 @@
+/**
+ * git-freshness.js
+ *
+ * Shared batched git helpers for the translation freshness tooling (#305).
+ *
+ * The naive approach — one `git log -1 -- <file>` plus one
+ * `git merge-base --is-ancestor` per translated file — spawns thousands of
+ * git processes across ~3,600 translations and takes 10+ minutes on
+ * NTFS/WSL. These helpers answer the same questions with a handful of
+ * spawns:
+ *
+ *  - isStale(sourceCommit, relPath): "has relPath changed since
+ *    sourceCommit?" via ONE `git log --name-only <commit>..HEAD` per
+ *    DISTINCT source_commit (scaffold batches share commits, so distinct
+ *    values number in the dozens, not thousands).
+ *  - buildLatestCommitMap(): path -> latest short hash for every file under
+ *    the given pathspecs, from ONE streaming `git log --name-only` pass.
+ *
+ * Semantics match the old per-file logic for the normal case (source_commit
+ * is an ancestor of HEAD). Differences, both deliberate:
+ *  - a full-length source_commit pointing at the newest commit of a file no
+ *    longer misreports as stale (the old short-hash equality shortcut missed
+ *    it and `merge-base --is-ancestor S S` succeeded);
+ *  - an unresolvable source_commit still counts as not-stale, matching the
+ *    old catch-to-false behaviour.
+ */
+
+import { execFileSync } from 'child_process';
+
+const GIT_BUFFER = 256 * 1024 * 1024;
+
+/**
+ * Create a staleness checker rooted at a git work tree.
+ * `pathspecs` bounds every git walk to the content trees that matter.
+ */
+export function createFreshnessChecker(root, pathspecs = ['skills', 'agents', 'teams', 'guides']) {
+  // source_commit -> Set(relative paths changed since it) | null (unresolvable)
+  const changedSince = new Map();
+
+  function commitResolves(commit) {
+    try {
+      execFileSync('git', ['rev-parse', '--quiet', '--verify', `${commit}^{commit}`],
+        { cwd: root, stdio: ['ignore', 'ignore', 'ignore'] });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  function pathsChangedSince(commit) {
+    if (changedSince.has(commit)) return changedSince.get(commit);
+    let result = null;
+    if (/^[a-f0-9]{4,40}$/i.test(commit) && commitResolves(commit)) {
+      const out = execFileSync('git',
+        ['log', '--name-only', '--format=', `${commit}..HEAD`, '--', ...pathspecs],
+        { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER });
+      result = new Set(out.split('\n').filter(Boolean));
+    }
+    changedSince.set(commit, result);
+    return result;
+  }
+
+  /**
+   * True when relPath (repo-relative, forward slashes) was touched by any
+   * commit after sourceCommit on the path to HEAD.
+   */
+  function isStale(sourceCommit, relPath) {
+    if (!sourceCommit || !relPath) return false;
+    const changed = pathsChangedSince(sourceCommit);
+    if (!changed) return false;
+    return changed.has(relPath);
+  }
+
+  /** Number of distinct source commits resolved so far (progress metric). */
+  function distinctCommits() {
+    return changedSince.size;
+  }
+
+  return { isStale, distinctCommits };
+}
+
+/**
+ * One streaming pass over history: repo-relative path -> latest short hash.
+ * First occurrence in `git log` order (newest first) wins.
+ */
+export function buildLatestCommitMap(root, pathspecs = ['skills', 'agents', 'teams', 'guides']) {
+  const out = execFileSync('git',
+    ['log', '--name-only', '--format=%x00%h', '--', ...pathspecs],
+    { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER });
+  const map = new Map();
+  let current = null;
+  for (const line of out.split('\n')) {
+    if (line.startsWith('\x00')) {
+      current = line.slice(1).trim();
+      continue;
+    }
+    if (line && current && !map.has(line)) {
+      map.set(line, current);
+    }
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary

`npm run translation:status` and `npm run validate:translations` spawned two git processes per translated file (`git log -1 -- <file>` + `git merge-base --is-ancestor`) — ~7,000 spawns across 3,576 translations. Measured on NTFS/WSL: **>10 minutes without completing** (killed twice; a killed run leaves partial per-locale status writes).

New shared `scripts/lib/git-freshness.js` answers the same staleness question with one `git log --name-only <source_commit>..HEAD` per **distinct** `source_commit` — scaffold batches cluster, so distinct commits number in single digits — plus one streaming history pass for the path→latest-hash map used in `STALE:` messages.

## Measured

| Script | Before | After |
|---|---|---|
| `translation:status` (10 locales) | >10 min, never completed | **3m 11s** |
| `validate:translations` (3,576 files) | comparable | **1m 26s** |

Remaining cost is 9P file reads (stub detection), not git — 8-13% CPU, I/O-bound.

## Correctness

- Parity test old-vs-new on a deterministic 41-file sample (every 89th file + all 28 fresh batch scaffolds exercising the `source_commit == latest` edge): **0 mismatches**.
- Fixes a latent misreport: a full-length `source_commit` pointing at a file's newest commit fell past the short-hash equality shortcut into `merge-base --is-ancestor S S` (which succeeds) and counted as stale. The new set-membership formulation has no hash-format sensitivity.
- Unresolvable `source_commit` still counts as not-stale (parity with the old catch-to-false path). The shallow-clone guard (#279) is untouched.

## Also

- Progress indicators (the issue's headline ask): per-locale/type scan lines with timings, and a per-500-files counter in the validator.
- Second commit regenerates all `translation_status.yml` files — the first successful full regeneration on this machine (PR #334 had to skip it): 2,327 stale (#278 backlog + post-batch drift).

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)