### PR TITLE
chore: clean up loose ends — gitignore cli-rs cache + register WSL guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ peon-ping-sound.wav
 tests/results/**/*.html
 *.knit.md
 
+# Rust CLI build cache (the Rust port's source lives on the rust-cli branch, not main)
+cli-rs/target/
+
 # Local Claude Code config (not shared)
 .claude/settings.json
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 <!-- AUTO:START:overview -->
-A documentation-first repository containing 32 guides, a skills library of 366 agentic skills, 73 agent definitions, 18 team compositions, and a curated set of code-driven workflow orchestration scripts, following the [Agent Skills open standard](https://agentskills.io). Almost all content is markdown and YAML; workflows are self-contained `.mjs` scripts run by Claude Code's Workflow tool.
+A documentation-first repository containing 33 guides, a skills library of 366 agentic skills, 73 agent definitions, 18 team compositions, and a curated set of code-driven workflow orchestration scripts, following the [Agent Skills open standard](https://agentskills.io). Almost all content is markdown and YAML; workflows are self-contained `.mjs` scripts run by Claude Code's Workflow tool.
 
 The guides serve as the human entry point to the agentic system: practical walkthroughs explaining when, why, and how to interact with agents, teams, skills, and workflows through Claude Code.
 <!-- AUTO:END:overview -->
@@ -32,7 +32,7 @@ These five types complement each other: skills define *how* (procedure, validati
 - `skills/_registry.yml` is the machine-readable catalog of all 366 skills across 66 domains: r-packages (10), jigsawr (5), containerization (10), reporting (5), compliance (17), mcp-integration (6), web-dev (5), git (8), general (24), citations (3), data-serialization (2), review (11), bushcraft (4), esoteric (29), design (6), defensive (6), project-management (6), devops (13), observability (13), edge-computing (1), mlops (12), workflow-visualization (6), swarm (9), morphic (7), alchemy (4), tcg (3), intellectual-property (4), web-scraping (2), gardening (5), shiny (7), animal-training (2), mycology (2), prospecting (2), crafting (1), library-science (3), linguistics (1), travel (6), relocation (3), a2a-protocol (3), geometry (3), number-theory (3), stochastic-processes (3), theoretical-science (3), diffusion (4), hildegard (5), maintenance (5), blender (3), visualization (4), 3d-printing (3), lapidary (4), entomology (5), versioning (4), spectroscopy (6), chromatography (5), gpu-optimization (2), digital-logic (4), electromagnetism (4), levitation (3), i18n (1), synoptic (4), tensegrity (1), cli (4), open-source (2), investigation (9), memex (5), ocr (1).
 - `agents/_registry.yml` is the machine-readable catalog of all 73 agents.
 - `teams/_registry.yml` is the machine-readable catalog of all 18 teams.
-- `guides/_registry.yml` is the machine-readable catalog of all 32 guides across 5 categories.
+- `guides/_registry.yml` is the machine-readable catalog of all 33 guides across 5 categories.
 
 When adding or removing skills, agents, teams, or guides, the corresponding registry must be updated to stay in sync.
 <!-- AUTO:END:registries -->

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A library of executable skills, specialist agents, and pre-built teams for [Clau
 - **366 skills** across 66 domains — structured, executable procedures
 - **73 agents** — specialized Claude Code personas covering development, review, compliance, and more
 - **18 teams** — predefined multi-agent compositions for complex workflows
-- **32 guides** — human-readable workflow, infrastructure, and reference documentation
+- **33 guides** — human-readable workflow, infrastructure, and reference documentation
 - **Interactive visualization** — force-graph explorer with 366 R-generated skill icons and 9 color themes
 <!-- AUTO:END:stats -->
 
@@ -122,7 +122,7 @@ agent-almanac/
   skills/          366 executable procedures across 66 domains
   agents/          73 specialist personas
   teams/           18 multi-agent compositions with 8 coordination patterns
-  guides/          32 human-readable reference docs
+  guides/          33 human-readable reference docs
   viz/             Interactive force-graph explorer with R-generated icons
   tests/           30 test scenarios for validation
   i18n/            Translations (10 locales: de, zh-CN, ja, es, caveman-lite, caveman, caveman-ultra, wenyan-lite, wenyan, wenyan-ultra)
@@ -163,6 +163,7 @@ New here? Start with [Understanding the System](guides/understanding-the-system.
 - [Setting Up Your Environment](guides/setting-up-your-environment.md) — WSL2 setup, shell config, MCP server integration, and Claude Code configuration
 - [Symlink Architecture](guides/symlink-architecture.md) — How symlinks enable multi-project discovery of skills, agents, and teams through Claude Code
 - [R Package Development](guides/r-package-development.md) — Package structure, testing, CRAN submission, pkgdown deployment, and renv management
+- [WSL Maintenance & Claude Code Reference](guides/wsl-maintenance.md) — WSL2 vhdx disk reclamation, Claude Code permission modes, and periodic security-scan greps for a WSL-based dev environment
 
 **Reference**
 
@@ -186,16 +187,16 @@ New here? Start with [Understanding the System](guides/understanding-the-system.
 <!-- AUTO:START:translations -->
 | Locale | Language | Skills | Agents | Teams | Guides | Total |
 |---|---|---|---|---|---|---|
-| de | Deutsch | 363/366 | 4/73 | 2/18 | 4/32 | 373/489 (76.3%) |
-| zh-CN | 简体中文 | 363/366 | 4/73 | 2/18 | 4/32 | 373/489 (76.3%) |
-| ja | 日本語 | 363/366 | 4/73 | 2/18 | 4/32 | 373/489 (76.3%) |
-| es | Español | 363/366 | 4/73 | 2/18 | 4/32 | 373/489 (76.3%) |
-| caveman-lite | Caveman Lite | 352/366 | 0/73 | 0/18 | 0/32 | 352/489 (72%) |
-| caveman | Caveman | 352/366 | 0/73 | 0/18 | 0/32 | 352/489 (72%) |
-| caveman-ultra | Caveman Ultra | 352/366 | 0/73 | 0/18 | 0/32 | 352/489 (72%) |
-| wenyan-lite | 文言文輕 | 352/366 | 0/73 | 0/18 | 0/32 | 352/489 (72%) |
-| wenyan | 文言文 | 352/366 | 0/73 | 0/18 | 0/32 | 352/489 (72%) |
-| wenyan-ultra | 文言文極 | 352/366 | 0/73 | 0/18 | 0/32 | 352/489 (72%) |
+| de | Deutsch | 363/366 | 4/73 | 2/18 | 4/33 | 373/490 (76.1%) |
+| zh-CN | 简体中文 | 363/366 | 4/73 | 2/18 | 4/33 | 373/490 (76.1%) |
+| ja | 日本語 | 363/366 | 4/73 | 2/18 | 4/33 | 373/490 (76.1%) |
+| es | Español | 363/366 | 4/73 | 2/18 | 4/33 | 373/490 (76.1%) |
+| caveman-lite | Caveman Lite | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
+| caveman | Caveman | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
+| caveman-ultra | Caveman Ultra | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
+| wenyan-lite | 文言文輕 | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
+| wenyan | 文言文 | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
+| wenyan-ultra | 文言文極 | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
 <!-- AUTO:END:translations -->
 
 See [i18n/README.md](i18n/README.md) for the translation contributor guide.

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,6 +1,6 @@
 # Guides
 
-32 guides serving as the human entry point to the agentic system — practical workflows for agents, teams, and skills, plus infrastructure setup and reference material.
+33 guides serving as the human entry point to the agentic system — practical workflows for agents, teams, and skills, plus infrastructure setup and reference material.
 
 ## Workflow
 
@@ -72,6 +72,9 @@ How symlinks enable multi-project discovery of skills, agents, and teams through
 
 ### [R Package Development](r-package-development.md)
 Package structure, testing, CRAN submission, pkgdown deployment, and renv management.
+
+### [WSL Maintenance & Claude Code Reference](wsl-maintenance.md)
+WSL2 vhdx disk reclamation, Claude Code permission modes, and periodic security-scan greps for a WSL-based dev environment.
 
 ## Reference
 

--- a/guides/_registry.yml
+++ b/guides/_registry.yml
@@ -2,9 +2,9 @@
 # Machine-readable catalog of all guide documents in this library.
 # Keep in sync with the actual guide files on disk.
 
-total_guides: 32
+total_guides: 33
 version: "1.0"
-last_updated: "2026-07-10"
+last_updated: "2026-07-16"
 
 categories:
   workflow:
@@ -209,6 +209,15 @@ guides:
     agents: [r-developer, code-reviewer]
     teams: [r-package-review]
     skills: [create-r-package, write-roxygen-docs, write-testthat-tests, submit-to-cran, build-pkgdown-site, manage-renv-dependencies, setup-github-actions-ci]
+
+  - id: wsl-maintenance
+    path: guides/wsl-maintenance.md
+    title: "WSL Maintenance & Claude Code Reference"
+    description: "WSL2 vhdx disk reclamation, Claude Code permission modes, and periodic security-scan greps for a WSL-based dev environment"
+    category: infrastructure
+    agents: []
+    teams: []
+    skills: [setup-wsl-dev-environment]
 
   # ── Reference guides ─────────────────────────────────────────────
   - id: quick-reference

--- a/guides/wsl-maintenance.md
+++ b/guides/wsl-maintenance.md
@@ -1,0 +1,108 @@
+---
+title: "WSL Maintenance & Claude Code Reference"
+description: "WSL2 vhdx disk reclamation, Claude Code permission modes, and periodic security-scan greps for a WSL-based dev environment"
+category: infrastructure
+agents: []
+teams: []
+skills: [setup-wsl-dev-environment]
+---
+
+# WSL Maintenance & Claude Code Reference
+
+On-demand reference for maintaining a WSL2-based Claude Code development environment: reclaiming virtual-disk space, choosing a permission mode, and periodically scanning a projects directory for leaked secrets or hardcoded personal paths. Kept out of always-loaded instructions so it does not consume session context.
+
+## When to Use This Guide
+
+- A WSL2 `.vhdx` has grown large and you want to reclaim space Windows still holds after files were deleted inside Linux
+- You need the precise meaning of each Claude Code permission mode before choosing one
+- You want a periodic security sweep of your projects directory for keys, tokens, real emails, or hardcoded personal paths
+
+## Prerequisites
+
+- A WSL2 distro (e.g. Ubuntu) on Windows, optionally with Docker Desktop
+- An elevated (Administrator) PowerShell for disk compaction
+- First-time setup lives in [Setting Up Your Environment](setting-up-your-environment.md) (`setup-wsl-dev-environment` skill)
+
+## WSL Disk Management
+
+WSL2 stores each distro as a sparse `.vhdx` virtual disk. Default max 1 TB. **Grows on demand, never auto-shrinks** when files are deleted inside Linux — Windows still sees the larger allocation.
+
+**Typical vhdx locations** (via `%LOCALAPPDATA%`, i.e. `C:\Users\<you>\AppData\Local`; `<distro-guid>` is the per-distro folder). Keep these on the system drive, not a data drive:
+
+- `%LOCALAPPDATA%\wsl\<distro-guid>\ext4.vhdx` — the Linux distro
+- `%LOCALAPPDATA%\Docker\wsl\disk\docker_data.vhdx` — Docker Desktop data
+- `%LOCALAPPDATA%\Docker\wsl\main\ext4.vhdx` — Docker Desktop bootstrap
+
+**Reclaim wasted vhdx space** (elevated PowerShell):
+
+```powershell
+wsl --shutdown
+Optimize-VHD -Path "$env:LOCALAPPDATA\wsl\<distro-guid>\ext4.vhdx" -Mode Full
+```
+
+Fallback (Windows Home, no Hyper-V module): `diskpart` → `select vdisk file=...` → `attach vdisk readonly` → `compact vdisk` → `detach vdisk`.
+
+Modern auto-shrink (WSL ≥ 2.0): `wsl --manage <distro> --set-sparse true`.
+
+Pre-step inside the distro to make compaction effective:
+
+```bash
+sudo apt clean
+sudo journalctl --vacuum-time=7d
+docker system prune -af --volumes  # if Docker Desktop in use
+npm cache clean --force
+pip cache purge
+```
+
+**Diagnose disk usage with Windows-native PowerShell**, not `du` over `/mnt/<drive>` — the 9P protocol is much slower than native NTFS access. Use `-Force` to include hidden + system files.
+
+```powershell
+# Top-level dirs by size (point at the drive you want to inspect;
+# an admin shell is required to traverse System Volume Information)
+Get-ChildItem D:\ -Directory -Force -ErrorAction SilentlyContinue |
+  ForEach-Object {
+    $size = (Get-ChildItem $_.FullName -Recurse -File -Force -ErrorAction SilentlyContinue |
+             Measure-Object Length -Sum).Sum
+    [PSCustomObject]@{ SizeGB=[math]::Round($size/1GB,2); Path=$_.FullName }
+  } | Sort-Object SizeGB -Descending | Format-Table -AutoSize
+```
+
+## Claude Code Permission Modes
+
+Six modes valid for both `claude --permission-mode <X>` and `settings.json` `permissions.defaultMode`:
+
+| Mode | Behavior |
+|---|---|
+| `default` | Prompt on first use of each tool |
+| `acceptEdits` | Auto-approve edits + filesystem cmds in cwd |
+| `plan` | Read-only; no edits, no execution |
+| `auto` | Auto-approve with background safety checks (research preview) |
+| `dontAsk` | Auto-deny unless pre-allowed via `/permissions` or rules |
+| `bypassPermissions` | Skip all prompts except protected dirs (.git, .claude) |
+
+Two related CLI flags still active:
+
+- `--dangerously-skip-permissions` — equivalent to `--permission-mode bypassPermissions`
+- `--allow-dangerously-skip-permissions` — adds bypass to the Shift+Tab cycle without starting in it
+
+Sources: <https://code.claude.com/docs/en/permission-modes>, <https://code.claude.com/docs/en/cli-reference>
+
+## Security-Scan Greps
+
+Re-run periodically over your projects directory (replace `<your-projects-dir>` with its path):
+
+```bash
+# Sensitive patterns (keys, tokens, real emails)
+grep -rn "sk-\|ghp_\|YOUR_.*_HERE\|your.*email" <your-projects-dir> --include="*.md" --exclude-dir=node_modules
+
+# Hardcoded personal paths (a Windows user directory that is not a placeholder)
+grep -rn "C:\\\\Users\\\\[^\\\\]*\\\\" <your-projects-dir> --include="*.md" --exclude-dir=node_modules
+```
+
+Best practices: keep `.Renviron` git-ignored; use placeholders (`your.email@example.com`, `YOUR_TOKEN_HERE`) in committed docs; treat only intentionally-public identifiers (your GitHub username, published app URLs) as safe to commit.
+
+## Related Resources
+
+- [Setting Up Your Environment](setting-up-your-environment.md) — first-time WSL2, shell, MCP, and Claude Code setup
+- [Symlink Architecture](symlink-architecture.md) — how discovery symlinks work across projects
+- `setup-wsl-dev-environment` skill — scripted WSL dev-environment bootstrap


### PR DESCRIPTION
## What

Clears the two untracked loose ends that were cluttering `git status` after the CRLF-gate work (#343).

### 1. `chore: gitignore cli-rs/target build cache` (`a5254b02`)

`cli-rs/` on `main` held only a stray Cargo `target/` build cache (the Rust port's source lives on the `rust-cli` branch). Added `cli-rs/target/` to `.gitignore` so it no longer surfaces in `git status`.

### 2. `docs(guides): add WSL Maintenance & Claude Code Reference guide` (`257a6a61`)

Registers the previously-untracked `guides/wsl-maintenance.md` — migrated from a private `CLAUDE.md` on 2026-07-13, referenced there but never committed here (a broken reference in the shipped state).

**Generalized before publishing** (this is a public repo): the file carried personal machine details that its *own* documented security-scan grep is designed to catch. Removed:

- `C:\Users\<name>\AppData\Local\…` → `%LOCALAPPDATA%\…` (canonical env-var form; no username)
- distro folder GUIDs → `<distro-guid>` placeholder
- a personal audit date and "on this machine" framing
- the hardcoded projects directory in the security greps → `<your-projects-dir>`

Added guide frontmatter (`category: infrastructure`, `skills: [setup-wsl-dev-environment]`) and registered it in `guides/_registry.yml` (`total_guides` 32 → 33). READMEs regenerated from the registry (`CLAUDE.md`, `README.md`, `guides/README.md`).

## Verification

- `npm run validate:integrity` → **PASSED** (A3 guide frontmatter OK, all structural checks pass)
- `npm run check-readmes` → clean (READMEs match the registry)
- `check-content-style.js --added` → **0 blocking errors** on added lines
- `npm run validate:line-endings` → LF (the new gate from #343)
- Guide re-scanned with its own personal-path grep → no real `C:\Users\<name>\` path remains (only `%LOCALAPPDATA%`, the `<you>` placeholder, and the escaped regex in the grep example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
