### PR TITLE
chore(i18n): refresh caveman/wenyan translation_status denominators (guide #33)

### DIFF
--- a/i18n/caveman-lite/translation_status.yml
+++ b/i18n/caveman-lite/translation_status.yml
@@ -1,5 +1,5 @@
 locale: caveman-lite
-last_updated: '2026-07-11'
+last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 32
+    total: 33
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 489
-    pct: 72
+    total: 490
+    pct: 71.8
     stale: 296
     stubs: 0

--- a/i18n/caveman-ultra/translation_status.yml
+++ b/i18n/caveman-ultra/translation_status.yml
@@ -1,5 +1,5 @@
 locale: caveman-ultra
-last_updated: '2026-07-11'
+last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 32
+    total: 33
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 489
-    pct: 72
+    total: 490
+    pct: 71.8
     stale: 296
     stubs: 0

--- a/i18n/caveman/translation_status.yml
+++ b/i18n/caveman/translation_status.yml
@@ -1,5 +1,5 @@
 locale: caveman
-last_updated: '2026-07-11'
+last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 32
+    total: 33
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 489
-    pct: 72
+    total: 490
+    pct: 71.8
     stale: 296
     stubs: 0

--- a/i18n/wenyan-lite/translation_status.yml
+++ b/i18n/wenyan-lite/translation_status.yml
@@ -1,5 +1,5 @@
 locale: wenyan-lite
-last_updated: '2026-07-11'
+last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 32
+    total: 33
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 489
-    pct: 72
+    total: 490
+    pct: 71.8
     stale: 296
     stubs: 0

--- a/i18n/wenyan-ultra/translation_status.yml
+++ b/i18n/wenyan-ultra/translation_status.yml
@@ -1,5 +1,5 @@
 locale: wenyan-ultra
-last_updated: '2026-07-11'
+last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 32
+    total: 33
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 489
-    pct: 72
+    total: 490
+    pct: 71.8
     stale: 293
     stubs: 0

--- a/i18n/wenyan/translation_status.yml
+++ b/i18n/wenyan/translation_status.yml
@@ -1,5 +1,5 @@
 locale: wenyan
-last_updated: '2026-07-11'
+last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 32
+    total: 33
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 489
-    pct: 72
+    total: 490
+    pct: 71.8
     stale: 296
     stubs: 0


### PR DESCRIPTION
Follow-up to #344. Adding `guides/wsl-maintenance.md` bumped the source guide count 32 → 33, shifting the translation-coverage denominator for all 10 locales. The `update-readmes` CI auto-commit (`46fa9717`) only regenerates the four `_config.yml` locales (de, es, ja, zh-CN); the six caveman/wenyan locales need a manual `npm run translation:status`.

Regenerated the six esoteric locales' `translation_status.yml`: only the guides `total` (32 → 33) and the derived overall total/pct changed. No primary-locale file re-changed — the local run is deterministic and consistent with CI's.

Leaves all 10 locales' denominators at 33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)