### PR TITLE
feat(content): GitHub repo-protection guide + assess/harden skill pair

### DIFF
--- a/.claude/skills/assess-github-repo-security
+++ b/.claude/skills/assess-github-repo-security
@@ -1,0 +1,1 @@
+../../skills/assess-github-repo-security

--- a/.claude/skills/harden-github-repo-security
+++ b/.claude/skills/harden-github-repo-security
@@ -1,0 +1,1 @@
+../../skills/harden-github-repo-security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 <!-- AUTO:START:overview -->
-A documentation-first repository containing 33 guides, a skills library of 366 agentic skills, 73 agent definitions, 18 team compositions, and a curated set of code-driven workflow orchestration scripts, following the [Agent Skills open standard](https://agentskills.io). Almost all content is markdown and YAML; workflows are self-contained `.mjs` scripts run by Claude Code's Workflow tool.
+A documentation-first repository containing 34 guides, a skills library of 368 agentic skills, 73 agent definitions, 18 team compositions, and a curated set of code-driven workflow orchestration scripts, following the [Agent Skills open standard](https://agentskills.io). Almost all content is markdown and YAML; workflows are self-contained `.mjs` scripts run by Claude Code's Workflow tool.
 
 The guides serve as the human entry point to the agentic system: practical walkthroughs explaining when, why, and how to interact with agents, teams, skills, and workflows through Claude Code.
 <!-- AUTO:END:overview -->
@@ -29,10 +29,10 @@ These five types complement each other: skills define *how* (procedure, validati
 ### Registries
 
 <!-- AUTO:START:registries -->
-- `skills/_registry.yml` is the machine-readable catalog of all 366 skills across 66 domains: r-packages (10), jigsawr (5), containerization (10), reporting (5), compliance (17), mcp-integration (6), web-dev (5), git (8), general (24), citations (3), data-serialization (2), review (11), bushcraft (4), esoteric (29), design (6), defensive (6), project-management (6), devops (13), observability (13), edge-computing (1), mlops (12), workflow-visualization (6), swarm (9), morphic (7), alchemy (4), tcg (3), intellectual-property (4), web-scraping (2), gardening (5), shiny (7), animal-training (2), mycology (2), prospecting (2), crafting (1), library-science (3), linguistics (1), travel (6), relocation (3), a2a-protocol (3), geometry (3), number-theory (3), stochastic-processes (3), theoretical-science (3), diffusion (4), hildegard (5), maintenance (5), blender (3), visualization (4), 3d-printing (3), lapidary (4), entomology (5), versioning (4), spectroscopy (6), chromatography (5), gpu-optimization (2), digital-logic (4), electromagnetism (4), levitation (3), i18n (1), synoptic (4), tensegrity (1), cli (4), open-source (2), investigation (9), memex (5), ocr (1).
+- `skills/_registry.yml` is the machine-readable catalog of all 368 skills across 66 domains: r-packages (10), jigsawr (5), containerization (10), reporting (5), compliance (17), mcp-integration (6), web-dev (5), git (10), general (24), citations (3), data-serialization (2), review (11), bushcraft (4), esoteric (29), design (6), defensive (6), project-management (6), devops (13), observability (13), edge-computing (1), mlops (12), workflow-visualization (6), swarm (9), morphic (7), alchemy (4), tcg (3), intellectual-property (4), web-scraping (2), gardening (5), shiny (7), animal-training (2), mycology (2), prospecting (2), crafting (1), library-science (3), linguistics (1), travel (6), relocation (3), a2a-protocol (3), geometry (3), number-theory (3), stochastic-processes (3), theoretical-science (3), diffusion (4), hildegard (5), maintenance (5), blender (3), visualization (4), 3d-printing (3), lapidary (4), entomology (5), versioning (4), spectroscopy (6), chromatography (5), gpu-optimization (2), digital-logic (4), electromagnetism (4), levitation (3), i18n (1), synoptic (4), tensegrity (1), cli (4), open-source (2), investigation (9), memex (5), ocr (1).
 - `agents/_registry.yml` is the machine-readable catalog of all 73 agents.
 - `teams/_registry.yml` is the machine-readable catalog of all 18 teams.
-- `guides/_registry.yml` is the machine-readable catalog of all 33 guides across 5 categories.
+- `guides/_registry.yml` is the machine-readable catalog of all 34 guides across 5 categories.
 
 When adding or removing skills, agents, teams, or guides, the corresponding registry must be updated to stay in sync.
 <!-- AUTO:END:registries -->

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ A library of executable skills, specialist agents, and pre-built teams for [Clau
 ## At a Glance
 
 <!-- AUTO:START:stats -->
-- **366 skills** across 66 domains — structured, executable procedures
+- **368 skills** across 66 domains — structured, executable procedures
 - **73 agents** — specialized Claude Code personas covering development, review, compliance, and more
 - **18 teams** — predefined multi-agent compositions for complex workflows
-- **33 guides** — human-readable workflow, infrastructure, and reference documentation
-- **Interactive visualization** — force-graph explorer with 366 R-generated skill icons and 9 color themes
+- **34 guides** — human-readable workflow, infrastructure, and reference documentation
+- **Interactive visualization** — force-graph explorer with 368 R-generated skill icons and 9 color themes
 <!-- AUTO:END:stats -->
 
 ## How It Works
@@ -81,7 +81,7 @@ claude plugin install agent-almanac@local
 ```
 
 <!-- AUTO:START:plugin-discovery -->
-Auto-discovers all 366 skills and 73 agents. Teams require activation via [TeamCreate](guides/creating-agents-and-teams.md). Windows / macOS variants in the [Installation guide](guides/installation.md#phase-1--plugin-install-claude-code-native).
+Auto-discovers all 368 skills and 73 agents. Teams require activation via [TeamCreate](guides/creating-agents-and-teams.md). Windows / macOS variants in the [Installation guide](guides/installation.md#phase-1--plugin-install-claude-code-native).
 <!-- AUTO:END:plugin-discovery -->
 
 ### Path 3 — Global CLI (cross-framework)
@@ -119,10 +119,10 @@ Requires R 4.5.x or Docker; per-OS R paths in the [Installation guide](guides/in
 ```
 agent-almanac/
   .claude-plugin/  Plugin manifest for Claude Code plugin installation
-  skills/          366 executable procedures across 66 domains
+  skills/          368 executable procedures across 66 domains
   agents/          73 specialist personas
   teams/           18 multi-agent compositions with 8 coordination patterns
-  guides/          33 human-readable reference docs
+  guides/          34 human-readable reference docs
   viz/             Interactive force-graph explorer with R-generated icons
   tests/           30 test scenarios for validation
   i18n/            Translations (10 locales: de, zh-CN, ja, es, caveman-lite, caveman, caveman-ultra, wenyan-lite, wenyan, wenyan-ultra)
@@ -164,6 +164,7 @@ New here? Start with [Understanding the System](guides/understanding-the-system.
 - [Symlink Architecture](guides/symlink-architecture.md) — How symlinks enable multi-project discovery of skills, agents, and teams through Claude Code
 - [R Package Development](guides/r-package-development.md) — Package structure, testing, CRAN submission, pkgdown deployment, and renv management
 - [WSL Maintenance & Claude Code Reference](guides/wsl-maintenance.md) — WSL2 vhdx disk reclamation, Claude Code permission modes, and periodic security-scan greps for a WSL-based dev environment
+- [Protecting GitHub Repositories](guides/protecting-github-repositories.md) — Honest threat model, tiered checklist, rulesets vs branch protection, and the CI-bot bypass problem for hardening a public GitHub repo
 
 **Reference**
 
@@ -187,16 +188,16 @@ New here? Start with [Understanding the System](guides/understanding-the-system.
 <!-- AUTO:START:translations -->
 | Locale | Language | Skills | Agents | Teams | Guides | Total |
 |---|---|---|---|---|---|---|
-| de | Deutsch | 363/366 | 4/73 | 2/18 | 4/33 | 373/490 (76.1%) |
-| zh-CN | 简体中文 | 363/366 | 4/73 | 2/18 | 4/33 | 373/490 (76.1%) |
-| ja | 日本語 | 363/366 | 4/73 | 2/18 | 4/33 | 373/490 (76.1%) |
-| es | Español | 363/366 | 4/73 | 2/18 | 4/33 | 373/490 (76.1%) |
-| caveman-lite | Caveman Lite | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
-| caveman | Caveman | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
-| caveman-ultra | Caveman Ultra | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
-| wenyan-lite | 文言文輕 | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
-| wenyan | 文言文 | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
-| wenyan-ultra | 文言文極 | 352/366 | 0/73 | 0/18 | 0/33 | 352/490 (71.8%) |
+| de | Deutsch | 363/368 | 4/73 | 2/18 | 4/34 | 373/493 (75.7%) |
+| zh-CN | 简体中文 | 363/368 | 4/73 | 2/18 | 4/34 | 373/493 (75.7%) |
+| ja | 日本語 | 363/368 | 4/73 | 2/18 | 4/34 | 373/493 (75.7%) |
+| es | Español | 363/368 | 4/73 | 2/18 | 4/34 | 373/493 (75.7%) |
+| caveman-lite | Caveman Lite | 352/368 | 0/73 | 0/18 | 0/34 | 352/493 (71.4%) |
+| caveman | Caveman | 352/368 | 0/73 | 0/18 | 0/34 | 352/493 (71.4%) |
+| caveman-ultra | Caveman Ultra | 352/368 | 0/73 | 0/18 | 0/34 | 352/493 (71.4%) |
+| wenyan-lite | 文言文輕 | 352/368 | 0/73 | 0/18 | 0/34 | 352/493 (71.4%) |
+| wenyan | 文言文 | 352/368 | 0/73 | 0/18 | 0/34 | 352/493 (71.4%) |
+| wenyan-ultra | 文言文極 | 352/368 | 0/73 | 0/18 | 0/34 | 352/493 (71.4%) |
 <!-- AUTO:END:translations -->
 
 See [i18n/README.md](i18n/README.md) for the translation contributor guide.
@@ -208,7 +209,7 @@ Agent-almanac is packaged as a Claude Code plugin at `.claude-plugin/plugin.json
 <!-- AUTO:START:plugin-table -->
 | Component | Discovery | Count |
 |-----------|-----------|-------|
-| Skills | `skills/*/SKILL.md` | 366 |
+| Skills | `skills/*/SKILL.md` | 368 |
 | Agents | `agents/*.md` | 73 |
 | Teams | Bundled but not auto-discovered | 18 |
 <!-- AUTO:END:plugin-table -->

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,6 +1,6 @@
 # Guides
 
-33 guides serving as the human entry point to the agentic system — practical workflows for agents, teams, and skills, plus infrastructure setup and reference material.
+34 guides serving as the human entry point to the agentic system — practical workflows for agents, teams, and skills, plus infrastructure setup and reference material.
 
 ## Workflow
 
@@ -75,6 +75,9 @@ Package structure, testing, CRAN submission, pkgdown deployment, and renv manage
 
 ### [WSL Maintenance & Claude Code Reference](wsl-maintenance.md)
 WSL2 vhdx disk reclamation, Claude Code permission modes, and periodic security-scan greps for a WSL-based dev environment.
+
+### [Protecting GitHub Repositories](protecting-github-repositories.md)
+Honest threat model, tiered checklist, rulesets vs branch protection, and the CI-bot bypass problem for hardening a public GitHub repo.
 
 ## Reference
 

--- a/guides/_registry.yml
+++ b/guides/_registry.yml
@@ -2,7 +2,7 @@
 # Machine-readable catalog of all guide documents in this library.
 # Keep in sync with the actual guide files on disk.
 
-total_guides: 33
+total_guides: 34
 version: "1.0"
 last_updated: "2026-07-16"
 
@@ -218,6 +218,15 @@ guides:
     agents: []
     teams: []
     skills: [setup-wsl-dev-environment]
+
+  - id: protecting-github-repositories
+    path: guides/protecting-github-repositories.md
+    title: "Protecting GitHub Repositories"
+    description: "Honest threat model, tiered checklist, rulesets vs branch protection, and the CI-bot bypass problem for hardening a public GitHub repo"
+    category: infrastructure
+    agents: [security-analyst]
+    teams: []
+    skills: [assess-github-repo-security, harden-github-repo-security]
 
   # ── Reference guides ─────────────────────────────────────────────
   - id: quick-reference

--- a/guides/protecting-github-repositories.md
+++ b/guides/protecting-github-repositories.md
@@ -1,0 +1,241 @@
+---
+title: "Protecting GitHub Repositories"
+description: "Honest threat model, tiered checklist, rulesets vs branch protection, and the CI-bot bypass problem for hardening a public GitHub repo"
+category: infrastructure
+agents: [security-analyst]
+teams: []
+skills: [assess-github-repo-security, harden-github-repo-security]
+---
+
+# Protecting GitHub Repositories
+
+Hardening a GitHub repository is mostly a sequence of small, well-understood toggles — but a handful of them silently change *who* is gated, break a CI auto-commit bot, or provide a false sense of security while protecting almost nothing. This guide is the human-facing walkthrough: it explains the honest threat model behind ref protection, gives a tiered checklist you can apply in order, contrasts rulesets with classic branch protection, and walks through the single hardest problem — letting trusted automation write to a protected branch. Assess first, then harden.
+
+The running example throughout is the concrete case that trips most people up: a **public, user-owned** repository (like this one, `pjt222/agent-almanac`) whose CI **auto-commits to the default branch** via `stefanzweifel/git-auto-commit-action` using the default `GITHUB_TOKEN`. Everything here is grounded in current GitHub behavior; where a control interacts badly with that bot, it is called out explicitly.
+
+## When to Use This Guide
+
+- You own a public repository and want to harden it without breaking a working CI pipeline that pushes to `main`.
+- You are about to turn on branch protection or a ruleset and want to know what it actually stops — and what it does not.
+- Your CI bot suddenly started getting `403` on its push, or your PRs are stuck on a check that never runs.
+- You are choosing between classic branch protection and repository rulesets and want the honest tradeoffs.
+- A single-maintainer repo locked you out of merging your own pull requests.
+
+## Prerequisites
+
+- Admin access to the repository (most controls require it).
+- The [`gh` CLI](https://cli.github.com) authenticated (`gh auth status`) — every command here uses it, and the API is the source of truth over the UI.
+- A completed **assessment** of the repo's current posture — run the [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) skill *before* changing anything, so you know your baseline and do not toggle controls you already have.
+- If your CI writes to a protected branch, know which action does the push and which token it uses.
+
+## Workflow Overview
+
+The order matters. Hardening blind is how you break the bot or lock yourself out.
+
+1. **Assess** — inventory the current state with [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md): existing rules, token defaults, enabled security features, and how CI pushes.
+2. **Apply the zero-downside baseline** — the essential tier below hardens the repo *without* touching anything the bot depends on.
+3. **Decide on required checks / required PR** — this is the fork in the road. It is the single control most in tension with a direct-push bot; if you want it, you must first provision a bypass identity for the bot (see the bypass matrix).
+4. **Harden the automation path** — swap the bot to a GitHub App token and add the App as a ruleset bypass actor, or route it through a pull request.
+5. **Verify** — re-run the assessment; confirm the bot still pushes and humans/forks are still gated.
+
+The [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) skill drives steps 2–4 as an executable procedure; the [security-analyst](../agents/security-analyst.md) agent is the persona that owns this end-to-end.
+
+## The Honest Threat Model
+
+Ref protection — whether you call it a *ruleset* or a *branch protection rule* — protects **one ref**, not the repository. Internalizing that sentence prevents most false-security mistakes.
+
+**What ref protection does stop:** rewriting, force-pushing, or deleting the protected branch; landing changes to it without a pull request (if you require one); merging before required status checks pass. It gates the *history of one branch*.
+
+**What it does NOT stop:**
+
+- A write collaborator pushing to any **unprotected** branch, then adding a malicious workflow that runs with your repo's token.
+- Moving or creating **tags** (unless you also protect tags with a tag ruleset).
+- Introducing a **compromised or typo-squatted action** into a workflow that holds `contents: write`.
+- A workflow triggered on **`pull_request_target`** that checks out the PR head. This trigger runs in the *base-repo* context with secrets and a write token regardless of branch protection, so checking out untrusted code under it is a documented privilege-escalation / RCE pattern. Avoid `pull_request_target` for anything that checks out untrusted code, and never interpolate `${{ github.event.pull_request.* }}` fields directly into a `run:` shell step (route them through an intermediate `env:` var). Ref protection does nothing about this.
+- Secrets already committed (protection is about refs, not content) — that is what secret scanning and push protection are for.
+
+So a branch rule is one layer. Ruleset scope, an allowed-actions policy, fork-PR approval, and secret scanning matter as much as the branch rule itself. Treat "the branch is protected" as *necessary, not sufficient*.
+
+### The mental-model shift that catches everyone
+
+Here is the subtle part. Under **classic branch protection**, repository admins bypass the rules **by default** — the rule simply does not apply to them unless you also check *"Do not allow bypassing the above settings"* (`enforce_admins=true`). That toggle is all-or-nothing: it applies the rules to *every* admin or *no* admin, with no per-actor granularity.
+
+**Rulesets invert this default.** A ruleset applies to admins too — nobody is exempt *unless they are explicitly added to the ruleset's `bypass_actors` list*. There is no `enforce_admins` toggle on a ruleset.
+
+Porting the classic "admins can always bypass" mental model to a ruleset **silently changes who is gated**:
+
+- If you *assume* you (as admin) can always push past a ruleset, you will be surprised by a `403` — the ruleset gates you unless you added your admin role to the bypass list.
+- Conversely, if you migrate from classic BP where admins were quietly exempt, a ruleset will now enforce against those same admins — usually what you wanted, but a behavior change to be aware of.
+
+This is why the assessment step matters: the same words ("branch protection") describe two systems with opposite default answers to "does this apply to me?"
+
+## Rulesets vs Classic Branch Protection
+
+**Prefer repository rulesets. Treat classic branch protection as legacy.** GitHub's own docs position classic BP as the thing rulesets are an "alternative" to, and rulesets are the actively developed path.
+
+| Capability | Repository Ruleset | Classic Branch Protection |
+|---|---|---|
+| Availability on free public user-owned repo | Yes, fully free | Yes |
+| Multiple rules stack (most-restrictive wins) | Yes | No — one rule matches |
+| Per-actor bypass list (roles, teams, Apps, deploy keys) | Yes | No |
+| Exempt a *specific actor* from required status checks | Yes | **No — impossible** |
+| Admin exemption model | Per-actor via bypass list | All-or-nothing (`enforce_admins`) |
+| Target multiple branches / tags by pattern | Yes (`~DEFAULT_BRANCH`, `~ALL`, fnmatch) | Limited |
+| Tag protection | Tag ruleset (`target: tag`) | Deprecated 2024-08-30, auto-migrated |
+
+Two facts do the heavy lifting for the running example:
+
+- **Rulesets are free on public user-owned repos.** The docs are explicit — do not tell a free personal-public-repo owner to upgrade. (Only *private* personal repos need GitHub Pro for rulesets; org-wide rulesets and the "Evaluate" dry-run mode are the Team/Enterprise-gated pieces.)
+- **Classic BP cannot exempt any actor from required status checks.** Its push allowlist ("Restrict who can push") is organization-only and, even where available, governs *who may push*, not *who may skip checks*. GitHub staff redirected the multi-year feature request for this to rulesets. For any "let one specific bot through required checks" need — exactly the auto-commit case — rulesets are mandatory.
+
+A minimal, safe default-branch ruleset (force-push + deletion protection only — this does **not** break a direct-push bot):
+
+```bash
+gh api --method POST /repos/OWNER/REPO/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+```
+
+Inspect what exists before and after: `gh api /repos/OWNER/REPO/rulesets` and `gh api /repos/OWNER/REPO/rulesets/RULESET_ID --jq '.bypass_actors'`.
+
+## The Tiered Hardening Checklist
+
+Apply top to bottom. The **essential** tier is zero-downside and does not break the auto-commit bot; **recommended** introduces the bot-bypass decision; **advanced** is high-friction or niche.
+
+### Essential (zero-downside baseline)
+
+- **Force-push + deletion protection** via a default-branch ruleset (`non_fast_forward` + `deletion`). The cheapest, no-downside hardening; safe for a direct-push bot.
+- **Set the default `GITHUB_TOKEN` to read-only** and disable token PR approval. This is a *default*, not a hard cap, for same-repo push events — so it does not break the bot **provided the committing job grants `contents: write` back** (the next bullet). If your workflow has no explicit `permissions:` block and relied on the ambient write default, add that grant *first* or the `git-auto-commit-action` push `403`s.
+  ```bash
+  gh api --method PUT /repos/OWNER/REPO/actions/permissions/workflow \
+    -f default_workflow_permissions=read -F can_approve_pull_request_reviews=false
+  ```
+- **Least-privilege per-workflow permissions.** Top-level `permissions: {}` in the workflow YAML, then grant `contents: write` back only on the job that commits — `git-auto-commit-action` needs nothing more.
+- **Pin every action to a full 40-char commit SHA** (including `actions/checkout` and `stefanzweifel/git-auto-commit-action`), with the human-readable version in a trailing comment. A mutable tag is a supply-chain hole on a workflow that holds `contents: write`.
+  ```yaml
+  - uses: stefanzweifel/git-auto-commit-action@<40-char-sha>  # v6.x.x
+  ```
+- **Leave fork-PR approval at the public-repo default** ("Require approval for first-time contributors"). Fork `pull_request` runs already get a read-only token and no secrets.
+- **Enable Dependabot alerts + security updates + a `.github/dependabot.yml`.** Alerts and fixes are *separate* toggles — enable both, or you detect vulnerabilities and fix nothing. Include a `github-actions` ecosystem block to keep action SHAs fresh.
+  ```bash
+  gh api -X PUT repos/OWNER/REPO/vulnerability-alerts      # alerts + dependency graph
+  gh api -X PUT repos/OWNER/REPO/automated-security-fixes  # Dependabot fix PRs
+  ```
+- **Enable secret scanning + push protection** (free and usually already on for public repos); add `.github/SECURITY.md` and private vulnerability reporting (both per-repo, no org needed).
+  ```bash
+  gh api -X PATCH repos/OWNER/REPO --input - <<<'{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}'
+  gh api -X PUT repos/OWNER/REPO/private-vulnerability-reporting
+  ```
+- **Do NOT purchase GHAS / Secret Protection / Code Security for a public repo.** Secret scanning, push protection, CodeQL, and dependency review are already free on public repos; those paid products are private/org-only.
+
+### Recommended
+
+- **Add `required_status_checks`** to the ruleset with `do_not_enforce_on_create=true` and `strict_required_status_checks_policy=true`. **Critical:** this blocks the bot's direct push unless you provision a bypass (next item), *and* the checks must run on `push`, not only `pull_request`, or they never report and the push is permanently blocked.
+- **Add a `pull_request` rule** if you want a review surface. On a solo repo keep `required_approving_review_count: 0` — you cannot approve your own PR, and `>= 1` is an unsatisfiable self-lockout.
+- **Provision a GitHub App bypass for the bot** (Contents: read/write) via `actions/create-github-app-token`, pass the token to checkout + `git-auto-commit-action`, and add the App as an `Integration` bypass actor with `bypass_mode: always`. This is the correct realization of "let the bot through" once required checks/PR are on.
+- **Enable CodeQL "default setup"** (server-managed) rather than advanced setup, so no extra workflow YAML is committed into a repo that auto-commits.
+- **Set merge-method toggles to match policy** (e.g. merge-commits-only: `allow_squash_merge=false`, `allow_rebase_merge=false`) and auto-delete head branches on merge.
+- **Restrict the allowed-actions policy** to GitHub-owned + an explicit allow-list that *includes* `stefanzweifel/git-auto-commit-action` (it is not GitHub-owned; omitting it silently fails the workflow).
+
+### Advanced
+
+- **Protect release tags** with a tag ruleset (`target: tag`, e.g. `v*`).
+- **Enable the `sha_pinning_required` repo policy** (2025-08-15) — but only *after* converting every `uses:` to a full SHA, or every run fails. First confirm the field is actually exposed on a free user-owned public repo (it may be org/enterprise-gated): `gh api /repos/OWNER/REPO/actions/permissions --jq '.sha_pinning_required'`.
+- **`dismiss_stale_reviews_on_push` + require conversation resolution + `require_last_push_approval`** — only meaningful once you run human PR reviews; a chatty auto-commit bot pushing into open PRs can make them perpetually unmergeable.
+- **CODEOWNERS + `require_code_owner_review`** — low value on a solo repo (you can only list `@users`, and the sole owner cannot satisfy it as PR author).
+- **Require signed commits** — high friction: `git-auto-commit-action` pushes unsigned via git CLI, so this blocks the bot. `GITHUB_TOKEN` commits are auto-verified only via the Contents API, not `git push`.
+- **Require linear history** — mutually exclusive with a merge-commits-only policy; pick one.
+
+## Automation Through Protection: The Bot Bypass Problem
+
+This is the crux of the running example. Once you turn on required checks or require-a-PR, a push to the default branch must either satisfy the rules or come from a **bypass actor**. And here is the hard constraint that no toggle removes:
+
+> The default `GITHUB_TOKEN` / `github-actions[bot]` **cannot** be added to any bypass list and **cannot** push to a protected branch. This is by GitHub design — otherwise any collaborator could ship a workflow that writes to any branch. Any plan phrased as "just add the Actions bot to bypass" silently has no such option, and the bot's push `403`s.
+
+So to let trusted automation through, you must give it a *real* bypass-eligible identity. Ranked from best to worst:
+
+| Approach | Keeps checks enforced for humans? | Least-privilege rank | Verdict |
+|---|---|---|---|
+| PR-based (create-pull-request) with a **GitHub App token**, human clicks merge — no standing bypass | Yes | 1 | Strongest separation of duties. App token makes checks actually fire on the bot's change; no standing branch bypass. Not fully hands-off — a human merges. |
+| **GitHub App** installation token (Contents: read/write) + App as `Integration` bypass actor, `bypass_mode: always` | Yes | 2 | **Recommended default for full automation.** Repo-scoped, ~1h ephemeral, identity-scoped bypass; humans/forks/admins stay gated. Crown-jewel risk shifts to the App private key. |
+| SSH **deploy key** (write) + `DeployKey` bypass actor, push over SSH | Yes | 3 | Good narrow single-repo alternative — no App to maintain, no API scope. One private key per repo to rotate. Slightly coarser identity than an App. |
+| Bot-account **PAT** as a `User` bypass actor | Yes | 4 | Anti-pattern. Long-lived, tied to a maintained account; rotation/offboarding risk; re-triggers workflows (needs a loop guard). Stopgap only. |
+| Admin/fine-grained **PAT** + `Repository admin` role in bypass | **No** | 5 | Worst. Role-wide hole — exempts *all* admin actions including your own interactive pushes, not just automation. A leaked PAT = admin bypass-write. |
+| Add the default **`GITHUB_TOKEN`** to the bypass list | — | 6 | **Impossible.** Not a selectable actor by design; the push `403`s. |
+
+> **Verify the bypass-actor picker before you commit to this.** Historically the ruleset bypass-actor UI did **not** appear on user-owned (personal) repositories — the exact repo class this guide centers on. Before you build the App and flip on required checks / require-a-PR for real, open **Settings > Rules > Rulesets > (your ruleset) > Bypass list > Add bypass** and confirm the App is actually selectable. If it is not, the required-checks / required-PR combination is **unsatisfiable** on a personal repo — the bot's direct push cannot be let through by any means — and GitHub's documented workaround is to move the repo under a (free) **organization**, where App and role bypass actors are reliably available. This is version-dependent, so check your own repo rather than assuming the App route works.
+
+The **GitHub App** route (rank 2) is the recommended default *once you have confirmed the App is addable as a bypass actor*. Mint the token at runtime and wire it through the bot:
+
+```yaml
+- uses: actions/create-github-app-token@<sha>  # official
+  id: app-token
+  with:
+    app-id: ${{ vars.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+- uses: actions/checkout@<sha>
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+- uses: stefanzweifel/git-auto-commit-action@<sha>  # inherits the App token
+```
+
+Then add the App to the ruleset bypass list:
+
+```bash
+gh api --method PUT /repos/OWNER/REPO/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+```
+
+Two follow-ups once an App token or PAT is in play: (1) the crown-jewel secret is now the **App private key** — store it as an Actions secret, scope the App install to the single repo, and rotate; (2) unlike the default `GITHUB_TOKEN` (which suppresses downstream triggers), an App/PAT push **re-triggers** `on: push` workflows, so add a loop guard (`if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`).
+
+## Common False-Security Traps
+
+These are the beliefs that feel like security but are not.
+
+- **"Just add the github-actions bot to the ruleset bypass list."** It is not a selectable actor; the push `403`s. Use a GitHub App or deploy key identity.
+- **"Convert the bot from push to a PR to satisfy the rules."** A PR opened by the default `GITHUB_TOKEN` does **not** trigger `pull_request`/`push` workflows, so required checks never run and the PR sits on "expected/pending" forever. The PR must be created with an App token or PAT.
+- **"Required status checks mean nothing unreviewed lands."** Without a *required-PR* rule, anyone with write can still push directly if a check reports on push; and in classic BP admins bypass by default unless `enforce_admins=true`. Rulesets differ — they do not auto-exempt admins — so porting the classic mental model silently changes who is gated.
+- **"Branch protection protects the repo from a malicious collaborator."** It protects one ref. A write collaborator can push to unprotected branches, add a malicious workflow, or move tags. Scope, allowed-actions policy, and fork approval matter as much.
+- **"Public-repo secret scanning stops leaks."** Alerts fire *after* the commit; push protection blocks at push time but the auto-commit bot cannot click the interactive web bypass, so a CI-committed secret just fails the job — treat it as a real finding, not a flake. The free tier also covers provider patterns only, not every generic secret.
+- **"Require signed commits is free hardening."** It blocks the bot, which pushes unsigned via git CLI. Keeping both requires an API-based commit action.
+- **"Swap `GITHUB_TOKEN` for a broad PAT to get past protection."** A PAT is long-lived and account-wide — a strict privilege escalation over the ephemeral repo-scoped token. Prefer an App or deploy key.
+- **"Buy GHAS to secure a public repo."** Those features are already free on public repos; the paid split targets private/org repos only.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Bot push `403`s after enabling required checks / require-PR | The default `GITHUB_TOKEN` cannot be a bypass actor and cannot push to a protected branch | Provision a GitHub App token (or deploy key) and add that identity to the ruleset `bypass_actors`; pass the token to checkout + `git-auto-commit-action` |
+| Cannot add the App (or any actor) to the ruleset bypass list on a personal repo | The bypass-actor picker historically did not appear on user-owned repos; without it, required-checks/required-PR + a direct-push bot is unsatisfiable | Verify the picker under Settings > Rules > Rulesets > Bypass list; if it is absent, move the repo under a free organization (GitHub's documented workaround) or keep the default branch at the essential-tier baseline only |
+| PR opened by the bot is stuck on a check that shows "expected"/pending forever | A PR created with the default `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so checks never run | Create the PR with a GitHub App token (or PAT), which fires both event types; then the checks actually run and can gate the merge |
+| Solo maintainer cannot merge own PR | `required_approving_review_count >= 1` (or `require_code_owner_review`) — you cannot approve your own PR, and a ruleset does not auto-exempt you as admin | Set `required_approving_review_count: 0`, or add a second reviewer / a second trusted App as a bypass path |
+| New branch cannot be created; "required status check is expected" | Required checks block branch *creation* — CI cannot have run on a branch that does not exist (catch-22); or checks only trigger on `pull_request` and never report on a push | Set `do_not_enforce_on_create: true` on the `required_status_checks` rule, and make the check run on `push`, not only `pull_request` |
+| `sha_pinning_required` breaks every workflow run | The policy fails any `uses:` not pinned to a full 40-char SHA, including `actions/checkout@v4` | Convert *all* `uses:` to full commit SHAs *before* enabling the policy |
+| `allowed_actions=selected` fails the auto-commit job | `github_owned_allowed=true` still blocks `git-auto-commit-action` — it is not GitHub-owned | Add `stefanzweifel/git-auto-commit-action@*` to `patterns_allowed` |
+| Bot loops / re-triggers itself after switching to an App token | App/PAT pushes re-trigger `on: push` (default `GITHUB_TOKEN` suppressed them) | Add a loop guard: `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]` in the commit message |
+
+## Related Resources
+
+- [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) — inventory the current posture **first**; run before any hardening
+- [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) — the executable procedure that applies this checklist and the bot bypass
+- [security-analyst](../agents/security-analyst.md) — the agent persona that owns repository hardening end-to-end
+- [WSL Maintenance & Claude Code Reference](wsl-maintenance.md) — periodic security-scan greps for leaked secrets and hardcoded paths
+- [Setting Up Your Environment](setting-up-your-environment.md) — first-time environment, shell, and Claude Code setup

--- a/i18n/caveman-lite/translation_status.yml
+++ b/i18n/caveman-lite/translation_status.yml
@@ -3,8 +3,8 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 296
     stubs: 0
   agents:
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 33
+    total: 34
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 490
-    pct: 71.8
+    total: 493
+    pct: 71.4
     stale: 296
     stubs: 0

--- a/i18n/caveman-ultra/translation_status.yml
+++ b/i18n/caveman-ultra/translation_status.yml
@@ -3,8 +3,8 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 296
     stubs: 0
   agents:
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 33
+    total: 34
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 490
-    pct: 71.8
+    total: 493
+    pct: 71.4
     stale: 296
     stubs: 0

--- a/i18n/caveman/translation_status.yml
+++ b/i18n/caveman/translation_status.yml
@@ -3,8 +3,8 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 296
     stubs: 0
   agents:
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 33
+    total: 34
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 490
-    pct: 71.8
+    total: 493
+    pct: 71.4
     stale: 296
     stubs: 0

--- a/i18n/de/guides/protecting-github-repositories.md
+++ b/i18n/de/guides/protecting-github-repositories.md
@@ -1,0 +1,246 @@
+---
+title: "Protecting GitHub Repositories"
+description: "Honest threat model, tiered checklist, rulesets vs branch protection, and the CI-bot bypass problem for hardening a public GitHub repo"
+category: infrastructure
+agents: [security-analyst]
+teams: []
+skills: [assess-github-repo-security, harden-github-repo-security]
+locale: de
+source_locale: en
+source_commit: 84a3c915
+translator: "Claude + human review"
+translation_date: "2026-07-16"
+---
+
+# Protecting GitHub Repositories
+
+Hardening a GitHub repository is mostly a sequence of small, well-understood toggles — but a handful of them silently change *who* is gated, break a CI auto-commit bot, or provide a false sense of security while protecting almost nothing. This guide is the human-facing walkthrough: it explains the honest threat model behind ref protection, gives a tiered checklist you can apply in order, contrasts rulesets with classic branch protection, and walks through the single hardest problem — letting trusted automation write to a protected branch. Assess first, then harden.
+
+The running example throughout is the concrete case that trips most people up: a **public, user-owned** repository (like this one, `pjt222/agent-almanac`) whose CI **auto-commits to the default branch** via `stefanzweifel/git-auto-commit-action` using the default `GITHUB_TOKEN`. Everything here is grounded in current GitHub behavior; where a control interacts badly with that bot, it is called out explicitly.
+
+## When to Use This Guide
+
+- You own a public repository and want to harden it without breaking a working CI pipeline that pushes to `main`.
+- You are about to turn on branch protection or a ruleset and want to know what it actually stops — and what it does not.
+- Your CI bot suddenly started getting `403` on its push, or your PRs are stuck on a check that never runs.
+- You are choosing between classic branch protection and repository rulesets and want the honest tradeoffs.
+- A single-maintainer repo locked you out of merging your own pull requests.
+
+## Prerequisites
+
+- Admin access to the repository (most controls require it).
+- The [`gh` CLI](https://cli.github.com) authenticated (`gh auth status`) — every command here uses it, and the API is the source of truth over the UI.
+- A completed **assessment** of the repo's current posture — run the [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) skill *before* changing anything, so you know your baseline and do not toggle controls you already have.
+- If your CI writes to a protected branch, know which action does the push and which token it uses.
+
+## Workflow Overview
+
+The order matters. Hardening blind is how you break the bot or lock yourself out.
+
+1. **Assess** — inventory the current state with [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md): existing rules, token defaults, enabled security features, and how CI pushes.
+2. **Apply the zero-downside baseline** — the essential tier below hardens the repo *without* touching anything the bot depends on.
+3. **Decide on required checks / required PR** — this is the fork in the road. It is the single control most in tension with a direct-push bot; if you want it, you must first provision a bypass identity for the bot (see the bypass matrix).
+4. **Harden the automation path** — swap the bot to a GitHub App token and add the App as a ruleset bypass actor, or route it through a pull request.
+5. **Verify** — re-run the assessment; confirm the bot still pushes and humans/forks are still gated.
+
+The [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) skill drives steps 2–4 as an executable procedure; the [security-analyst](../agents/security-analyst.md) agent is the persona that owns this end-to-end.
+
+## The Honest Threat Model
+
+Ref protection — whether you call it a *ruleset* or a *branch protection rule* — protects **one ref**, not the repository. Internalizing that sentence prevents most false-security mistakes.
+
+**What ref protection does stop:** rewriting, force-pushing, or deleting the protected branch; landing changes to it without a pull request (if you require one); merging before required status checks pass. It gates the *history of one branch*.
+
+**What it does NOT stop:**
+
+- A write collaborator pushing to any **unprotected** branch, then adding a malicious workflow that runs with your repo's token.
+- Moving or creating **tags** (unless you also protect tags with a tag ruleset).
+- Introducing a **compromised or typo-squatted action** into a workflow that holds `contents: write`.
+- A workflow triggered on **`pull_request_target`** that checks out the PR head. This trigger runs in the *base-repo* context with secrets and a write token regardless of branch protection, so checking out untrusted code under it is a documented privilege-escalation / RCE pattern. Avoid `pull_request_target` for anything that checks out untrusted code, and never interpolate `${{ github.event.pull_request.* }}` fields directly into a `run:` shell step (route them through an intermediate `env:` var). Ref protection does nothing about this.
+- Secrets already committed (protection is about refs, not content) — that is what secret scanning and push protection are for.
+
+So a branch rule is one layer. Ruleset scope, an allowed-actions policy, fork-PR approval, and secret scanning matter as much as the branch rule itself. Treat "the branch is protected" as *necessary, not sufficient*.
+
+### The mental-model shift that catches everyone
+
+Here is the subtle part. Under **classic branch protection**, repository admins bypass the rules **by default** — the rule simply does not apply to them unless you also check *"Do not allow bypassing the above settings"* (`enforce_admins=true`). That toggle is all-or-nothing: it applies the rules to *every* admin or *no* admin, with no per-actor granularity.
+
+**Rulesets invert this default.** A ruleset applies to admins too — nobody is exempt *unless they are explicitly added to the ruleset's `bypass_actors` list*. There is no `enforce_admins` toggle on a ruleset.
+
+Porting the classic "admins can always bypass" mental model to a ruleset **silently changes who is gated**:
+
+- If you *assume* you (as admin) can always push past a ruleset, you will be surprised by a `403` — the ruleset gates you unless you added your admin role to the bypass list.
+- Conversely, if you migrate from classic BP where admins were quietly exempt, a ruleset will now enforce against those same admins — usually what you wanted, but a behavior change to be aware of.
+
+This is why the assessment step matters: the same words ("branch protection") describe two systems with opposite default answers to "does this apply to me?"
+
+## Rulesets vs Classic Branch Protection
+
+**Prefer repository rulesets. Treat classic branch protection as legacy.** GitHub's own docs position classic BP as the thing rulesets are an "alternative" to, and rulesets are the actively developed path.
+
+| Capability | Repository Ruleset | Classic Branch Protection |
+|---|---|---|
+| Availability on free public user-owned repo | Yes, fully free | Yes |
+| Multiple rules stack (most-restrictive wins) | Yes | No — one rule matches |
+| Per-actor bypass list (roles, teams, Apps, deploy keys) | Yes | No |
+| Exempt a *specific actor* from required status checks | Yes | **No — impossible** |
+| Admin exemption model | Per-actor via bypass list | All-or-nothing (`enforce_admins`) |
+| Target multiple branches / tags by pattern | Yes (`~DEFAULT_BRANCH`, `~ALL`, fnmatch) | Limited |
+| Tag protection | Tag ruleset (`target: tag`) | Deprecated 2024-08-30, auto-migrated |
+
+Two facts do the heavy lifting for the running example:
+
+- **Rulesets are free on public user-owned repos.** The docs are explicit — do not tell a free personal-public-repo owner to upgrade. (Only *private* personal repos need GitHub Pro for rulesets; org-wide rulesets and the "Evaluate" dry-run mode are the Team/Enterprise-gated pieces.)
+- **Classic BP cannot exempt any actor from required status checks.** Its push allowlist ("Restrict who can push") is organization-only and, even where available, governs *who may push*, not *who may skip checks*. GitHub staff redirected the multi-year feature request for this to rulesets. For any "let one specific bot through required checks" need — exactly the auto-commit case — rulesets are mandatory.
+
+A minimal, safe default-branch ruleset (force-push + deletion protection only — this does **not** break a direct-push bot):
+
+```bash
+gh api --method POST /repos/OWNER/REPO/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+```
+
+Inspect what exists before and after: `gh api /repos/OWNER/REPO/rulesets` and `gh api /repos/OWNER/REPO/rulesets/RULESET_ID --jq '.bypass_actors'`.
+
+## The Tiered Hardening Checklist
+
+Apply top to bottom. The **essential** tier is zero-downside and does not break the auto-commit bot; **recommended** introduces the bot-bypass decision; **advanced** is high-friction or niche.
+
+### Essential (zero-downside baseline)
+
+- **Force-push + deletion protection** via a default-branch ruleset (`non_fast_forward` + `deletion`). The cheapest, no-downside hardening; safe for a direct-push bot.
+- **Set the default `GITHUB_TOKEN` to read-only** and disable token PR approval. This is a *default*, not a hard cap, for same-repo push events — so it does not break the bot **provided the committing job grants `contents: write` back** (the next bullet). If your workflow has no explicit `permissions:` block and relied on the ambient write default, add that grant *first* or the `git-auto-commit-action` push `403`s.
+  ```bash
+  gh api --method PUT /repos/OWNER/REPO/actions/permissions/workflow \
+    -f default_workflow_permissions=read -F can_approve_pull_request_reviews=false
+  ```
+- **Least-privilege per-workflow permissions.** Top-level `permissions: {}` in the workflow YAML, then grant `contents: write` back only on the job that commits — `git-auto-commit-action` needs nothing more.
+- **Pin every action to a full 40-char commit SHA** (including `actions/checkout` and `stefanzweifel/git-auto-commit-action`), with the human-readable version in a trailing comment. A mutable tag is a supply-chain hole on a workflow that holds `contents: write`.
+  ```yaml
+  - uses: stefanzweifel/git-auto-commit-action@<40-char-sha>  # v6.x.x
+  ```
+- **Leave fork-PR approval at the public-repo default** ("Require approval for first-time contributors"). Fork `pull_request` runs already get a read-only token and no secrets.
+- **Enable Dependabot alerts + security updates + a `.github/dependabot.yml`.** Alerts and fixes are *separate* toggles — enable both, or you detect vulnerabilities and fix nothing. Include a `github-actions` ecosystem block to keep action SHAs fresh.
+  ```bash
+  gh api -X PUT repos/OWNER/REPO/vulnerability-alerts      # alerts + dependency graph
+  gh api -X PUT repos/OWNER/REPO/automated-security-fixes  # Dependabot fix PRs
+  ```
+- **Enable secret scanning + push protection** (free and usually already on for public repos); add `.github/SECURITY.md` and private vulnerability reporting (both per-repo, no org needed).
+  ```bash
+  gh api -X PATCH repos/OWNER/REPO --input - <<<'{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}'
+  gh api -X PUT repos/OWNER/REPO/private-vulnerability-reporting
+  ```
+- **Do NOT purchase GHAS / Secret Protection / Code Security for a public repo.** Secret scanning, push protection, CodeQL, and dependency review are already free on public repos; those paid products are private/org-only.
+
+### Recommended
+
+- **Add `required_status_checks`** to the ruleset with `do_not_enforce_on_create=true` and `strict_required_status_checks_policy=true`. **Critical:** this blocks the bot's direct push unless you provision a bypass (next item), *and* the checks must run on `push`, not only `pull_request`, or they never report and the push is permanently blocked.
+- **Add a `pull_request` rule** if you want a review surface. On a solo repo keep `required_approving_review_count: 0` — you cannot approve your own PR, and `>= 1` is an unsatisfiable self-lockout.
+- **Provision a GitHub App bypass for the bot** (Contents: read/write) via `actions/create-github-app-token`, pass the token to checkout + `git-auto-commit-action`, and add the App as an `Integration` bypass actor with `bypass_mode: always`. This is the correct realization of "let the bot through" once required checks/PR are on.
+- **Enable CodeQL "default setup"** (server-managed) rather than advanced setup, so no extra workflow YAML is committed into a repo that auto-commits.
+- **Set merge-method toggles to match policy** (e.g. merge-commits-only: `allow_squash_merge=false`, `allow_rebase_merge=false`) and auto-delete head branches on merge.
+- **Restrict the allowed-actions policy** to GitHub-owned + an explicit allow-list that *includes* `stefanzweifel/git-auto-commit-action` (it is not GitHub-owned; omitting it silently fails the workflow).
+
+### Advanced
+
+- **Protect release tags** with a tag ruleset (`target: tag`, e.g. `v*`).
+- **Enable the `sha_pinning_required` repo policy** (2025-08-15) — but only *after* converting every `uses:` to a full SHA, or every run fails. First confirm the field is actually exposed on a free user-owned public repo (it may be org/enterprise-gated): `gh api /repos/OWNER/REPO/actions/permissions --jq '.sha_pinning_required'`.
+- **`dismiss_stale_reviews_on_push` + require conversation resolution + `require_last_push_approval`** — only meaningful once you run human PR reviews; a chatty auto-commit bot pushing into open PRs can make them perpetually unmergeable.
+- **CODEOWNERS + `require_code_owner_review`** — low value on a solo repo (you can only list `@users`, and the sole owner cannot satisfy it as PR author).
+- **Require signed commits** — high friction: `git-auto-commit-action` pushes unsigned via git CLI, so this blocks the bot. `GITHUB_TOKEN` commits are auto-verified only via the Contents API, not `git push`.
+- **Require linear history** — mutually exclusive with a merge-commits-only policy; pick one.
+
+## Automation Through Protection: The Bot Bypass Problem
+
+This is the crux of the running example. Once you turn on required checks or require-a-PR, a push to the default branch must either satisfy the rules or come from a **bypass actor**. And here is the hard constraint that no toggle removes:
+
+> The default `GITHUB_TOKEN` / `github-actions[bot]` **cannot** be added to any bypass list and **cannot** push to a protected branch. This is by GitHub design — otherwise any collaborator could ship a workflow that writes to any branch. Any plan phrased as "just add the Actions bot to bypass" silently has no such option, and the bot's push `403`s.
+
+So to let trusted automation through, you must give it a *real* bypass-eligible identity. Ranked from best to worst:
+
+| Approach | Keeps checks enforced for humans? | Least-privilege rank | Verdict |
+|---|---|---|---|
+| PR-based (create-pull-request) with a **GitHub App token**, human clicks merge — no standing bypass | Yes | 1 | Strongest separation of duties. App token makes checks actually fire on the bot's change; no standing branch bypass. Not fully hands-off — a human merges. |
+| **GitHub App** installation token (Contents: read/write) + App as `Integration` bypass actor, `bypass_mode: always` | Yes | 2 | **Recommended default for full automation.** Repo-scoped, ~1h ephemeral, identity-scoped bypass; humans/forks/admins stay gated. Crown-jewel risk shifts to the App private key. |
+| SSH **deploy key** (write) + `DeployKey` bypass actor, push over SSH | Yes | 3 | Good narrow single-repo alternative — no App to maintain, no API scope. One private key per repo to rotate. Slightly coarser identity than an App. |
+| Bot-account **PAT** as a `User` bypass actor | Yes | 4 | Anti-pattern. Long-lived, tied to a maintained account; rotation/offboarding risk; re-triggers workflows (needs a loop guard). Stopgap only. |
+| Admin/fine-grained **PAT** + `Repository admin` role in bypass | **No** | 5 | Worst. Role-wide hole — exempts *all* admin actions including your own interactive pushes, not just automation. A leaked PAT = admin bypass-write. |
+| Add the default **`GITHUB_TOKEN`** to the bypass list | — | 6 | **Impossible.** Not a selectable actor by design; the push `403`s. |
+
+> **Verify the bypass-actor picker before you commit to this.** Historically the ruleset bypass-actor UI did **not** appear on user-owned (personal) repositories — the exact repo class this guide centers on. Before you build the App and flip on required checks / require-a-PR for real, open **Settings > Rules > Rulesets > (your ruleset) > Bypass list > Add bypass** and confirm the App is actually selectable. If it is not, the required-checks / required-PR combination is **unsatisfiable** on a personal repo — the bot's direct push cannot be let through by any means — and GitHub's documented workaround is to move the repo under a (free) **organization**, where App and role bypass actors are reliably available. This is version-dependent, so check your own repo rather than assuming the App route works.
+
+The **GitHub App** route (rank 2) is the recommended default *once you have confirmed the App is addable as a bypass actor*. Mint the token at runtime and wire it through the bot:
+
+```yaml
+- uses: actions/create-github-app-token@<sha>  # official
+  id: app-token
+  with:
+    app-id: ${{ vars.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+- uses: actions/checkout@<sha>
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+- uses: stefanzweifel/git-auto-commit-action@<sha>  # inherits the App token
+```
+
+Then add the App to the ruleset bypass list:
+
+```bash
+gh api --method PUT /repos/OWNER/REPO/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+```
+
+Two follow-ups once an App token or PAT is in play: (1) the crown-jewel secret is now the **App private key** — store it as an Actions secret, scope the App install to the single repo, and rotate; (2) unlike the default `GITHUB_TOKEN` (which suppresses downstream triggers), an App/PAT push **re-triggers** `on: push` workflows, so add a loop guard (`if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`).
+
+## Common False-Security Traps
+
+These are the beliefs that feel like security but are not.
+
+- **"Just add the github-actions bot to the ruleset bypass list."** It is not a selectable actor; the push `403`s. Use a GitHub App or deploy key identity.
+- **"Convert the bot from push to a PR to satisfy the rules."** A PR opened by the default `GITHUB_TOKEN` does **not** trigger `pull_request`/`push` workflows, so required checks never run and the PR sits on "expected/pending" forever. The PR must be created with an App token or PAT.
+- **"Required status checks mean nothing unreviewed lands."** Without a *required-PR* rule, anyone with write can still push directly if a check reports on push; and in classic BP admins bypass by default unless `enforce_admins=true`. Rulesets differ — they do not auto-exempt admins — so porting the classic mental model silently changes who is gated.
+- **"Branch protection protects the repo from a malicious collaborator."** It protects one ref. A write collaborator can push to unprotected branches, add a malicious workflow, or move tags. Scope, allowed-actions policy, and fork approval matter as much.
+- **"Public-repo secret scanning stops leaks."** Alerts fire *after* the commit; push protection blocks at push time but the auto-commit bot cannot click the interactive web bypass, so a CI-committed secret just fails the job — treat it as a real finding, not a flake. The free tier also covers provider patterns only, not every generic secret.
+- **"Require signed commits is free hardening."** It blocks the bot, which pushes unsigned via git CLI. Keeping both requires an API-based commit action.
+- **"Swap `GITHUB_TOKEN` for a broad PAT to get past protection."** A PAT is long-lived and account-wide — a strict privilege escalation over the ephemeral repo-scoped token. Prefer an App or deploy key.
+- **"Buy GHAS to secure a public repo."** Those features are already free on public repos; the paid split targets private/org repos only.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Bot push `403`s after enabling required checks / require-PR | The default `GITHUB_TOKEN` cannot be a bypass actor and cannot push to a protected branch | Provision a GitHub App token (or deploy key) and add that identity to the ruleset `bypass_actors`; pass the token to checkout + `git-auto-commit-action` |
+| Cannot add the App (or any actor) to the ruleset bypass list on a personal repo | The bypass-actor picker historically did not appear on user-owned repos; without it, required-checks/required-PR + a direct-push bot is unsatisfiable | Verify the picker under Settings > Rules > Rulesets > Bypass list; if it is absent, move the repo under a free organization (GitHub's documented workaround) or keep the default branch at the essential-tier baseline only |
+| PR opened by the bot is stuck on a check that shows "expected"/pending forever | A PR created with the default `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so checks never run | Create the PR with a GitHub App token (or PAT), which fires both event types; then the checks actually run and can gate the merge |
+| Solo maintainer cannot merge own PR | `required_approving_review_count >= 1` (or `require_code_owner_review`) — you cannot approve your own PR, and a ruleset does not auto-exempt you as admin | Set `required_approving_review_count: 0`, or add a second reviewer / a second trusted App as a bypass path |
+| New branch cannot be created; "required status check is expected" | Required checks block branch *creation* — CI cannot have run on a branch that does not exist (catch-22); or checks only trigger on `pull_request` and never report on a push | Set `do_not_enforce_on_create: true` on the `required_status_checks` rule, and make the check run on `push`, not only `pull_request` |
+| `sha_pinning_required` breaks every workflow run | The policy fails any `uses:` not pinned to a full 40-char SHA, including `actions/checkout@v4` | Convert *all* `uses:` to full commit SHAs *before* enabling the policy |
+| `allowed_actions=selected` fails the auto-commit job | `github_owned_allowed=true` still blocks `git-auto-commit-action` — it is not GitHub-owned | Add `stefanzweifel/git-auto-commit-action@*` to `patterns_allowed` |
+| Bot loops / re-triggers itself after switching to an App token | App/PAT pushes re-trigger `on: push` (default `GITHUB_TOKEN` suppressed them) | Add a loop guard: `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]` in the commit message |
+
+## Related Resources
+
+- [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) — inventory the current posture **first**; run before any hardening
+- [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) — the executable procedure that applies this checklist and the bot bypass
+- [security-analyst](../agents/security-analyst.md) — the agent persona that owns repository hardening end-to-end
+- [WSL Maintenance & Claude Code Reference](wsl-maintenance.md) — periodic security-scan greps for leaked secrets and hardcoded paths
+- [Setting Up Your Environment](setting-up-your-environment.md) — first-time environment, shell, and Claude Code setup

--- a/i18n/de/skills/assess-github-repo-security/SKILL.md
+++ b/i18n/de/skills/assess-github-repo-security/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: assess-github-repo-security
+description: >
+  Read-only audit of a GitHub repository's security posture. Gathers ref
+  protection (rulesets AND classic branch protection), Actions token
+  permissions, code and supply-chain features (Dependabot, secret
+  scanning, push protection, CodeQL), and repo hygiene toggles via
+  `gh api`, then classifies findings against essential / recommended /
+  advanced tiers into a PASS/GAP report. Makes NO changes. Use when
+  reviewing a repo before open-sourcing or a release, auditing a public
+  user-owned repo whose CI auto-commits to the default branch, verifying
+  a hardening change actually took effect, or producing a baseline
+  security posture report for a repository.
+license: MIT
+allowed-tools: Read Bash Grep
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: intermediate
+  language: multi
+  tags: github, security, audit, rulesets, branch-protection, dependabot, actions
+  locale: de
+  source_locale: en
+  source_commit: 84a3c915
+  translator: "Claude + human review"
+  translation_date: "2026-07-16"
+---
+
+# Assess GitHub Repository Security
+
+Audit a GitHub repository's security posture, read-only, and classify it
+against tiered best practices. This skill only reads — it never enables,
+disables, or changes any setting. Remediation is a separate concern (see
+`harden-github-repo-security`).
+
+## When to Use
+
+- Reviewing a repo before open-sourcing it or cutting a release
+- Auditing a public, user-owned repo whose CI auto-commits to the default
+  branch (e.g. via `stefanzweifel/git-auto-commit-action` + the default
+  `GITHUB_TOKEN`)
+- Verifying that a hardening change actually took effect
+- Producing a baseline posture report to track over time
+
+## Inputs
+
+- **Required**: Target repository as `OWNER/REPO`
+- **Required**: `gh` CLI authenticated with an account that has the
+  **admin repository role** on the target repo (some endpoints 403
+  otherwise). This is a role requirement, not a need for a broad
+  write-capable token: a fine-grained, single-repo PAT scoped to
+  read-only Administration / Actions / Secret-scanning permissions
+  satisfies the same admin check with far less blast radius if the
+  audit credential is ever leaked or reused in automation
+- **Optional**: Branch to check for classic protection (defaults to the
+  repo's `default_branch`)
+- **Optional**: `security_events` token scope — needed only to count open
+  Dependabot alerts; the rest works without it
+
+Set a shorthand for every command below:
+
+```bash
+R="OWNER/REPO"   # e.g. pjt222/agent-almanac
+```
+
+## Procedure
+
+### Step 1: Preflight — auth and admin
+
+Confirm the CLI is authenticated and the account has admin on the repo.
+Non-admins get partial data (403 on rulesets, Actions, and security
+endpoints), which silently understates the posture.
+
+```bash
+gh auth status
+gh api "repos/$R" --jq '{full_name, admin: .permissions.admin, visibility}'
+```
+
+**Expected:** `gh auth status` shows a logged-in account; the second call
+prints `admin: true`.
+
+**On failure:** If not authenticated, run `gh auth login` (or set
+`GH_TOKEN`). If `admin: false`, stop and note in the report that findings
+are **incomplete** — a non-admin cannot read ruleset internals or Actions
+permissions, so absence of a control cannot be distinguished from lack of
+access.
+
+### Step 2: Repo basics — visibility, merge toggles, collaborators
+
+```bash
+gh api "repos/$R" --jq '{visibility, private, allow_forking,
+  default_branch, allow_merge_commit, allow_squash_merge,
+  allow_rebase_merge, delete_branch_on_merge}'
+
+# Direct collaborators and their effective role
+gh api "repos/$R/collaborators?affiliation=direct" \
+  --jq '.[] | {login, role_name}'
+```
+
+**Expected:** JSON for the repo toggles plus one line per direct
+collaborator with `role_name` (`admin`/`maintain`/`write`/`triage`/`read`).
+
+**On failure:** A 403 on `collaborators` means the token lacks admin; note
+it and continue. Record `visibility` — it changes which features are
+**free**: on **public** repos secret scanning, push protection, CodeQL,
+and dependency review are free; the paid GHAS/Secret Protection products
+are private/org-only, so their absence on a public repo is not a gap.
+
+### Step 3: Ref protection — check rulesets AND classic (both)
+
+A repo can be protected by a **ruleset**, by **classic branch
+protection**, by both, or by neither. Rulesets are the actively-developed
+path and are free on public user-owned repos. You MUST check both — a repo
+with only a ruleset returns 404 on the classic endpoint and vice versa.
+
+```bash
+b=$(gh api "repos/$R" --jq '.default_branch')
+
+# (a) Rulesets — list, then inspect each active one's rules + bypass list
+gh api "repos/$R/rulesets" --jq '.[] | {id, name, enforcement, target}'
+# For each id from above:
+#   gh api "repos/$R/rulesets/<id>" \
+#     --jq '{name, enforcement,
+#            rules: [.rules[].type],
+#            bypass: [.bypass_actors[] | {actor_type, bypass_mode}]}'
+
+# (b) Classic branch protection on the default branch (404 = none)
+gh api -i "repos/$R/branches/$b/protection" 2>/dev/null | head -1
+gh api "repos/$R/branches/$b/protection" \
+  --jq '{required_status_checks: .required_status_checks.checks,
+         strict: .required_status_checks.strict,
+         enforce_admins: .enforce_admins.enabled,
+         required_reviews: .required_pull_request_reviews.required_approving_review_count,
+         linear: .required_linear_history.enabled,
+         signatures: .required_signatures.enabled,
+         allow_force_pushes: .allow_force_pushes.enabled,
+         allow_deletions: .allow_deletions.enabled}' 2>/dev/null \
+  || echo "no classic branch protection"
+```
+
+**Expected:** Either a ruleset with rules such as `deletion`,
+`non_fast_forward`, `pull_request`, `required_status_checks`, or a classic
+protection object, or an explicit "none" from both.
+
+**On failure:** A `404` on either endpoint means that mechanism is **not
+configured** — it is a valid data point, not an error; record "none" for
+that mechanism. Note the rule set from the ruleset `rules[].type` list and
+the `bypass_actors`. Remember: the default `GITHUB_TOKEN` /
+`github-actions[bot]` can never be a bypass actor by design — if the repo
+auto-commits AND has `required_status_checks`/`pull_request` rules with no
+`Integration` (GitHub App) or `DeployKey` bypass actor, flag that the bot
+push must be 403ing (a real finding).
+
+### Step 4: Actions security — token defaults and PR approval
+
+```bash
+# Actions enablement + allowed-actions policy (+ SHA-pinning policy)
+gh api "repos/$R/actions/permissions" \
+  --jq '{enabled, allowed_actions, sha_pinning_required}'
+
+# Default GITHUB_TOKEN permissions + can-the-bot-approve-PRs
+gh api "repos/$R/actions/permissions/workflow" \
+  --jq '{default_workflow_permissions, can_approve_pull_request_reviews}'
+```
+
+**Expected:** `default_workflow_permissions` is `read` (hardened) or
+`write` (permissive default), and `can_approve_pull_request_reviews` is
+`false` (hardened) or `true` (a review-bypass vector).
+
+**On failure:** 403 means non-admin — note it. If
+`allowed_actions` is `all`, any action can run (looser); `selected` with a
+pinned allow-list is tighter — but note that `selected` +
+`github_owned_allowed` still blocks non-GitHub actions like
+`stefanzweifel/git-auto-commit-action` unless explicitly allow-listed.
+`sha_pinning_required` may be absent/`null` on repos that never set the
+2025-08 policy — record as "not enforced". Per-workflow `permissions:`
+blocks live in the YAML, not the API; note that the API shows only the
+repo **default**, which is a default (not a cap) for same-repo push
+events.
+
+### Step 5: Code and supply-chain features
+
+```bash
+# Dependabot alerts + dependency graph (204 = ON, 404 = OFF)
+gh api -i "repos/$R/vulnerability-alerts" 2>/dev/null | head -1
+
+# Dependabot security updates (auto fix PRs) — separate toggle
+gh api "repos/$R/automated-security-fixes" \
+  --jq '{enabled, paused}' 2>/dev/null || echo "automated-security-fixes: off/unavailable"
+
+# Secret scanning + push protection status (security_and_analysis has NO
+# code-scanning field — CodeQL is probed separately below)
+gh api "repos/$R" --jq '.security_and_analysis'
+
+# CodeQL code scanning — default setup state (its own endpoint)
+gh api "repos/$R/code-scanning/default-setup" --jq '.state' 2>/dev/null \
+  || echo "code-scanning default setup: not configured / no access"
+
+# Dependabot version updates config present?
+gh api -i "repos/$R/contents/.github/dependabot.yml" 2>/dev/null | head -1
+
+# SECURITY.md — GitHub auto-detects it at root, docs/, OR .github/.
+# Present if ANY of the three returns 200; only a GAP if all three 404.
+for p in SECURITY.md docs/SECURITY.md .github/SECURITY.md; do
+  echo "$p: $(gh api -i "repos/$R/contents/$p" 2>/dev/null | head -1)"
+done
+
+# Private vulnerability reporting — status is a 200 body {"enabled": bool},
+# NOT a 204/404 toggle, so read the field directly.
+gh api "repos/$R/private-vulnerability-reporting" --jq '.enabled' 2>/dev/null \
+  || echo "PVR: not accessible"
+
+# Open Dependabot alert count — needs security_events scope; may 403
+gh api "repos/$R/dependabot/alerts?state=open" --jq 'length' 2>/dev/null \
+  || echo "dependabot/alerts: 403 (needs security_events scope) — skipped"
+```
+
+**Expected:** `vulnerability-alerts` → `HTTP/2.0 204` when enabled;
+`security_and_analysis` shows `secret_scanning.status` and
+`secret_scanning_push_protection.status` as `enabled` on a hardened public
+repo; `code-scanning/default-setup` `.state` is `configured` when CodeQL
+default setup is on; `automated-security-fixes` → `enabled: true`; the
+`dependabot.yml` probe returns `200` when present; at least one of the
+three SECURITY.md paths returns `200` when a policy file exists;
+`private-vulnerability-reporting` `.enabled` prints `true` when PVR is on.
+
+**On failure:** `vulnerability-alerts` returning `404` = Dependabot alerts
+OFF (a gap). Remember **alerts != fixes**: alerts on with
+`automated-security-fixes` off means nothing is auto-remediated — flag
+both separately. On **public** repos `secret_scanning` is usually already
+`enabled` by default; if `security_and_analysis` omits the field entirely,
+treat it as advisory (public-repo default on) but note the API did not
+confirm it. `code-scanning/default-setup` `404`/non-`configured` = CodeQL
+default setup not enabled (a recommended-tier gap on a public repo, where
+code scanning is free). For SECURITY.md, record a GAP **only if all three
+paths 404** — a `200` on root, `docs/`, or `.github/` all count as
+present. `private-vulnerability-reporting` empty/`false` = PVR off; a
+non-JSON or error response = not accessible. `dependabot/alerts` 403 is
+expected without `security_events` scope — record "not assessed", not "0".
+
+### Step 6: Produce the tiered PASS/GAP report
+
+Classify every gathered fact into three tiers and mark **PASS** (control
+present), **GAP** (control absent), or **N/A** (not applicable, e.g. a paid
+private-repo feature on a public repo). Distinguish a **required** check
+from an **advisory** one: a status check that runs but is not listed in the
+ruleset's `required_status_checks` does not gate anything — it is advisory
+only.
+
+**Interpret the solo-maintainer lockout.** Cross-reference the Step 2
+direct-collaborator count with the Step 3 `required_approving_review_count`.
+On a single-maintainer repo, `required_approving_review_count >= 1` (and
+`require_code_owner_review` with a sole owner) is **unsatisfiable** — you
+cannot approve your own PR — so on an auto-commit repo it is a self-lockout
+/ functional breakage, **not** a PASS. Flag it as a GAP-with-caveat, and
+note that a **ruleset** (unlike classic branch protection's `enforce_admins`)
+does **not** auto-exempt the admin: the sole maintainer stays blocked unless
+explicitly added to the ruleset `bypass_actors`.
+
+**Do not publish the raw report into the audited repo.** The PASS/GAP list
+enumerates exact, admin-only-visible gaps (no ruleset, `GITHUB_TOKEN` can
+approve PRs, no push protection) — a pre-remediation vulnerability roadmap.
+While any GAP is open, keep the findings **local/private** (a gitignored
+file, a private gist, or a draft GitHub Security Advisory); never commit it
+into the public repo being audited (contrast `security-audit-codebase`,
+which writes `SECURITY_AUDIT_REPORT.md` into the project root — do NOT copy
+that pattern here). Redact ruleset / App ID / bypass-actor identifiers
+before any public write.
+
+```text
+# GitHub Repo Security Assessment — OWNER/REPO
+Date: YYYY-MM-DD   Visibility: public   Auditor role: admin
+
+## Essential
+- [PASS] Ruleset with deletion + non_fast_forward on default branch
+- [GAP]  default_workflow_permissions = write (should be read)
+- [PASS] can_approve_pull_request_reviews = false
+- [GAP]  actions/checkout pinned to @v4 tag, not a 40-char SHA
+- [PASS] Dependabot alerts (204) + security updates (enabled)
+- [GAP]  No .github/dependabot.yml (version updates off — keeps
+         github-actions action pins fresh; essential supply-chain hygiene)
+- [PASS] Secret scanning + push protection enabled
+
+## Recommended
+- [N/A]  required_status_checks — none (no CI gate configured)
+- [PASS] CodeQL default setup: configured
+- [PASS] SECURITY.md present (.github/) + PVR enabled
+
+## Advanced
+- [GAP]  sha_pinning_required: not enforced
+- [N/A]  Required signed commits — would block the auto-commit bot
+- [N/A]  Paid GHAS / Secret Protection — public repo, features free
+
+## Notes
+- Auto-commit bot: ruleset has NO App/DeployKey bypass actor; if
+  required_status_checks were added the github-actions[bot] push would 403.
+- Solo maintainer (1 direct collaborator): required_approving_review_count
+  is 0 — correct; any value >= 1 would be an unsatisfiable self-lockout and
+  a ruleset would NOT auto-exempt the admin.
+- Dependabot open alerts: not assessed (token lacks security_events).
+- This report is kept local/private — not committed into the audited repo
+  while GAPs remain open.
+```
+
+**Expected:** A written report with every fact placed in a tier and
+marked PASS / GAP / N/A, plus a Notes section for auth gaps, advisory-only
+checks, and the auto-commit-bot bypass interaction.
+
+**On failure:** If some endpoints 403'd, still emit the report but mark
+those rows "not assessed" and state the missing scope/role at the top —
+never record an unreadable control as a GAP (absence of access is not
+absence of the control).
+
+## Validation
+
+- [ ] `gh auth status` confirmed and admin on the repo verified (or the
+      report is explicitly flagged incomplete)
+- [ ] `visibility` recorded (drives which features are free vs N/A)
+- [ ] BOTH rulesets AND classic branch protection were queried (not just one)
+- [ ] Actions `permissions` and `permissions/workflow` both read
+- [ ] Dependabot alerts, security updates, secret scanning, and push
+      protection each checked as **separate** toggles
+- [ ] CodeQL default setup queried via `code-scanning/default-setup`
+      (not inferred from `security_and_analysis`, which has no such field)
+- [ ] SECURITY.md checked at all three auto-detected paths (root, `docs/`,
+      `.github/`) — GAP only if all three 404
+- [ ] Private vulnerability reporting read from the `.enabled` body field
+      (not a 204/404 toggle)
+- [ ] Solo-maintainer lockout interpreted: collaborator count cross-referenced
+      with `required_approving_review_count`
+- [ ] Every finding is tiered and marked PASS / GAP / N/A
+- [ ] Report kept local/private while GAPs are open — NOT committed into
+      the audited public repo
+- [ ] No setting was changed — this audit is strictly read-only
+
+## Common Pitfalls
+
+- **Checking only rulesets or only classic protection**: They are
+  independent mechanisms. A repo protected by a ruleset returns `404` on
+  `branches/{b}/protection`; concluding "unprotected" from that alone is
+  wrong. Always query both.
+- **Some endpoints 403 without security scope/admin**: `dependabot/alerts`
+  needs `security_events`; rulesets and Actions permissions need admin. A
+  403 is "not assessed", not a GAP — recording it as a gap fabricates a
+  finding.
+- **A green check that is not REQUIRED is advisory only**: A CI job that
+  runs and passes gates nothing unless its context is in the ruleset's
+  `required_status_checks`. Do not report a running check as a protective
+  control.
+- **Alerts != fixes**: Dependabot **alerts** (`vulnerability-alerts`, 204)
+  only detect; **security updates** (`automated-security-fixes`) open the
+  fix PRs. Enabling one does not enable the other — assess both.
+- **Treating paid-feature absence as a gap on a public repo**: Secret
+  scanning, push protection, CodeQL, and dependency review are free on
+  public repos; GHAS / Secret Protection / Code Security are private/org
+  products. Their absence on a public repo is N/A, not a gap.
+- **Misreading the auto-commit-bot bypass**: The default `GITHUB_TOKEN` /
+  `github-actions[bot]` can never be a ruleset bypass actor. If a repo
+  auto-commits to a branch that has `required_status_checks` or a
+  `pull_request` rule with no `Integration`/`DeployKey` bypass actor, the
+  bot push is being rejected — surface it as a real finding.
+- **Reading the API default as a hard cap**: `default_workflow_permissions`
+  is the repo default; per-job `permissions:` in the workflow YAML can
+  raise or drop it for same-repo events. The API cannot show the effective
+  per-workflow grant — note that limitation.
+- **Probing SECURITY.md at only one path**: GitHub auto-detects the policy
+  at the repo root, `docs/`, OR `.github/`. Checking only one path and
+  recording a 404 as a GAP fabricates a finding — a repo with SECURITY.md
+  at root is fully compliant. Only record a GAP if all three 404.
+- **Inferring CodeQL from `security_and_analysis`**: that object carries
+  `secret_scanning*`, `dependabot_security_updates`, and `advanced_security`
+  — but **no** code-scanning field. CodeQL default-setup state comes only
+  from the `code-scanning/default-setup` endpoint; never claim a CodeQL
+  PASS/GAP the skill did not actually probe.
+- **Marking a solo review requirement as PASS**: on a one-maintainer repo,
+  `required_approving_review_count >= 1` is an unsatisfiable self-lockout,
+  not a protective control — and a ruleset (unlike classic `enforce_admins`)
+  will not auto-exempt the admin. Report it as a functional-breakage GAP.
+
+## Related Skills
+
+- `harden-github-repo-security` - apply the fixes this audit surfaces
+- `security-audit-codebase` - complementary in-tree secret/dependency scan
+- `configure-git-repository` - foundational repo + `.gitignore` setup

--- a/i18n/de/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/de/skills/harden-github-repo-security/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: harden-github-repo-security
+description: >
+  Apply GitHub repository security protections tier by tier — rulesets,
+  read-only Actions token, secret scanning + push protection, Dependabot,
+  and (gated) required status checks / required PR with a GitHub App bypass
+  for a CI auto-commit bot. Mutating and confirmation-gated: always assess
+  first, apply the zero-downside baseline, then decide required checks
+  separately. Use when hardening a public user-owned repo after an audit,
+  when a repo has no branch protection, when adding required checks without
+  breaking a bot that pushes to the default branch, or when provisioning a
+  GitHub App bypass actor for trusted automation.
+license: MIT
+allowed-tools: Read Write Edit Bash
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: advanced
+  language: multi
+  tags: github, security, rulesets, branch-protection, github-actions, hardening
+  locale: de
+  source_locale: en
+  source_commit: 84a3c915
+  translator: "Claude + human review"
+  translation_date: "2026-07-16"
+---
+
+# Harden GitHub Repository Security
+
+Apply GitHub protections in order of blast radius: assess, then a zero-downside
+baseline that never breaks CI, then a gated decision on required checks / PR.
+Every mutating step is confirmation-gated. Running example: a **public,
+user-owned** repo whose CI auto-commits to the default branch via
+`stefanzweifel/git-auto-commit-action` with the default `GITHUB_TOKEN`.
+
+Throughout, `R` = `OWNER/REPO` (e.g. `pjt222/agent-almanac`). Set it once:
+`R=OWNER/REPO`. All `gh api` writes require repo admin.
+
+## When to Use
+
+- Hardening a public user-owned repo after `assess-github-repo-security`
+- A repo has no ruleset / branch protection and you want a safe baseline
+- Adding required status checks or required PR **without** breaking a bot that
+  pushes to the default branch
+- Provisioning a GitHub App (or deploy key) bypass actor for trusted automation
+
+## Inputs
+
+- **Required**: `OWNER/REPO` and admin access (`gh auth status` shows admin)
+- **Required**: whether a CI bot pushes to the default branch (and which action/identity)
+- **Optional**: assessment report from `assess-github-repo-security`
+- **Optional**: exact CI check `context` name(s) to require (must run on `push`)
+- **Optional**: GitHub App id + private key if going to required checks/PR
+
+## Procedure
+
+### Step 1: Assess First and Confirm Scope
+
+Never mutate blind. Run the read-only assessment and confirm the plan with the user.
+
+```bash
+# 1. Run the companion read-only skill first (or its core probes):
+gh api /repos/$R --jq '{visibility,default_branch,is_org:.organization!=null}'
+gh api /repos/$R/rulesets --jq '.[] | {id,name,enforcement}'
+gh api /repos/$R/actions/permissions/workflow
+
+# 2. Confirm the two decisive facts before any write:
+#    - Is the repo PUBLIC and USER-OWNED?  (rulesets are free here)
+#    - Does a bot push to the default branch?  (gates Step 3 entirely)
+```
+
+Confirm with the user: baseline (Step 2) is always safe; Step 3 (required
+checks / PR) is a separate opt-in that **will** block a default-branch bot
+unless a bypass is provisioned first.
+
+**Expected:** You know visibility, owner type, current rulesets, current token
+default, and whether a bot pushes to the default branch. The user has approved
+applying at least the baseline.
+
+**On failure:** If the repo is **private and user-owned**, rulesets need GitHub
+Pro — stop and surface that. If not admin, stop (writes will 403). If a bot
+pushes to the default branch, flag that Step 3 is blocked until Step 3a runs.
+
+### Step 2: Apply the Zero-Downside Baseline (never breaks a CI auto-commit)
+
+This tier hardens the repo without breaking a direct-push bot. Apply after
+confirmation. Force-push/deletion protection, a read-only token default, the
+free security features, and policy files.
+
+```bash
+# 2a. Default-branch ruleset: force-push + deletion protection ONLY.
+#     These do NOT block the bot's direct push.
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+
+# 2b. Actions token: read-only default + no token PR approval.
+#     A DEFAULT (not a cap) for same-repo push events, so the bot still works
+#     once its job declares contents: write.
+gh api --method PUT /repos/$R/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=false
+
+# 2c. Free security features (all free on public repos):
+gh api -X PUT repos/$R/vulnerability-alerts          # alerts + dependency graph
+gh api -X PUT repos/$R/automated-security-fixes      # Dependabot fix PRs (separate toggle!)
+gh api -X PATCH repos/$R --input - <<'JSON'
+{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}
+JSON
+gh api -X PUT repos/$R/private-vulnerability-reporting
+```
+
+Leave **Settings > Actions > General** fork-PR approval at the public-repo
+default ("Require approval for first-time contributors"). Fork `pull_request`
+runs already receive a read-only `GITHUB_TOKEN` with no access to secrets, so a
+fork cannot auto-commit to the default branch (no REST toggle — this is a UI
+setting; tighten to "all external contributors" only if the repo has secrets or
+self-hosted runners).
+
+Then add two tracked files (commit them):
+
+`.github/dependabot.yml` — include a `github-actions` block so action SHAs stay fresh:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+`.github/SECURITY.md` — a short disclosure policy pointing reporters at the
+"Report a vulnerability" button (private vulnerability reporting, enabled above).
+
+Flipping the token default to `read` silently strips write from **every**
+workflow that assumed a write default, not just the auto-commit job. Audit
+**all** files in `.github/workflows/` and declare the minimal `permissions:` each
+job actually needs — common scopes are `contents`, `packages`, `pull-requests`,
+`pages`, and `id-token`. For the running example: top-level `permissions: {}`,
+`contents: write` only on the auto-commit job, and every `uses:` pinned to a
+full 40-char commit SHA with the version in a trailing comment.
+
+**Expected:** `gh api /repos/$R/rulesets` shows `protect-default` active;
+`.../actions/permissions/workflow` shows `default_workflow_permissions: read`
+and `can_approve_pull_request_reviews: false`; secret scanning + push protection
++ Dependabot + private reporting are on; `.github/dependabot.yml` and
+`.github/SECURITY.md` are committed. The bot's next run still pushes.
+
+**On failure:** If 2b makes an existing bot push 403 — or any other workflow
+fails after losing a write scope it silently relied on — the job is missing the
+explicit `permissions:` it needs (e.g. `contents: write`, `packages: write`,
+`pull-requests: write`); add the minimal scope back (the read-only default is not
+a hard cap for same-repo pushes). If `automated-security-fixes` seems to do nothing, verify
+`vulnerability-alerts` (2c line 1) ran first — alerts are a separate prerequisite
+toggle from fixes. If push protection later fails a bot run, treat the flagged
+secret as a **real finding** — the bot cannot click the interactive web bypass.
+
+### Step 3: Decision Gate — Required Status Checks / Required PR
+
+STOP. Required checks and required PR **block direct pushes to the ref**, not
+just PR merges. If a bot pushes to the default branch, turning either on **will
+break it** unless you first provision a bypass. The default `GITHUB_TOKEN` /
+`github-actions[bot]` **cannot** be a bypass actor (GitHub design). Do not enable
+this tier on a bot-pushing branch without a bypass in place.
+
+Also, on a **solo** repo, `required_approving_review_count >= 1` is a self-lockout
+(you cannot approve your own PR) — keep it `0`. And a required check that only
+runs on `pull_request` never reports on a direct push, so it **permanently**
+blocks the bot. Ensure the check runs on `push`.
+
+**Step 3a — provision the bot bypass FIRST (if a bot pushes to this branch).**
+Recommended: a GitHub App installation token. (Deploy key is a narrower
+single-repo alternative: add an SSH deploy key with write access and use
+`actor_type: DeployKey` in 3b.)
+
+```bash
+# Create a GitHub App (personal account, Settings > Developer settings >
+# GitHub Apps), permission Repository > Contents: Read and write; install it
+# on THIS repo. Store the App id as a repo variable and the private key as an
+# Actions secret. In the workflow, mint a token and pass it to checkout + the
+# commit action:
+#   - uses: actions/create-github-app-token@<sha>   # v2
+#     id: app-token
+#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+#   - uses: actions/checkout@<sha>
+#     with: { token: ${{ steps.app-token.outputs.token }} }
+#   - uses: stefanzweifel/git-auto-commit-action@<sha>
+#     with: { ... }   # inherits the app token via the checkout credentials
+#
+# The numeric App id used in Step 3b is shown on the App's own page:
+# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+# It is unrelated to the repository id and cannot be derived from /repos/$R.
+```
+
+**Higher-assurance alternative (no standing bypass actor).** If a manual merge
+click is acceptable, convert the job to open a PR with the App token (e.g.
+`peter-evans/create-pull-request`) and let a human merge. No bypass actor is
+needed and every rule stays enforced even against the automation's identity. The
+App token is still required: a PR opened with the plain `GITHUB_TOKEN` does not
+trigger `pull_request`/`push` workflows, so required checks never run and it sits
+`expected` forever (see Common Pitfalls).
+
+**Step 3b — apply the hardened ruleset with the App as an `Integration` bypass
+actor.** Replace `RULESET_ID` with the id from Step 2a, `<APP_ID>` with your App
+id, and `build` with your real check context. `bypass_mode: always` because the
+action pushes directly (use `pull_request` only if the bot opens PRs).
+
+```bash
+gh api --method PUT /repos/$R/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "pull_request", "parameters": { "required_approving_review_count": 0, "dismiss_stale_reviews_on_push": true, "require_code_owner_review": false, "require_last_push_approval": false, "required_review_thread_resolution": false, "allowed_merge_methods": ["merge"] } },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+
+# Verify the bypass actor is present:
+gh api /repos/$R/rulesets/RULESET_ID --jq '.bypass_actors'
+```
+
+`do_not_enforce_on_create: true` avoids the new-branch catch-22 (CI can't have
+run on a branch that does not exist yet). If there is **no** bot on this branch,
+you may skip 3a and omit `bypass_actors`.
+
+Trade-off: `strict_required_status_checks_policy: true` ("branch must be
+up to date") forces every open human PR to be re-updated each time the bot
+auto-commits to the default branch, and `dismiss_stale_reviews_on_push: true`
+compounds the churn — a chatty bot can make PRs perpetually unmergeable. On a
+frequently-auto-committed branch prefer `strict_required_status_checks_policy:
+false` (loose) unless up-to-date-before-merge is genuinely required.
+
+**Expected:** The ruleset now enforces the required check and required-PR rule
+for humans and forks, `.bypass_actors` lists the App (`Integration`), and the
+bot's next run still lands on the default branch (via the App token). Humans
+must open a PR; the check must be green.
+
+**On failure:** If the bot 403s after 3b, the App identity is not actually the
+bypass actor — confirm the workflow passes the App token to **checkout** (not
+just to the commit action) and that `<APP_ID>` in `bypass_actors` matches. If
+the bot's push sits `expected`/`pending` forever, the required check does not run
+on `push` — make it trigger on `push` or drop it from the required list. If the
+bypass-actor picker does not appear on your personal repo, the required-PR +
+auto-commit combination is unsatisfiable here; GitHub's workaround is a free org.
+If merges are blocked on a solo repo, `required_approving_review_count` is `>= 1`
+— set it to `0`.
+
+### Step 4: Optional Advanced Hardening
+
+Apply individually, each still confirmation-gated. None of these are needed for
+the baseline; several have sharp edges.
+
+```bash
+# 4a. Tag ruleset — protect release tags (classic tag protection is deprecated):
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{ "name": "protect-tags", "target": "tag", "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/tags/v*"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ] }
+JSON
+
+# 4b. Merge-method toggles (e.g. merge-commits-only to preserve per-commit history):
+gh api -X PATCH repos/$R -F allow_merge_commit=true -F allow_squash_merge=false \
+  -F allow_rebase_merge=false -F delete_branch_on_merge=true
+
+# 4c. CodeQL "default setup" (server-managed — commits NO workflow YAML):
+gh api -X PATCH repos/$R/code-scanning/default-setup -f state=configured -f query_suite=default
+
+# 4d. sha_pinning_required — ONLY after every `uses:` is a full 40-char SHA,
+#     or every workflow run fails (including actions/checkout):
+gh api --method PUT /repos/$R/actions/permissions -F enabled=true \
+  -f allowed_actions=selected -F sha_pinning_required=true
+# selected mode also gates WHICH actions may run: github_owned covers actions/*,
+# but git-auto-commit-action is NOT GitHub-owned — allow-list it in the SAME
+# step or the bot fails with "actions are not allowed":
+gh api --method PUT /repos/$R/actions/permissions/selected-actions \
+  -F github_owned_allowed=true -F verified_allowed=false \
+  -f 'patterns_allowed[]=stefanzweifel/git-auto-commit-action@*'
+gh api /repos/$R/actions/permissions --jq '.sha_pinning_required'   # verify
+```
+
+Note: `allowed_actions=selected` with `github_owned_allowed=true` still blocks
+`stefanzweifel/git-auto-commit-action` until it is in `patterns_allowed` (the 4d
+allow-list command handles this). Require-signed-commits and require-linear-history
+are intentionally omitted here:
+signing blocks the unsigned git-CLI bot push, and linear history is mutually
+exclusive with a merge-commits-only policy.
+
+**Expected:** Each selected advanced control is applied and verified without
+breaking the bot: tag ruleset lists on `.../rulesets`, merge toggles reflect on
+the repo object, CodeQL default setup shows `state: configured`,
+`sha_pinning_required` reads `true` only after all actions are SHA-pinned, and
+`git-auto-commit-action` is in `patterns_allowed` so the bot still runs.
+
+**On failure:** If every workflow fails right after 4d, an action is still
+tag-pinned — convert all `uses:` to SHAs or revert `sha_pinning_required` to
+`false`. If the bot fails with "actions are not allowed" after restricting
+allowed actions, add `git-auto-commit-action` to `patterns_allowed`. If 4c
+errors, the repo may have no CodeQL-supported language — skip it.
+
+## Validation
+
+- [ ] Assessment ran and scope (public/user-owned, bot-on-default-branch) confirmed before any write
+- [ ] `protect-default` ruleset active with `deletion` + `non_fast_forward`
+- [ ] `default_workflow_permissions=read` and `can_approve_pull_request_reviews=false`
+- [ ] Secret scanning + push protection + Dependabot alerts + fixes + private reporting enabled
+- [ ] `.github/dependabot.yml` (github-actions ecosystem) and `.github/SECURITY.md` committed
+- [ ] Auto-commit bot's next run still pushes successfully (baseline did not break it)
+- [ ] Required checks/PR enabled ONLY with a GitHub App (or deploy key) bypass in place first
+- [ ] Solo repo keeps `required_approving_review_count: 0`; required checks run on `push`
+- [ ] Loop guard added if a bot now pushes with an App token or PAT
+
+## Common Pitfalls
+
+- **GITHUB_TOKEN is not a bypass actor**: `github-actions[bot]` / the default
+  token cannot be added to any ruleset bypass list and cannot push to a
+  protected branch, by design. "Just add the Actions bot to the bypass list"
+  has no such option — the push 403s. Use a GitHub App or deploy key.
+- **PAT bypass is an anti-pattern**: an admin/personal PAT in the bypass list
+  (or classic BP with `enforce_admins=false`) exempts ALL admin actions
+  including your own interactive pushes — role-wide, not automation-scoped, and
+  long-lived. Prefer an App (`Integration`) or deploy key (`DeployKey`).
+- **Required checks only on `pull_request`**: a check that never runs on `push`
+  never reports on the bot's direct push, so it **permanently** blocks the bot
+  and new-branch creation. Make the check run on `push` and set
+  `do_not_enforce_on_create: true`.
+- **Loop guard once an App token replaces GITHUB_TOKEN**: the default token
+  suppresses downstream `push`/`pull_request` triggers; an App token or PAT does
+  not, so the auto-commit workflow can re-trigger itself indefinitely. Guard with
+  `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`.
+- **PR via the default GITHUB_TOKEN is a false fix**: a PR opened by
+  `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so required
+  checks never run and it sits `expected` forever. Create the PR with the App token.
+- **Alerts != fixes**: `vulnerability-alerts` and `automated-security-fixes` are
+  separate toggles; enabling alerts opens no PRs. Enable both.
+- **Don't buy GHAS on a public repo**: secret scanning, push protection, CodeQL,
+  and dependency review are already free on public repos; the paid Secret
+  Protection / Code Security products target private/org repos.
+
+## Related Skills
+
+- `assess-github-repo-security` - the read-only companion; always run this first
+- `configure-git-repository` - baseline .gitignore, branches, remotes, hooks
+- `setup-github-actions-ci` - the CI workflow whose token/permissions this hardens

--- a/i18n/de/translation_status.yml
+++ b/i18n/de/translation_status.yml
@@ -3,10 +3,10 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 137
-    stubs: 11
+    stubs: 13
   agents:
     translated: 3
     total: 73
@@ -21,13 +21,13 @@ coverage:
     stubs: 1
   guides:
     translated: 3
-    total: 33
-    pct: 9.1
+    total: 34
+    pct: 8.8
     stale: 2
-    stubs: 1
+    stubs: 2
   total:
     translated: 359
-    total: 490
-    pct: 73.3
+    total: 493
+    pct: 72.8
     stale: 143
-    stubs: 14
+    stubs: 17

--- a/i18n/es/guides/protecting-github-repositories.md
+++ b/i18n/es/guides/protecting-github-repositories.md
@@ -1,0 +1,246 @@
+---
+title: "Protecting GitHub Repositories"
+description: "Honest threat model, tiered checklist, rulesets vs branch protection, and the CI-bot bypass problem for hardening a public GitHub repo"
+category: infrastructure
+agents: [security-analyst]
+teams: []
+skills: [assess-github-repo-security, harden-github-repo-security]
+locale: es
+source_locale: en
+source_commit: 84a3c915
+translator: "Claude + human review"
+translation_date: "2026-07-16"
+---
+
+# Protecting GitHub Repositories
+
+Hardening a GitHub repository is mostly a sequence of small, well-understood toggles — but a handful of them silently change *who* is gated, break a CI auto-commit bot, or provide a false sense of security while protecting almost nothing. This guide is the human-facing walkthrough: it explains the honest threat model behind ref protection, gives a tiered checklist you can apply in order, contrasts rulesets with classic branch protection, and walks through the single hardest problem — letting trusted automation write to a protected branch. Assess first, then harden.
+
+The running example throughout is the concrete case that trips most people up: a **public, user-owned** repository (like this one, `pjt222/agent-almanac`) whose CI **auto-commits to the default branch** via `stefanzweifel/git-auto-commit-action` using the default `GITHUB_TOKEN`. Everything here is grounded in current GitHub behavior; where a control interacts badly with that bot, it is called out explicitly.
+
+## When to Use This Guide
+
+- You own a public repository and want to harden it without breaking a working CI pipeline that pushes to `main`.
+- You are about to turn on branch protection or a ruleset and want to know what it actually stops — and what it does not.
+- Your CI bot suddenly started getting `403` on its push, or your PRs are stuck on a check that never runs.
+- You are choosing between classic branch protection and repository rulesets and want the honest tradeoffs.
+- A single-maintainer repo locked you out of merging your own pull requests.
+
+## Prerequisites
+
+- Admin access to the repository (most controls require it).
+- The [`gh` CLI](https://cli.github.com) authenticated (`gh auth status`) — every command here uses it, and the API is the source of truth over the UI.
+- A completed **assessment** of the repo's current posture — run the [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) skill *before* changing anything, so you know your baseline and do not toggle controls you already have.
+- If your CI writes to a protected branch, know which action does the push and which token it uses.
+
+## Workflow Overview
+
+The order matters. Hardening blind is how you break the bot or lock yourself out.
+
+1. **Assess** — inventory the current state with [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md): existing rules, token defaults, enabled security features, and how CI pushes.
+2. **Apply the zero-downside baseline** — the essential tier below hardens the repo *without* touching anything the bot depends on.
+3. **Decide on required checks / required PR** — this is the fork in the road. It is the single control most in tension with a direct-push bot; if you want it, you must first provision a bypass identity for the bot (see the bypass matrix).
+4. **Harden the automation path** — swap the bot to a GitHub App token and add the App as a ruleset bypass actor, or route it through a pull request.
+5. **Verify** — re-run the assessment; confirm the bot still pushes and humans/forks are still gated.
+
+The [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) skill drives steps 2–4 as an executable procedure; the [security-analyst](../agents/security-analyst.md) agent is the persona that owns this end-to-end.
+
+## The Honest Threat Model
+
+Ref protection — whether you call it a *ruleset* or a *branch protection rule* — protects **one ref**, not the repository. Internalizing that sentence prevents most false-security mistakes.
+
+**What ref protection does stop:** rewriting, force-pushing, or deleting the protected branch; landing changes to it without a pull request (if you require one); merging before required status checks pass. It gates the *history of one branch*.
+
+**What it does NOT stop:**
+
+- A write collaborator pushing to any **unprotected** branch, then adding a malicious workflow that runs with your repo's token.
+- Moving or creating **tags** (unless you also protect tags with a tag ruleset).
+- Introducing a **compromised or typo-squatted action** into a workflow that holds `contents: write`.
+- A workflow triggered on **`pull_request_target`** that checks out the PR head. This trigger runs in the *base-repo* context with secrets and a write token regardless of branch protection, so checking out untrusted code under it is a documented privilege-escalation / RCE pattern. Avoid `pull_request_target` for anything that checks out untrusted code, and never interpolate `${{ github.event.pull_request.* }}` fields directly into a `run:` shell step (route them through an intermediate `env:` var). Ref protection does nothing about this.
+- Secrets already committed (protection is about refs, not content) — that is what secret scanning and push protection are for.
+
+So a branch rule is one layer. Ruleset scope, an allowed-actions policy, fork-PR approval, and secret scanning matter as much as the branch rule itself. Treat "the branch is protected" as *necessary, not sufficient*.
+
+### The mental-model shift that catches everyone
+
+Here is the subtle part. Under **classic branch protection**, repository admins bypass the rules **by default** — the rule simply does not apply to them unless you also check *"Do not allow bypassing the above settings"* (`enforce_admins=true`). That toggle is all-or-nothing: it applies the rules to *every* admin or *no* admin, with no per-actor granularity.
+
+**Rulesets invert this default.** A ruleset applies to admins too — nobody is exempt *unless they are explicitly added to the ruleset's `bypass_actors` list*. There is no `enforce_admins` toggle on a ruleset.
+
+Porting the classic "admins can always bypass" mental model to a ruleset **silently changes who is gated**:
+
+- If you *assume* you (as admin) can always push past a ruleset, you will be surprised by a `403` — the ruleset gates you unless you added your admin role to the bypass list.
+- Conversely, if you migrate from classic BP where admins were quietly exempt, a ruleset will now enforce against those same admins — usually what you wanted, but a behavior change to be aware of.
+
+This is why the assessment step matters: the same words ("branch protection") describe two systems with opposite default answers to "does this apply to me?"
+
+## Rulesets vs Classic Branch Protection
+
+**Prefer repository rulesets. Treat classic branch protection as legacy.** GitHub's own docs position classic BP as the thing rulesets are an "alternative" to, and rulesets are the actively developed path.
+
+| Capability | Repository Ruleset | Classic Branch Protection |
+|---|---|---|
+| Availability on free public user-owned repo | Yes, fully free | Yes |
+| Multiple rules stack (most-restrictive wins) | Yes | No — one rule matches |
+| Per-actor bypass list (roles, teams, Apps, deploy keys) | Yes | No |
+| Exempt a *specific actor* from required status checks | Yes | **No — impossible** |
+| Admin exemption model | Per-actor via bypass list | All-or-nothing (`enforce_admins`) |
+| Target multiple branches / tags by pattern | Yes (`~DEFAULT_BRANCH`, `~ALL`, fnmatch) | Limited |
+| Tag protection | Tag ruleset (`target: tag`) | Deprecated 2024-08-30, auto-migrated |
+
+Two facts do the heavy lifting for the running example:
+
+- **Rulesets are free on public user-owned repos.** The docs are explicit — do not tell a free personal-public-repo owner to upgrade. (Only *private* personal repos need GitHub Pro for rulesets; org-wide rulesets and the "Evaluate" dry-run mode are the Team/Enterprise-gated pieces.)
+- **Classic BP cannot exempt any actor from required status checks.** Its push allowlist ("Restrict who can push") is organization-only and, even where available, governs *who may push*, not *who may skip checks*. GitHub staff redirected the multi-year feature request for this to rulesets. For any "let one specific bot through required checks" need — exactly the auto-commit case — rulesets are mandatory.
+
+A minimal, safe default-branch ruleset (force-push + deletion protection only — this does **not** break a direct-push bot):
+
+```bash
+gh api --method POST /repos/OWNER/REPO/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+```
+
+Inspect what exists before and after: `gh api /repos/OWNER/REPO/rulesets` and `gh api /repos/OWNER/REPO/rulesets/RULESET_ID --jq '.bypass_actors'`.
+
+## The Tiered Hardening Checklist
+
+Apply top to bottom. The **essential** tier is zero-downside and does not break the auto-commit bot; **recommended** introduces the bot-bypass decision; **advanced** is high-friction or niche.
+
+### Essential (zero-downside baseline)
+
+- **Force-push + deletion protection** via a default-branch ruleset (`non_fast_forward` + `deletion`). The cheapest, no-downside hardening; safe for a direct-push bot.
+- **Set the default `GITHUB_TOKEN` to read-only** and disable token PR approval. This is a *default*, not a hard cap, for same-repo push events — so it does not break the bot **provided the committing job grants `contents: write` back** (the next bullet). If your workflow has no explicit `permissions:` block and relied on the ambient write default, add that grant *first* or the `git-auto-commit-action` push `403`s.
+  ```bash
+  gh api --method PUT /repos/OWNER/REPO/actions/permissions/workflow \
+    -f default_workflow_permissions=read -F can_approve_pull_request_reviews=false
+  ```
+- **Least-privilege per-workflow permissions.** Top-level `permissions: {}` in the workflow YAML, then grant `contents: write` back only on the job that commits — `git-auto-commit-action` needs nothing more.
+- **Pin every action to a full 40-char commit SHA** (including `actions/checkout` and `stefanzweifel/git-auto-commit-action`), with the human-readable version in a trailing comment. A mutable tag is a supply-chain hole on a workflow that holds `contents: write`.
+  ```yaml
+  - uses: stefanzweifel/git-auto-commit-action@<40-char-sha>  # v6.x.x
+  ```
+- **Leave fork-PR approval at the public-repo default** ("Require approval for first-time contributors"). Fork `pull_request` runs already get a read-only token and no secrets.
+- **Enable Dependabot alerts + security updates + a `.github/dependabot.yml`.** Alerts and fixes are *separate* toggles — enable both, or you detect vulnerabilities and fix nothing. Include a `github-actions` ecosystem block to keep action SHAs fresh.
+  ```bash
+  gh api -X PUT repos/OWNER/REPO/vulnerability-alerts      # alerts + dependency graph
+  gh api -X PUT repos/OWNER/REPO/automated-security-fixes  # Dependabot fix PRs
+  ```
+- **Enable secret scanning + push protection** (free and usually already on for public repos); add `.github/SECURITY.md` and private vulnerability reporting (both per-repo, no org needed).
+  ```bash
+  gh api -X PATCH repos/OWNER/REPO --input - <<<'{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}'
+  gh api -X PUT repos/OWNER/REPO/private-vulnerability-reporting
+  ```
+- **Do NOT purchase GHAS / Secret Protection / Code Security for a public repo.** Secret scanning, push protection, CodeQL, and dependency review are already free on public repos; those paid products are private/org-only.
+
+### Recommended
+
+- **Add `required_status_checks`** to the ruleset with `do_not_enforce_on_create=true` and `strict_required_status_checks_policy=true`. **Critical:** this blocks the bot's direct push unless you provision a bypass (next item), *and* the checks must run on `push`, not only `pull_request`, or they never report and the push is permanently blocked.
+- **Add a `pull_request` rule** if you want a review surface. On a solo repo keep `required_approving_review_count: 0` — you cannot approve your own PR, and `>= 1` is an unsatisfiable self-lockout.
+- **Provision a GitHub App bypass for the bot** (Contents: read/write) via `actions/create-github-app-token`, pass the token to checkout + `git-auto-commit-action`, and add the App as an `Integration` bypass actor with `bypass_mode: always`. This is the correct realization of "let the bot through" once required checks/PR are on.
+- **Enable CodeQL "default setup"** (server-managed) rather than advanced setup, so no extra workflow YAML is committed into a repo that auto-commits.
+- **Set merge-method toggles to match policy** (e.g. merge-commits-only: `allow_squash_merge=false`, `allow_rebase_merge=false`) and auto-delete head branches on merge.
+- **Restrict the allowed-actions policy** to GitHub-owned + an explicit allow-list that *includes* `stefanzweifel/git-auto-commit-action` (it is not GitHub-owned; omitting it silently fails the workflow).
+
+### Advanced
+
+- **Protect release tags** with a tag ruleset (`target: tag`, e.g. `v*`).
+- **Enable the `sha_pinning_required` repo policy** (2025-08-15) — but only *after* converting every `uses:` to a full SHA, or every run fails. First confirm the field is actually exposed on a free user-owned public repo (it may be org/enterprise-gated): `gh api /repos/OWNER/REPO/actions/permissions --jq '.sha_pinning_required'`.
+- **`dismiss_stale_reviews_on_push` + require conversation resolution + `require_last_push_approval`** — only meaningful once you run human PR reviews; a chatty auto-commit bot pushing into open PRs can make them perpetually unmergeable.
+- **CODEOWNERS + `require_code_owner_review`** — low value on a solo repo (you can only list `@users`, and the sole owner cannot satisfy it as PR author).
+- **Require signed commits** — high friction: `git-auto-commit-action` pushes unsigned via git CLI, so this blocks the bot. `GITHUB_TOKEN` commits are auto-verified only via the Contents API, not `git push`.
+- **Require linear history** — mutually exclusive with a merge-commits-only policy; pick one.
+
+## Automation Through Protection: The Bot Bypass Problem
+
+This is the crux of the running example. Once you turn on required checks or require-a-PR, a push to the default branch must either satisfy the rules or come from a **bypass actor**. And here is the hard constraint that no toggle removes:
+
+> The default `GITHUB_TOKEN` / `github-actions[bot]` **cannot** be added to any bypass list and **cannot** push to a protected branch. This is by GitHub design — otherwise any collaborator could ship a workflow that writes to any branch. Any plan phrased as "just add the Actions bot to bypass" silently has no such option, and the bot's push `403`s.
+
+So to let trusted automation through, you must give it a *real* bypass-eligible identity. Ranked from best to worst:
+
+| Approach | Keeps checks enforced for humans? | Least-privilege rank | Verdict |
+|---|---|---|---|
+| PR-based (create-pull-request) with a **GitHub App token**, human clicks merge — no standing bypass | Yes | 1 | Strongest separation of duties. App token makes checks actually fire on the bot's change; no standing branch bypass. Not fully hands-off — a human merges. |
+| **GitHub App** installation token (Contents: read/write) + App as `Integration` bypass actor, `bypass_mode: always` | Yes | 2 | **Recommended default for full automation.** Repo-scoped, ~1h ephemeral, identity-scoped bypass; humans/forks/admins stay gated. Crown-jewel risk shifts to the App private key. |
+| SSH **deploy key** (write) + `DeployKey` bypass actor, push over SSH | Yes | 3 | Good narrow single-repo alternative — no App to maintain, no API scope. One private key per repo to rotate. Slightly coarser identity than an App. |
+| Bot-account **PAT** as a `User` bypass actor | Yes | 4 | Anti-pattern. Long-lived, tied to a maintained account; rotation/offboarding risk; re-triggers workflows (needs a loop guard). Stopgap only. |
+| Admin/fine-grained **PAT** + `Repository admin` role in bypass | **No** | 5 | Worst. Role-wide hole — exempts *all* admin actions including your own interactive pushes, not just automation. A leaked PAT = admin bypass-write. |
+| Add the default **`GITHUB_TOKEN`** to the bypass list | — | 6 | **Impossible.** Not a selectable actor by design; the push `403`s. |
+
+> **Verify the bypass-actor picker before you commit to this.** Historically the ruleset bypass-actor UI did **not** appear on user-owned (personal) repositories — the exact repo class this guide centers on. Before you build the App and flip on required checks / require-a-PR for real, open **Settings > Rules > Rulesets > (your ruleset) > Bypass list > Add bypass** and confirm the App is actually selectable. If it is not, the required-checks / required-PR combination is **unsatisfiable** on a personal repo — the bot's direct push cannot be let through by any means — and GitHub's documented workaround is to move the repo under a (free) **organization**, where App and role bypass actors are reliably available. This is version-dependent, so check your own repo rather than assuming the App route works.
+
+The **GitHub App** route (rank 2) is the recommended default *once you have confirmed the App is addable as a bypass actor*. Mint the token at runtime and wire it through the bot:
+
+```yaml
+- uses: actions/create-github-app-token@<sha>  # official
+  id: app-token
+  with:
+    app-id: ${{ vars.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+- uses: actions/checkout@<sha>
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+- uses: stefanzweifel/git-auto-commit-action@<sha>  # inherits the App token
+```
+
+Then add the App to the ruleset bypass list:
+
+```bash
+gh api --method PUT /repos/OWNER/REPO/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+```
+
+Two follow-ups once an App token or PAT is in play: (1) the crown-jewel secret is now the **App private key** — store it as an Actions secret, scope the App install to the single repo, and rotate; (2) unlike the default `GITHUB_TOKEN` (which suppresses downstream triggers), an App/PAT push **re-triggers** `on: push` workflows, so add a loop guard (`if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`).
+
+## Common False-Security Traps
+
+These are the beliefs that feel like security but are not.
+
+- **"Just add the github-actions bot to the ruleset bypass list."** It is not a selectable actor; the push `403`s. Use a GitHub App or deploy key identity.
+- **"Convert the bot from push to a PR to satisfy the rules."** A PR opened by the default `GITHUB_TOKEN` does **not** trigger `pull_request`/`push` workflows, so required checks never run and the PR sits on "expected/pending" forever. The PR must be created with an App token or PAT.
+- **"Required status checks mean nothing unreviewed lands."** Without a *required-PR* rule, anyone with write can still push directly if a check reports on push; and in classic BP admins bypass by default unless `enforce_admins=true`. Rulesets differ — they do not auto-exempt admins — so porting the classic mental model silently changes who is gated.
+- **"Branch protection protects the repo from a malicious collaborator."** It protects one ref. A write collaborator can push to unprotected branches, add a malicious workflow, or move tags. Scope, allowed-actions policy, and fork approval matter as much.
+- **"Public-repo secret scanning stops leaks."** Alerts fire *after* the commit; push protection blocks at push time but the auto-commit bot cannot click the interactive web bypass, so a CI-committed secret just fails the job — treat it as a real finding, not a flake. The free tier also covers provider patterns only, not every generic secret.
+- **"Require signed commits is free hardening."** It blocks the bot, which pushes unsigned via git CLI. Keeping both requires an API-based commit action.
+- **"Swap `GITHUB_TOKEN` for a broad PAT to get past protection."** A PAT is long-lived and account-wide — a strict privilege escalation over the ephemeral repo-scoped token. Prefer an App or deploy key.
+- **"Buy GHAS to secure a public repo."** Those features are already free on public repos; the paid split targets private/org repos only.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Bot push `403`s after enabling required checks / require-PR | The default `GITHUB_TOKEN` cannot be a bypass actor and cannot push to a protected branch | Provision a GitHub App token (or deploy key) and add that identity to the ruleset `bypass_actors`; pass the token to checkout + `git-auto-commit-action` |
+| Cannot add the App (or any actor) to the ruleset bypass list on a personal repo | The bypass-actor picker historically did not appear on user-owned repos; without it, required-checks/required-PR + a direct-push bot is unsatisfiable | Verify the picker under Settings > Rules > Rulesets > Bypass list; if it is absent, move the repo under a free organization (GitHub's documented workaround) or keep the default branch at the essential-tier baseline only |
+| PR opened by the bot is stuck on a check that shows "expected"/pending forever | A PR created with the default `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so checks never run | Create the PR with a GitHub App token (or PAT), which fires both event types; then the checks actually run and can gate the merge |
+| Solo maintainer cannot merge own PR | `required_approving_review_count >= 1` (or `require_code_owner_review`) — you cannot approve your own PR, and a ruleset does not auto-exempt you as admin | Set `required_approving_review_count: 0`, or add a second reviewer / a second trusted App as a bypass path |
+| New branch cannot be created; "required status check is expected" | Required checks block branch *creation* — CI cannot have run on a branch that does not exist (catch-22); or checks only trigger on `pull_request` and never report on a push | Set `do_not_enforce_on_create: true` on the `required_status_checks` rule, and make the check run on `push`, not only `pull_request` |
+| `sha_pinning_required` breaks every workflow run | The policy fails any `uses:` not pinned to a full 40-char SHA, including `actions/checkout@v4` | Convert *all* `uses:` to full commit SHAs *before* enabling the policy |
+| `allowed_actions=selected` fails the auto-commit job | `github_owned_allowed=true` still blocks `git-auto-commit-action` — it is not GitHub-owned | Add `stefanzweifel/git-auto-commit-action@*` to `patterns_allowed` |
+| Bot loops / re-triggers itself after switching to an App token | App/PAT pushes re-trigger `on: push` (default `GITHUB_TOKEN` suppressed them) | Add a loop guard: `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]` in the commit message |
+
+## Related Resources
+
+- [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) — inventory the current posture **first**; run before any hardening
+- [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) — the executable procedure that applies this checklist and the bot bypass
+- [security-analyst](../agents/security-analyst.md) — the agent persona that owns repository hardening end-to-end
+- [WSL Maintenance & Claude Code Reference](wsl-maintenance.md) — periodic security-scan greps for leaked secrets and hardcoded paths
+- [Setting Up Your Environment](setting-up-your-environment.md) — first-time environment, shell, and Claude Code setup

--- a/i18n/es/skills/assess-github-repo-security/SKILL.md
+++ b/i18n/es/skills/assess-github-repo-security/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: assess-github-repo-security
+description: >
+  Read-only audit of a GitHub repository's security posture. Gathers ref
+  protection (rulesets AND classic branch protection), Actions token
+  permissions, code and supply-chain features (Dependabot, secret
+  scanning, push protection, CodeQL), and repo hygiene toggles via
+  `gh api`, then classifies findings against essential / recommended /
+  advanced tiers into a PASS/GAP report. Makes NO changes. Use when
+  reviewing a repo before open-sourcing or a release, auditing a public
+  user-owned repo whose CI auto-commits to the default branch, verifying
+  a hardening change actually took effect, or producing a baseline
+  security posture report for a repository.
+license: MIT
+allowed-tools: Read Bash Grep
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: intermediate
+  language: multi
+  tags: github, security, audit, rulesets, branch-protection, dependabot, actions
+  locale: es
+  source_locale: en
+  source_commit: 84a3c915
+  translator: "Claude + human review"
+  translation_date: "2026-07-16"
+---
+
+# Assess GitHub Repository Security
+
+Audit a GitHub repository's security posture, read-only, and classify it
+against tiered best practices. This skill only reads — it never enables,
+disables, or changes any setting. Remediation is a separate concern (see
+`harden-github-repo-security`).
+
+## When to Use
+
+- Reviewing a repo before open-sourcing it or cutting a release
+- Auditing a public, user-owned repo whose CI auto-commits to the default
+  branch (e.g. via `stefanzweifel/git-auto-commit-action` + the default
+  `GITHUB_TOKEN`)
+- Verifying that a hardening change actually took effect
+- Producing a baseline posture report to track over time
+
+## Inputs
+
+- **Required**: Target repository as `OWNER/REPO`
+- **Required**: `gh` CLI authenticated with an account that has the
+  **admin repository role** on the target repo (some endpoints 403
+  otherwise). This is a role requirement, not a need for a broad
+  write-capable token: a fine-grained, single-repo PAT scoped to
+  read-only Administration / Actions / Secret-scanning permissions
+  satisfies the same admin check with far less blast radius if the
+  audit credential is ever leaked or reused in automation
+- **Optional**: Branch to check for classic protection (defaults to the
+  repo's `default_branch`)
+- **Optional**: `security_events` token scope — needed only to count open
+  Dependabot alerts; the rest works without it
+
+Set a shorthand for every command below:
+
+```bash
+R="OWNER/REPO"   # e.g. pjt222/agent-almanac
+```
+
+## Procedure
+
+### Step 1: Preflight — auth and admin
+
+Confirm the CLI is authenticated and the account has admin on the repo.
+Non-admins get partial data (403 on rulesets, Actions, and security
+endpoints), which silently understates the posture.
+
+```bash
+gh auth status
+gh api "repos/$R" --jq '{full_name, admin: .permissions.admin, visibility}'
+```
+
+**Expected:** `gh auth status` shows a logged-in account; the second call
+prints `admin: true`.
+
+**On failure:** If not authenticated, run `gh auth login` (or set
+`GH_TOKEN`). If `admin: false`, stop and note in the report that findings
+are **incomplete** — a non-admin cannot read ruleset internals or Actions
+permissions, so absence of a control cannot be distinguished from lack of
+access.
+
+### Step 2: Repo basics — visibility, merge toggles, collaborators
+
+```bash
+gh api "repos/$R" --jq '{visibility, private, allow_forking,
+  default_branch, allow_merge_commit, allow_squash_merge,
+  allow_rebase_merge, delete_branch_on_merge}'
+
+# Direct collaborators and their effective role
+gh api "repos/$R/collaborators?affiliation=direct" \
+  --jq '.[] | {login, role_name}'
+```
+
+**Expected:** JSON for the repo toggles plus one line per direct
+collaborator with `role_name` (`admin`/`maintain`/`write`/`triage`/`read`).
+
+**On failure:** A 403 on `collaborators` means the token lacks admin; note
+it and continue. Record `visibility` — it changes which features are
+**free**: on **public** repos secret scanning, push protection, CodeQL,
+and dependency review are free; the paid GHAS/Secret Protection products
+are private/org-only, so their absence on a public repo is not a gap.
+
+### Step 3: Ref protection — check rulesets AND classic (both)
+
+A repo can be protected by a **ruleset**, by **classic branch
+protection**, by both, or by neither. Rulesets are the actively-developed
+path and are free on public user-owned repos. You MUST check both — a repo
+with only a ruleset returns 404 on the classic endpoint and vice versa.
+
+```bash
+b=$(gh api "repos/$R" --jq '.default_branch')
+
+# (a) Rulesets — list, then inspect each active one's rules + bypass list
+gh api "repos/$R/rulesets" --jq '.[] | {id, name, enforcement, target}'
+# For each id from above:
+#   gh api "repos/$R/rulesets/<id>" \
+#     --jq '{name, enforcement,
+#            rules: [.rules[].type],
+#            bypass: [.bypass_actors[] | {actor_type, bypass_mode}]}'
+
+# (b) Classic branch protection on the default branch (404 = none)
+gh api -i "repos/$R/branches/$b/protection" 2>/dev/null | head -1
+gh api "repos/$R/branches/$b/protection" \
+  --jq '{required_status_checks: .required_status_checks.checks,
+         strict: .required_status_checks.strict,
+         enforce_admins: .enforce_admins.enabled,
+         required_reviews: .required_pull_request_reviews.required_approving_review_count,
+         linear: .required_linear_history.enabled,
+         signatures: .required_signatures.enabled,
+         allow_force_pushes: .allow_force_pushes.enabled,
+         allow_deletions: .allow_deletions.enabled}' 2>/dev/null \
+  || echo "no classic branch protection"
+```
+
+**Expected:** Either a ruleset with rules such as `deletion`,
+`non_fast_forward`, `pull_request`, `required_status_checks`, or a classic
+protection object, or an explicit "none" from both.
+
+**On failure:** A `404` on either endpoint means that mechanism is **not
+configured** — it is a valid data point, not an error; record "none" for
+that mechanism. Note the rule set from the ruleset `rules[].type` list and
+the `bypass_actors`. Remember: the default `GITHUB_TOKEN` /
+`github-actions[bot]` can never be a bypass actor by design — if the repo
+auto-commits AND has `required_status_checks`/`pull_request` rules with no
+`Integration` (GitHub App) or `DeployKey` bypass actor, flag that the bot
+push must be 403ing (a real finding).
+
+### Step 4: Actions security — token defaults and PR approval
+
+```bash
+# Actions enablement + allowed-actions policy (+ SHA-pinning policy)
+gh api "repos/$R/actions/permissions" \
+  --jq '{enabled, allowed_actions, sha_pinning_required}'
+
+# Default GITHUB_TOKEN permissions + can-the-bot-approve-PRs
+gh api "repos/$R/actions/permissions/workflow" \
+  --jq '{default_workflow_permissions, can_approve_pull_request_reviews}'
+```
+
+**Expected:** `default_workflow_permissions` is `read` (hardened) or
+`write` (permissive default), and `can_approve_pull_request_reviews` is
+`false` (hardened) or `true` (a review-bypass vector).
+
+**On failure:** 403 means non-admin — note it. If
+`allowed_actions` is `all`, any action can run (looser); `selected` with a
+pinned allow-list is tighter — but note that `selected` +
+`github_owned_allowed` still blocks non-GitHub actions like
+`stefanzweifel/git-auto-commit-action` unless explicitly allow-listed.
+`sha_pinning_required` may be absent/`null` on repos that never set the
+2025-08 policy — record as "not enforced". Per-workflow `permissions:`
+blocks live in the YAML, not the API; note that the API shows only the
+repo **default**, which is a default (not a cap) for same-repo push
+events.
+
+### Step 5: Code and supply-chain features
+
+```bash
+# Dependabot alerts + dependency graph (204 = ON, 404 = OFF)
+gh api -i "repos/$R/vulnerability-alerts" 2>/dev/null | head -1
+
+# Dependabot security updates (auto fix PRs) — separate toggle
+gh api "repos/$R/automated-security-fixes" \
+  --jq '{enabled, paused}' 2>/dev/null || echo "automated-security-fixes: off/unavailable"
+
+# Secret scanning + push protection status (security_and_analysis has NO
+# code-scanning field — CodeQL is probed separately below)
+gh api "repos/$R" --jq '.security_and_analysis'
+
+# CodeQL code scanning — default setup state (its own endpoint)
+gh api "repos/$R/code-scanning/default-setup" --jq '.state' 2>/dev/null \
+  || echo "code-scanning default setup: not configured / no access"
+
+# Dependabot version updates config present?
+gh api -i "repos/$R/contents/.github/dependabot.yml" 2>/dev/null | head -1
+
+# SECURITY.md — GitHub auto-detects it at root, docs/, OR .github/.
+# Present if ANY of the three returns 200; only a GAP if all three 404.
+for p in SECURITY.md docs/SECURITY.md .github/SECURITY.md; do
+  echo "$p: $(gh api -i "repos/$R/contents/$p" 2>/dev/null | head -1)"
+done
+
+# Private vulnerability reporting — status is a 200 body {"enabled": bool},
+# NOT a 204/404 toggle, so read the field directly.
+gh api "repos/$R/private-vulnerability-reporting" --jq '.enabled' 2>/dev/null \
+  || echo "PVR: not accessible"
+
+# Open Dependabot alert count — needs security_events scope; may 403
+gh api "repos/$R/dependabot/alerts?state=open" --jq 'length' 2>/dev/null \
+  || echo "dependabot/alerts: 403 (needs security_events scope) — skipped"
+```
+
+**Expected:** `vulnerability-alerts` → `HTTP/2.0 204` when enabled;
+`security_and_analysis` shows `secret_scanning.status` and
+`secret_scanning_push_protection.status` as `enabled` on a hardened public
+repo; `code-scanning/default-setup` `.state` is `configured` when CodeQL
+default setup is on; `automated-security-fixes` → `enabled: true`; the
+`dependabot.yml` probe returns `200` when present; at least one of the
+three SECURITY.md paths returns `200` when a policy file exists;
+`private-vulnerability-reporting` `.enabled` prints `true` when PVR is on.
+
+**On failure:** `vulnerability-alerts` returning `404` = Dependabot alerts
+OFF (a gap). Remember **alerts != fixes**: alerts on with
+`automated-security-fixes` off means nothing is auto-remediated — flag
+both separately. On **public** repos `secret_scanning` is usually already
+`enabled` by default; if `security_and_analysis` omits the field entirely,
+treat it as advisory (public-repo default on) but note the API did not
+confirm it. `code-scanning/default-setup` `404`/non-`configured` = CodeQL
+default setup not enabled (a recommended-tier gap on a public repo, where
+code scanning is free). For SECURITY.md, record a GAP **only if all three
+paths 404** — a `200` on root, `docs/`, or `.github/` all count as
+present. `private-vulnerability-reporting` empty/`false` = PVR off; a
+non-JSON or error response = not accessible. `dependabot/alerts` 403 is
+expected without `security_events` scope — record "not assessed", not "0".
+
+### Step 6: Produce the tiered PASS/GAP report
+
+Classify every gathered fact into three tiers and mark **PASS** (control
+present), **GAP** (control absent), or **N/A** (not applicable, e.g. a paid
+private-repo feature on a public repo). Distinguish a **required** check
+from an **advisory** one: a status check that runs but is not listed in the
+ruleset's `required_status_checks` does not gate anything — it is advisory
+only.
+
+**Interpret the solo-maintainer lockout.** Cross-reference the Step 2
+direct-collaborator count with the Step 3 `required_approving_review_count`.
+On a single-maintainer repo, `required_approving_review_count >= 1` (and
+`require_code_owner_review` with a sole owner) is **unsatisfiable** — you
+cannot approve your own PR — so on an auto-commit repo it is a self-lockout
+/ functional breakage, **not** a PASS. Flag it as a GAP-with-caveat, and
+note that a **ruleset** (unlike classic branch protection's `enforce_admins`)
+does **not** auto-exempt the admin: the sole maintainer stays blocked unless
+explicitly added to the ruleset `bypass_actors`.
+
+**Do not publish the raw report into the audited repo.** The PASS/GAP list
+enumerates exact, admin-only-visible gaps (no ruleset, `GITHUB_TOKEN` can
+approve PRs, no push protection) — a pre-remediation vulnerability roadmap.
+While any GAP is open, keep the findings **local/private** (a gitignored
+file, a private gist, or a draft GitHub Security Advisory); never commit it
+into the public repo being audited (contrast `security-audit-codebase`,
+which writes `SECURITY_AUDIT_REPORT.md` into the project root — do NOT copy
+that pattern here). Redact ruleset / App ID / bypass-actor identifiers
+before any public write.
+
+```text
+# GitHub Repo Security Assessment — OWNER/REPO
+Date: YYYY-MM-DD   Visibility: public   Auditor role: admin
+
+## Essential
+- [PASS] Ruleset with deletion + non_fast_forward on default branch
+- [GAP]  default_workflow_permissions = write (should be read)
+- [PASS] can_approve_pull_request_reviews = false
+- [GAP]  actions/checkout pinned to @v4 tag, not a 40-char SHA
+- [PASS] Dependabot alerts (204) + security updates (enabled)
+- [GAP]  No .github/dependabot.yml (version updates off — keeps
+         github-actions action pins fresh; essential supply-chain hygiene)
+- [PASS] Secret scanning + push protection enabled
+
+## Recommended
+- [N/A]  required_status_checks — none (no CI gate configured)
+- [PASS] CodeQL default setup: configured
+- [PASS] SECURITY.md present (.github/) + PVR enabled
+
+## Advanced
+- [GAP]  sha_pinning_required: not enforced
+- [N/A]  Required signed commits — would block the auto-commit bot
+- [N/A]  Paid GHAS / Secret Protection — public repo, features free
+
+## Notes
+- Auto-commit bot: ruleset has NO App/DeployKey bypass actor; if
+  required_status_checks were added the github-actions[bot] push would 403.
+- Solo maintainer (1 direct collaborator): required_approving_review_count
+  is 0 — correct; any value >= 1 would be an unsatisfiable self-lockout and
+  a ruleset would NOT auto-exempt the admin.
+- Dependabot open alerts: not assessed (token lacks security_events).
+- This report is kept local/private — not committed into the audited repo
+  while GAPs remain open.
+```
+
+**Expected:** A written report with every fact placed in a tier and
+marked PASS / GAP / N/A, plus a Notes section for auth gaps, advisory-only
+checks, and the auto-commit-bot bypass interaction.
+
+**On failure:** If some endpoints 403'd, still emit the report but mark
+those rows "not assessed" and state the missing scope/role at the top —
+never record an unreadable control as a GAP (absence of access is not
+absence of the control).
+
+## Validation
+
+- [ ] `gh auth status` confirmed and admin on the repo verified (or the
+      report is explicitly flagged incomplete)
+- [ ] `visibility` recorded (drives which features are free vs N/A)
+- [ ] BOTH rulesets AND classic branch protection were queried (not just one)
+- [ ] Actions `permissions` and `permissions/workflow` both read
+- [ ] Dependabot alerts, security updates, secret scanning, and push
+      protection each checked as **separate** toggles
+- [ ] CodeQL default setup queried via `code-scanning/default-setup`
+      (not inferred from `security_and_analysis`, which has no such field)
+- [ ] SECURITY.md checked at all three auto-detected paths (root, `docs/`,
+      `.github/`) — GAP only if all three 404
+- [ ] Private vulnerability reporting read from the `.enabled` body field
+      (not a 204/404 toggle)
+- [ ] Solo-maintainer lockout interpreted: collaborator count cross-referenced
+      with `required_approving_review_count`
+- [ ] Every finding is tiered and marked PASS / GAP / N/A
+- [ ] Report kept local/private while GAPs are open — NOT committed into
+      the audited public repo
+- [ ] No setting was changed — this audit is strictly read-only
+
+## Common Pitfalls
+
+- **Checking only rulesets or only classic protection**: They are
+  independent mechanisms. A repo protected by a ruleset returns `404` on
+  `branches/{b}/protection`; concluding "unprotected" from that alone is
+  wrong. Always query both.
+- **Some endpoints 403 without security scope/admin**: `dependabot/alerts`
+  needs `security_events`; rulesets and Actions permissions need admin. A
+  403 is "not assessed", not a GAP — recording it as a gap fabricates a
+  finding.
+- **A green check that is not REQUIRED is advisory only**: A CI job that
+  runs and passes gates nothing unless its context is in the ruleset's
+  `required_status_checks`. Do not report a running check as a protective
+  control.
+- **Alerts != fixes**: Dependabot **alerts** (`vulnerability-alerts`, 204)
+  only detect; **security updates** (`automated-security-fixes`) open the
+  fix PRs. Enabling one does not enable the other — assess both.
+- **Treating paid-feature absence as a gap on a public repo**: Secret
+  scanning, push protection, CodeQL, and dependency review are free on
+  public repos; GHAS / Secret Protection / Code Security are private/org
+  products. Their absence on a public repo is N/A, not a gap.
+- **Misreading the auto-commit-bot bypass**: The default `GITHUB_TOKEN` /
+  `github-actions[bot]` can never be a ruleset bypass actor. If a repo
+  auto-commits to a branch that has `required_status_checks` or a
+  `pull_request` rule with no `Integration`/`DeployKey` bypass actor, the
+  bot push is being rejected — surface it as a real finding.
+- **Reading the API default as a hard cap**: `default_workflow_permissions`
+  is the repo default; per-job `permissions:` in the workflow YAML can
+  raise or drop it for same-repo events. The API cannot show the effective
+  per-workflow grant — note that limitation.
+- **Probing SECURITY.md at only one path**: GitHub auto-detects the policy
+  at the repo root, `docs/`, OR `.github/`. Checking only one path and
+  recording a 404 as a GAP fabricates a finding — a repo with SECURITY.md
+  at root is fully compliant. Only record a GAP if all three 404.
+- **Inferring CodeQL from `security_and_analysis`**: that object carries
+  `secret_scanning*`, `dependabot_security_updates`, and `advanced_security`
+  — but **no** code-scanning field. CodeQL default-setup state comes only
+  from the `code-scanning/default-setup` endpoint; never claim a CodeQL
+  PASS/GAP the skill did not actually probe.
+- **Marking a solo review requirement as PASS**: on a one-maintainer repo,
+  `required_approving_review_count >= 1` is an unsatisfiable self-lockout,
+  not a protective control — and a ruleset (unlike classic `enforce_admins`)
+  will not auto-exempt the admin. Report it as a functional-breakage GAP.
+
+## Related Skills
+
+- `harden-github-repo-security` - apply the fixes this audit surfaces
+- `security-audit-codebase` - complementary in-tree secret/dependency scan
+- `configure-git-repository` - foundational repo + `.gitignore` setup

--- a/i18n/es/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/es/skills/harden-github-repo-security/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: harden-github-repo-security
+description: >
+  Apply GitHub repository security protections tier by tier — rulesets,
+  read-only Actions token, secret scanning + push protection, Dependabot,
+  and (gated) required status checks / required PR with a GitHub App bypass
+  for a CI auto-commit bot. Mutating and confirmation-gated: always assess
+  first, apply the zero-downside baseline, then decide required checks
+  separately. Use when hardening a public user-owned repo after an audit,
+  when a repo has no branch protection, when adding required checks without
+  breaking a bot that pushes to the default branch, or when provisioning a
+  GitHub App bypass actor for trusted automation.
+license: MIT
+allowed-tools: Read Write Edit Bash
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: advanced
+  language: multi
+  tags: github, security, rulesets, branch-protection, github-actions, hardening
+  locale: es
+  source_locale: en
+  source_commit: 84a3c915
+  translator: "Claude + human review"
+  translation_date: "2026-07-16"
+---
+
+# Harden GitHub Repository Security
+
+Apply GitHub protections in order of blast radius: assess, then a zero-downside
+baseline that never breaks CI, then a gated decision on required checks / PR.
+Every mutating step is confirmation-gated. Running example: a **public,
+user-owned** repo whose CI auto-commits to the default branch via
+`stefanzweifel/git-auto-commit-action` with the default `GITHUB_TOKEN`.
+
+Throughout, `R` = `OWNER/REPO` (e.g. `pjt222/agent-almanac`). Set it once:
+`R=OWNER/REPO`. All `gh api` writes require repo admin.
+
+## When to Use
+
+- Hardening a public user-owned repo after `assess-github-repo-security`
+- A repo has no ruleset / branch protection and you want a safe baseline
+- Adding required status checks or required PR **without** breaking a bot that
+  pushes to the default branch
+- Provisioning a GitHub App (or deploy key) bypass actor for trusted automation
+
+## Inputs
+
+- **Required**: `OWNER/REPO` and admin access (`gh auth status` shows admin)
+- **Required**: whether a CI bot pushes to the default branch (and which action/identity)
+- **Optional**: assessment report from `assess-github-repo-security`
+- **Optional**: exact CI check `context` name(s) to require (must run on `push`)
+- **Optional**: GitHub App id + private key if going to required checks/PR
+
+## Procedure
+
+### Step 1: Assess First and Confirm Scope
+
+Never mutate blind. Run the read-only assessment and confirm the plan with the user.
+
+```bash
+# 1. Run the companion read-only skill first (or its core probes):
+gh api /repos/$R --jq '{visibility,default_branch,is_org:.organization!=null}'
+gh api /repos/$R/rulesets --jq '.[] | {id,name,enforcement}'
+gh api /repos/$R/actions/permissions/workflow
+
+# 2. Confirm the two decisive facts before any write:
+#    - Is the repo PUBLIC and USER-OWNED?  (rulesets are free here)
+#    - Does a bot push to the default branch?  (gates Step 3 entirely)
+```
+
+Confirm with the user: baseline (Step 2) is always safe; Step 3 (required
+checks / PR) is a separate opt-in that **will** block a default-branch bot
+unless a bypass is provisioned first.
+
+**Expected:** You know visibility, owner type, current rulesets, current token
+default, and whether a bot pushes to the default branch. The user has approved
+applying at least the baseline.
+
+**On failure:** If the repo is **private and user-owned**, rulesets need GitHub
+Pro — stop and surface that. If not admin, stop (writes will 403). If a bot
+pushes to the default branch, flag that Step 3 is blocked until Step 3a runs.
+
+### Step 2: Apply the Zero-Downside Baseline (never breaks a CI auto-commit)
+
+This tier hardens the repo without breaking a direct-push bot. Apply after
+confirmation. Force-push/deletion protection, a read-only token default, the
+free security features, and policy files.
+
+```bash
+# 2a. Default-branch ruleset: force-push + deletion protection ONLY.
+#     These do NOT block the bot's direct push.
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+
+# 2b. Actions token: read-only default + no token PR approval.
+#     A DEFAULT (not a cap) for same-repo push events, so the bot still works
+#     once its job declares contents: write.
+gh api --method PUT /repos/$R/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=false
+
+# 2c. Free security features (all free on public repos):
+gh api -X PUT repos/$R/vulnerability-alerts          # alerts + dependency graph
+gh api -X PUT repos/$R/automated-security-fixes      # Dependabot fix PRs (separate toggle!)
+gh api -X PATCH repos/$R --input - <<'JSON'
+{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}
+JSON
+gh api -X PUT repos/$R/private-vulnerability-reporting
+```
+
+Leave **Settings > Actions > General** fork-PR approval at the public-repo
+default ("Require approval for first-time contributors"). Fork `pull_request`
+runs already receive a read-only `GITHUB_TOKEN` with no access to secrets, so a
+fork cannot auto-commit to the default branch (no REST toggle — this is a UI
+setting; tighten to "all external contributors" only if the repo has secrets or
+self-hosted runners).
+
+Then add two tracked files (commit them):
+
+`.github/dependabot.yml` — include a `github-actions` block so action SHAs stay fresh:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+`.github/SECURITY.md` — a short disclosure policy pointing reporters at the
+"Report a vulnerability" button (private vulnerability reporting, enabled above).
+
+Flipping the token default to `read` silently strips write from **every**
+workflow that assumed a write default, not just the auto-commit job. Audit
+**all** files in `.github/workflows/` and declare the minimal `permissions:` each
+job actually needs — common scopes are `contents`, `packages`, `pull-requests`,
+`pages`, and `id-token`. For the running example: top-level `permissions: {}`,
+`contents: write` only on the auto-commit job, and every `uses:` pinned to a
+full 40-char commit SHA with the version in a trailing comment.
+
+**Expected:** `gh api /repos/$R/rulesets` shows `protect-default` active;
+`.../actions/permissions/workflow` shows `default_workflow_permissions: read`
+and `can_approve_pull_request_reviews: false`; secret scanning + push protection
++ Dependabot + private reporting are on; `.github/dependabot.yml` and
+`.github/SECURITY.md` are committed. The bot's next run still pushes.
+
+**On failure:** If 2b makes an existing bot push 403 — or any other workflow
+fails after losing a write scope it silently relied on — the job is missing the
+explicit `permissions:` it needs (e.g. `contents: write`, `packages: write`,
+`pull-requests: write`); add the minimal scope back (the read-only default is not
+a hard cap for same-repo pushes). If `automated-security-fixes` seems to do nothing, verify
+`vulnerability-alerts` (2c line 1) ran first — alerts are a separate prerequisite
+toggle from fixes. If push protection later fails a bot run, treat the flagged
+secret as a **real finding** — the bot cannot click the interactive web bypass.
+
+### Step 3: Decision Gate — Required Status Checks / Required PR
+
+STOP. Required checks and required PR **block direct pushes to the ref**, not
+just PR merges. If a bot pushes to the default branch, turning either on **will
+break it** unless you first provision a bypass. The default `GITHUB_TOKEN` /
+`github-actions[bot]` **cannot** be a bypass actor (GitHub design). Do not enable
+this tier on a bot-pushing branch without a bypass in place.
+
+Also, on a **solo** repo, `required_approving_review_count >= 1` is a self-lockout
+(you cannot approve your own PR) — keep it `0`. And a required check that only
+runs on `pull_request` never reports on a direct push, so it **permanently**
+blocks the bot. Ensure the check runs on `push`.
+
+**Step 3a — provision the bot bypass FIRST (if a bot pushes to this branch).**
+Recommended: a GitHub App installation token. (Deploy key is a narrower
+single-repo alternative: add an SSH deploy key with write access and use
+`actor_type: DeployKey` in 3b.)
+
+```bash
+# Create a GitHub App (personal account, Settings > Developer settings >
+# GitHub Apps), permission Repository > Contents: Read and write; install it
+# on THIS repo. Store the App id as a repo variable and the private key as an
+# Actions secret. In the workflow, mint a token and pass it to checkout + the
+# commit action:
+#   - uses: actions/create-github-app-token@<sha>   # v2
+#     id: app-token
+#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+#   - uses: actions/checkout@<sha>
+#     with: { token: ${{ steps.app-token.outputs.token }} }
+#   - uses: stefanzweifel/git-auto-commit-action@<sha>
+#     with: { ... }   # inherits the app token via the checkout credentials
+#
+# The numeric App id used in Step 3b is shown on the App's own page:
+# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+# It is unrelated to the repository id and cannot be derived from /repos/$R.
+```
+
+**Higher-assurance alternative (no standing bypass actor).** If a manual merge
+click is acceptable, convert the job to open a PR with the App token (e.g.
+`peter-evans/create-pull-request`) and let a human merge. No bypass actor is
+needed and every rule stays enforced even against the automation's identity. The
+App token is still required: a PR opened with the plain `GITHUB_TOKEN` does not
+trigger `pull_request`/`push` workflows, so required checks never run and it sits
+`expected` forever (see Common Pitfalls).
+
+**Step 3b — apply the hardened ruleset with the App as an `Integration` bypass
+actor.** Replace `RULESET_ID` with the id from Step 2a, `<APP_ID>` with your App
+id, and `build` with your real check context. `bypass_mode: always` because the
+action pushes directly (use `pull_request` only if the bot opens PRs).
+
+```bash
+gh api --method PUT /repos/$R/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "pull_request", "parameters": { "required_approving_review_count": 0, "dismiss_stale_reviews_on_push": true, "require_code_owner_review": false, "require_last_push_approval": false, "required_review_thread_resolution": false, "allowed_merge_methods": ["merge"] } },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+
+# Verify the bypass actor is present:
+gh api /repos/$R/rulesets/RULESET_ID --jq '.bypass_actors'
+```
+
+`do_not_enforce_on_create: true` avoids the new-branch catch-22 (CI can't have
+run on a branch that does not exist yet). If there is **no** bot on this branch,
+you may skip 3a and omit `bypass_actors`.
+
+Trade-off: `strict_required_status_checks_policy: true` ("branch must be
+up to date") forces every open human PR to be re-updated each time the bot
+auto-commits to the default branch, and `dismiss_stale_reviews_on_push: true`
+compounds the churn — a chatty bot can make PRs perpetually unmergeable. On a
+frequently-auto-committed branch prefer `strict_required_status_checks_policy:
+false` (loose) unless up-to-date-before-merge is genuinely required.
+
+**Expected:** The ruleset now enforces the required check and required-PR rule
+for humans and forks, `.bypass_actors` lists the App (`Integration`), and the
+bot's next run still lands on the default branch (via the App token). Humans
+must open a PR; the check must be green.
+
+**On failure:** If the bot 403s after 3b, the App identity is not actually the
+bypass actor — confirm the workflow passes the App token to **checkout** (not
+just to the commit action) and that `<APP_ID>` in `bypass_actors` matches. If
+the bot's push sits `expected`/`pending` forever, the required check does not run
+on `push` — make it trigger on `push` or drop it from the required list. If the
+bypass-actor picker does not appear on your personal repo, the required-PR +
+auto-commit combination is unsatisfiable here; GitHub's workaround is a free org.
+If merges are blocked on a solo repo, `required_approving_review_count` is `>= 1`
+— set it to `0`.
+
+### Step 4: Optional Advanced Hardening
+
+Apply individually, each still confirmation-gated. None of these are needed for
+the baseline; several have sharp edges.
+
+```bash
+# 4a. Tag ruleset — protect release tags (classic tag protection is deprecated):
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{ "name": "protect-tags", "target": "tag", "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/tags/v*"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ] }
+JSON
+
+# 4b. Merge-method toggles (e.g. merge-commits-only to preserve per-commit history):
+gh api -X PATCH repos/$R -F allow_merge_commit=true -F allow_squash_merge=false \
+  -F allow_rebase_merge=false -F delete_branch_on_merge=true
+
+# 4c. CodeQL "default setup" (server-managed — commits NO workflow YAML):
+gh api -X PATCH repos/$R/code-scanning/default-setup -f state=configured -f query_suite=default
+
+# 4d. sha_pinning_required — ONLY after every `uses:` is a full 40-char SHA,
+#     or every workflow run fails (including actions/checkout):
+gh api --method PUT /repos/$R/actions/permissions -F enabled=true \
+  -f allowed_actions=selected -F sha_pinning_required=true
+# selected mode also gates WHICH actions may run: github_owned covers actions/*,
+# but git-auto-commit-action is NOT GitHub-owned — allow-list it in the SAME
+# step or the bot fails with "actions are not allowed":
+gh api --method PUT /repos/$R/actions/permissions/selected-actions \
+  -F github_owned_allowed=true -F verified_allowed=false \
+  -f 'patterns_allowed[]=stefanzweifel/git-auto-commit-action@*'
+gh api /repos/$R/actions/permissions --jq '.sha_pinning_required'   # verify
+```
+
+Note: `allowed_actions=selected` with `github_owned_allowed=true` still blocks
+`stefanzweifel/git-auto-commit-action` until it is in `patterns_allowed` (the 4d
+allow-list command handles this). Require-signed-commits and require-linear-history
+are intentionally omitted here:
+signing blocks the unsigned git-CLI bot push, and linear history is mutually
+exclusive with a merge-commits-only policy.
+
+**Expected:** Each selected advanced control is applied and verified without
+breaking the bot: tag ruleset lists on `.../rulesets`, merge toggles reflect on
+the repo object, CodeQL default setup shows `state: configured`,
+`sha_pinning_required` reads `true` only after all actions are SHA-pinned, and
+`git-auto-commit-action` is in `patterns_allowed` so the bot still runs.
+
+**On failure:** If every workflow fails right after 4d, an action is still
+tag-pinned — convert all `uses:` to SHAs or revert `sha_pinning_required` to
+`false`. If the bot fails with "actions are not allowed" after restricting
+allowed actions, add `git-auto-commit-action` to `patterns_allowed`. If 4c
+errors, the repo may have no CodeQL-supported language — skip it.
+
+## Validation
+
+- [ ] Assessment ran and scope (public/user-owned, bot-on-default-branch) confirmed before any write
+- [ ] `protect-default` ruleset active with `deletion` + `non_fast_forward`
+- [ ] `default_workflow_permissions=read` and `can_approve_pull_request_reviews=false`
+- [ ] Secret scanning + push protection + Dependabot alerts + fixes + private reporting enabled
+- [ ] `.github/dependabot.yml` (github-actions ecosystem) and `.github/SECURITY.md` committed
+- [ ] Auto-commit bot's next run still pushes successfully (baseline did not break it)
+- [ ] Required checks/PR enabled ONLY with a GitHub App (or deploy key) bypass in place first
+- [ ] Solo repo keeps `required_approving_review_count: 0`; required checks run on `push`
+- [ ] Loop guard added if a bot now pushes with an App token or PAT
+
+## Common Pitfalls
+
+- **GITHUB_TOKEN is not a bypass actor**: `github-actions[bot]` / the default
+  token cannot be added to any ruleset bypass list and cannot push to a
+  protected branch, by design. "Just add the Actions bot to the bypass list"
+  has no such option — the push 403s. Use a GitHub App or deploy key.
+- **PAT bypass is an anti-pattern**: an admin/personal PAT in the bypass list
+  (or classic BP with `enforce_admins=false`) exempts ALL admin actions
+  including your own interactive pushes — role-wide, not automation-scoped, and
+  long-lived. Prefer an App (`Integration`) or deploy key (`DeployKey`).
+- **Required checks only on `pull_request`**: a check that never runs on `push`
+  never reports on the bot's direct push, so it **permanently** blocks the bot
+  and new-branch creation. Make the check run on `push` and set
+  `do_not_enforce_on_create: true`.
+- **Loop guard once an App token replaces GITHUB_TOKEN**: the default token
+  suppresses downstream `push`/`pull_request` triggers; an App token or PAT does
+  not, so the auto-commit workflow can re-trigger itself indefinitely. Guard with
+  `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`.
+- **PR via the default GITHUB_TOKEN is a false fix**: a PR opened by
+  `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so required
+  checks never run and it sits `expected` forever. Create the PR with the App token.
+- **Alerts != fixes**: `vulnerability-alerts` and `automated-security-fixes` are
+  separate toggles; enabling alerts opens no PRs. Enable both.
+- **Don't buy GHAS on a public repo**: secret scanning, push protection, CodeQL,
+  and dependency review are already free on public repos; the paid Secret
+  Protection / Code Security products target private/org repos.
+
+## Related Skills
+
+- `assess-github-repo-security` - the read-only companion; always run this first
+- `configure-git-repository` - baseline .gitignore, branches, remotes, hooks
+- `setup-github-actions-ci` - the CI workflow whose token/permissions this hardens

--- a/i18n/es/translation_status.yml
+++ b/i18n/es/translation_status.yml
@@ -3,10 +3,10 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 140
-    stubs: 11
+    stubs: 13
   agents:
     translated: 3
     total: 73
@@ -21,13 +21,13 @@ coverage:
     stubs: 1
   guides:
     translated: 3
-    total: 33
-    pct: 9.1
+    total: 34
+    pct: 8.8
     stale: 2
-    stubs: 1
+    stubs: 2
   total:
     translated: 359
-    total: 490
-    pct: 73.3
+    total: 493
+    pct: 72.8
     stale: 146
-    stubs: 14
+    stubs: 17

--- a/i18n/ja/guides/protecting-github-repositories.md
+++ b/i18n/ja/guides/protecting-github-repositories.md
@@ -1,0 +1,246 @@
+---
+title: "Protecting GitHub Repositories"
+description: "Honest threat model, tiered checklist, rulesets vs branch protection, and the CI-bot bypass problem for hardening a public GitHub repo"
+category: infrastructure
+agents: [security-analyst]
+teams: []
+skills: [assess-github-repo-security, harden-github-repo-security]
+locale: ja
+source_locale: en
+source_commit: 84a3c915
+translator: "Claude + human review"
+translation_date: "2026-07-16"
+---
+
+# Protecting GitHub Repositories
+
+Hardening a GitHub repository is mostly a sequence of small, well-understood toggles — but a handful of them silently change *who* is gated, break a CI auto-commit bot, or provide a false sense of security while protecting almost nothing. This guide is the human-facing walkthrough: it explains the honest threat model behind ref protection, gives a tiered checklist you can apply in order, contrasts rulesets with classic branch protection, and walks through the single hardest problem — letting trusted automation write to a protected branch. Assess first, then harden.
+
+The running example throughout is the concrete case that trips most people up: a **public, user-owned** repository (like this one, `pjt222/agent-almanac`) whose CI **auto-commits to the default branch** via `stefanzweifel/git-auto-commit-action` using the default `GITHUB_TOKEN`. Everything here is grounded in current GitHub behavior; where a control interacts badly with that bot, it is called out explicitly.
+
+## When to Use This Guide
+
+- You own a public repository and want to harden it without breaking a working CI pipeline that pushes to `main`.
+- You are about to turn on branch protection or a ruleset and want to know what it actually stops — and what it does not.
+- Your CI bot suddenly started getting `403` on its push, or your PRs are stuck on a check that never runs.
+- You are choosing between classic branch protection and repository rulesets and want the honest tradeoffs.
+- A single-maintainer repo locked you out of merging your own pull requests.
+
+## Prerequisites
+
+- Admin access to the repository (most controls require it).
+- The [`gh` CLI](https://cli.github.com) authenticated (`gh auth status`) — every command here uses it, and the API is the source of truth over the UI.
+- A completed **assessment** of the repo's current posture — run the [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) skill *before* changing anything, so you know your baseline and do not toggle controls you already have.
+- If your CI writes to a protected branch, know which action does the push and which token it uses.
+
+## Workflow Overview
+
+The order matters. Hardening blind is how you break the bot or lock yourself out.
+
+1. **Assess** — inventory the current state with [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md): existing rules, token defaults, enabled security features, and how CI pushes.
+2. **Apply the zero-downside baseline** — the essential tier below hardens the repo *without* touching anything the bot depends on.
+3. **Decide on required checks / required PR** — this is the fork in the road. It is the single control most in tension with a direct-push bot; if you want it, you must first provision a bypass identity for the bot (see the bypass matrix).
+4. **Harden the automation path** — swap the bot to a GitHub App token and add the App as a ruleset bypass actor, or route it through a pull request.
+5. **Verify** — re-run the assessment; confirm the bot still pushes and humans/forks are still gated.
+
+The [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) skill drives steps 2–4 as an executable procedure; the [security-analyst](../agents/security-analyst.md) agent is the persona that owns this end-to-end.
+
+## The Honest Threat Model
+
+Ref protection — whether you call it a *ruleset* or a *branch protection rule* — protects **one ref**, not the repository. Internalizing that sentence prevents most false-security mistakes.
+
+**What ref protection does stop:** rewriting, force-pushing, or deleting the protected branch; landing changes to it without a pull request (if you require one); merging before required status checks pass. It gates the *history of one branch*.
+
+**What it does NOT stop:**
+
+- A write collaborator pushing to any **unprotected** branch, then adding a malicious workflow that runs with your repo's token.
+- Moving or creating **tags** (unless you also protect tags with a tag ruleset).
+- Introducing a **compromised or typo-squatted action** into a workflow that holds `contents: write`.
+- A workflow triggered on **`pull_request_target`** that checks out the PR head. This trigger runs in the *base-repo* context with secrets and a write token regardless of branch protection, so checking out untrusted code under it is a documented privilege-escalation / RCE pattern. Avoid `pull_request_target` for anything that checks out untrusted code, and never interpolate `${{ github.event.pull_request.* }}` fields directly into a `run:` shell step (route them through an intermediate `env:` var). Ref protection does nothing about this.
+- Secrets already committed (protection is about refs, not content) — that is what secret scanning and push protection are for.
+
+So a branch rule is one layer. Ruleset scope, an allowed-actions policy, fork-PR approval, and secret scanning matter as much as the branch rule itself. Treat "the branch is protected" as *necessary, not sufficient*.
+
+### The mental-model shift that catches everyone
+
+Here is the subtle part. Under **classic branch protection**, repository admins bypass the rules **by default** — the rule simply does not apply to them unless you also check *"Do not allow bypassing the above settings"* (`enforce_admins=true`). That toggle is all-or-nothing: it applies the rules to *every* admin or *no* admin, with no per-actor granularity.
+
+**Rulesets invert this default.** A ruleset applies to admins too — nobody is exempt *unless they are explicitly added to the ruleset's `bypass_actors` list*. There is no `enforce_admins` toggle on a ruleset.
+
+Porting the classic "admins can always bypass" mental model to a ruleset **silently changes who is gated**:
+
+- If you *assume* you (as admin) can always push past a ruleset, you will be surprised by a `403` — the ruleset gates you unless you added your admin role to the bypass list.
+- Conversely, if you migrate from classic BP where admins were quietly exempt, a ruleset will now enforce against those same admins — usually what you wanted, but a behavior change to be aware of.
+
+This is why the assessment step matters: the same words ("branch protection") describe two systems with opposite default answers to "does this apply to me?"
+
+## Rulesets vs Classic Branch Protection
+
+**Prefer repository rulesets. Treat classic branch protection as legacy.** GitHub's own docs position classic BP as the thing rulesets are an "alternative" to, and rulesets are the actively developed path.
+
+| Capability | Repository Ruleset | Classic Branch Protection |
+|---|---|---|
+| Availability on free public user-owned repo | Yes, fully free | Yes |
+| Multiple rules stack (most-restrictive wins) | Yes | No — one rule matches |
+| Per-actor bypass list (roles, teams, Apps, deploy keys) | Yes | No |
+| Exempt a *specific actor* from required status checks | Yes | **No — impossible** |
+| Admin exemption model | Per-actor via bypass list | All-or-nothing (`enforce_admins`) |
+| Target multiple branches / tags by pattern | Yes (`~DEFAULT_BRANCH`, `~ALL`, fnmatch) | Limited |
+| Tag protection | Tag ruleset (`target: tag`) | Deprecated 2024-08-30, auto-migrated |
+
+Two facts do the heavy lifting for the running example:
+
+- **Rulesets are free on public user-owned repos.** The docs are explicit — do not tell a free personal-public-repo owner to upgrade. (Only *private* personal repos need GitHub Pro for rulesets; org-wide rulesets and the "Evaluate" dry-run mode are the Team/Enterprise-gated pieces.)
+- **Classic BP cannot exempt any actor from required status checks.** Its push allowlist ("Restrict who can push") is organization-only and, even where available, governs *who may push*, not *who may skip checks*. GitHub staff redirected the multi-year feature request for this to rulesets. For any "let one specific bot through required checks" need — exactly the auto-commit case — rulesets are mandatory.
+
+A minimal, safe default-branch ruleset (force-push + deletion protection only — this does **not** break a direct-push bot):
+
+```bash
+gh api --method POST /repos/OWNER/REPO/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+```
+
+Inspect what exists before and after: `gh api /repos/OWNER/REPO/rulesets` and `gh api /repos/OWNER/REPO/rulesets/RULESET_ID --jq '.bypass_actors'`.
+
+## The Tiered Hardening Checklist
+
+Apply top to bottom. The **essential** tier is zero-downside and does not break the auto-commit bot; **recommended** introduces the bot-bypass decision; **advanced** is high-friction or niche.
+
+### Essential (zero-downside baseline)
+
+- **Force-push + deletion protection** via a default-branch ruleset (`non_fast_forward` + `deletion`). The cheapest, no-downside hardening; safe for a direct-push bot.
+- **Set the default `GITHUB_TOKEN` to read-only** and disable token PR approval. This is a *default*, not a hard cap, for same-repo push events — so it does not break the bot **provided the committing job grants `contents: write` back** (the next bullet). If your workflow has no explicit `permissions:` block and relied on the ambient write default, add that grant *first* or the `git-auto-commit-action` push `403`s.
+  ```bash
+  gh api --method PUT /repos/OWNER/REPO/actions/permissions/workflow \
+    -f default_workflow_permissions=read -F can_approve_pull_request_reviews=false
+  ```
+- **Least-privilege per-workflow permissions.** Top-level `permissions: {}` in the workflow YAML, then grant `contents: write` back only on the job that commits — `git-auto-commit-action` needs nothing more.
+- **Pin every action to a full 40-char commit SHA** (including `actions/checkout` and `stefanzweifel/git-auto-commit-action`), with the human-readable version in a trailing comment. A mutable tag is a supply-chain hole on a workflow that holds `contents: write`.
+  ```yaml
+  - uses: stefanzweifel/git-auto-commit-action@<40-char-sha>  # v6.x.x
+  ```
+- **Leave fork-PR approval at the public-repo default** ("Require approval for first-time contributors"). Fork `pull_request` runs already get a read-only token and no secrets.
+- **Enable Dependabot alerts + security updates + a `.github/dependabot.yml`.** Alerts and fixes are *separate* toggles — enable both, or you detect vulnerabilities and fix nothing. Include a `github-actions` ecosystem block to keep action SHAs fresh.
+  ```bash
+  gh api -X PUT repos/OWNER/REPO/vulnerability-alerts      # alerts + dependency graph
+  gh api -X PUT repos/OWNER/REPO/automated-security-fixes  # Dependabot fix PRs
+  ```
+- **Enable secret scanning + push protection** (free and usually already on for public repos); add `.github/SECURITY.md` and private vulnerability reporting (both per-repo, no org needed).
+  ```bash
+  gh api -X PATCH repos/OWNER/REPO --input - <<<'{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}'
+  gh api -X PUT repos/OWNER/REPO/private-vulnerability-reporting
+  ```
+- **Do NOT purchase GHAS / Secret Protection / Code Security for a public repo.** Secret scanning, push protection, CodeQL, and dependency review are already free on public repos; those paid products are private/org-only.
+
+### Recommended
+
+- **Add `required_status_checks`** to the ruleset with `do_not_enforce_on_create=true` and `strict_required_status_checks_policy=true`. **Critical:** this blocks the bot's direct push unless you provision a bypass (next item), *and* the checks must run on `push`, not only `pull_request`, or they never report and the push is permanently blocked.
+- **Add a `pull_request` rule** if you want a review surface. On a solo repo keep `required_approving_review_count: 0` — you cannot approve your own PR, and `>= 1` is an unsatisfiable self-lockout.
+- **Provision a GitHub App bypass for the bot** (Contents: read/write) via `actions/create-github-app-token`, pass the token to checkout + `git-auto-commit-action`, and add the App as an `Integration` bypass actor with `bypass_mode: always`. This is the correct realization of "let the bot through" once required checks/PR are on.
+- **Enable CodeQL "default setup"** (server-managed) rather than advanced setup, so no extra workflow YAML is committed into a repo that auto-commits.
+- **Set merge-method toggles to match policy** (e.g. merge-commits-only: `allow_squash_merge=false`, `allow_rebase_merge=false`) and auto-delete head branches on merge.
+- **Restrict the allowed-actions policy** to GitHub-owned + an explicit allow-list that *includes* `stefanzweifel/git-auto-commit-action` (it is not GitHub-owned; omitting it silently fails the workflow).
+
+### Advanced
+
+- **Protect release tags** with a tag ruleset (`target: tag`, e.g. `v*`).
+- **Enable the `sha_pinning_required` repo policy** (2025-08-15) — but only *after* converting every `uses:` to a full SHA, or every run fails. First confirm the field is actually exposed on a free user-owned public repo (it may be org/enterprise-gated): `gh api /repos/OWNER/REPO/actions/permissions --jq '.sha_pinning_required'`.
+- **`dismiss_stale_reviews_on_push` + require conversation resolution + `require_last_push_approval`** — only meaningful once you run human PR reviews; a chatty auto-commit bot pushing into open PRs can make them perpetually unmergeable.
+- **CODEOWNERS + `require_code_owner_review`** — low value on a solo repo (you can only list `@users`, and the sole owner cannot satisfy it as PR author).
+- **Require signed commits** — high friction: `git-auto-commit-action` pushes unsigned via git CLI, so this blocks the bot. `GITHUB_TOKEN` commits are auto-verified only via the Contents API, not `git push`.
+- **Require linear history** — mutually exclusive with a merge-commits-only policy; pick one.
+
+## Automation Through Protection: The Bot Bypass Problem
+
+This is the crux of the running example. Once you turn on required checks or require-a-PR, a push to the default branch must either satisfy the rules or come from a **bypass actor**. And here is the hard constraint that no toggle removes:
+
+> The default `GITHUB_TOKEN` / `github-actions[bot]` **cannot** be added to any bypass list and **cannot** push to a protected branch. This is by GitHub design — otherwise any collaborator could ship a workflow that writes to any branch. Any plan phrased as "just add the Actions bot to bypass" silently has no such option, and the bot's push `403`s.
+
+So to let trusted automation through, you must give it a *real* bypass-eligible identity. Ranked from best to worst:
+
+| Approach | Keeps checks enforced for humans? | Least-privilege rank | Verdict |
+|---|---|---|---|
+| PR-based (create-pull-request) with a **GitHub App token**, human clicks merge — no standing bypass | Yes | 1 | Strongest separation of duties. App token makes checks actually fire on the bot's change; no standing branch bypass. Not fully hands-off — a human merges. |
+| **GitHub App** installation token (Contents: read/write) + App as `Integration` bypass actor, `bypass_mode: always` | Yes | 2 | **Recommended default for full automation.** Repo-scoped, ~1h ephemeral, identity-scoped bypass; humans/forks/admins stay gated. Crown-jewel risk shifts to the App private key. |
+| SSH **deploy key** (write) + `DeployKey` bypass actor, push over SSH | Yes | 3 | Good narrow single-repo alternative — no App to maintain, no API scope. One private key per repo to rotate. Slightly coarser identity than an App. |
+| Bot-account **PAT** as a `User` bypass actor | Yes | 4 | Anti-pattern. Long-lived, tied to a maintained account; rotation/offboarding risk; re-triggers workflows (needs a loop guard). Stopgap only. |
+| Admin/fine-grained **PAT** + `Repository admin` role in bypass | **No** | 5 | Worst. Role-wide hole — exempts *all* admin actions including your own interactive pushes, not just automation. A leaked PAT = admin bypass-write. |
+| Add the default **`GITHUB_TOKEN`** to the bypass list | — | 6 | **Impossible.** Not a selectable actor by design; the push `403`s. |
+
+> **Verify the bypass-actor picker before you commit to this.** Historically the ruleset bypass-actor UI did **not** appear on user-owned (personal) repositories — the exact repo class this guide centers on. Before you build the App and flip on required checks / require-a-PR for real, open **Settings > Rules > Rulesets > (your ruleset) > Bypass list > Add bypass** and confirm the App is actually selectable. If it is not, the required-checks / required-PR combination is **unsatisfiable** on a personal repo — the bot's direct push cannot be let through by any means — and GitHub's documented workaround is to move the repo under a (free) **organization**, where App and role bypass actors are reliably available. This is version-dependent, so check your own repo rather than assuming the App route works.
+
+The **GitHub App** route (rank 2) is the recommended default *once you have confirmed the App is addable as a bypass actor*. Mint the token at runtime and wire it through the bot:
+
+```yaml
+- uses: actions/create-github-app-token@<sha>  # official
+  id: app-token
+  with:
+    app-id: ${{ vars.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+- uses: actions/checkout@<sha>
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+- uses: stefanzweifel/git-auto-commit-action@<sha>  # inherits the App token
+```
+
+Then add the App to the ruleset bypass list:
+
+```bash
+gh api --method PUT /repos/OWNER/REPO/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+```
+
+Two follow-ups once an App token or PAT is in play: (1) the crown-jewel secret is now the **App private key** — store it as an Actions secret, scope the App install to the single repo, and rotate; (2) unlike the default `GITHUB_TOKEN` (which suppresses downstream triggers), an App/PAT push **re-triggers** `on: push` workflows, so add a loop guard (`if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`).
+
+## Common False-Security Traps
+
+These are the beliefs that feel like security but are not.
+
+- **"Just add the github-actions bot to the ruleset bypass list."** It is not a selectable actor; the push `403`s. Use a GitHub App or deploy key identity.
+- **"Convert the bot from push to a PR to satisfy the rules."** A PR opened by the default `GITHUB_TOKEN` does **not** trigger `pull_request`/`push` workflows, so required checks never run and the PR sits on "expected/pending" forever. The PR must be created with an App token or PAT.
+- **"Required status checks mean nothing unreviewed lands."** Without a *required-PR* rule, anyone with write can still push directly if a check reports on push; and in classic BP admins bypass by default unless `enforce_admins=true`. Rulesets differ — they do not auto-exempt admins — so porting the classic mental model silently changes who is gated.
+- **"Branch protection protects the repo from a malicious collaborator."** It protects one ref. A write collaborator can push to unprotected branches, add a malicious workflow, or move tags. Scope, allowed-actions policy, and fork approval matter as much.
+- **"Public-repo secret scanning stops leaks."** Alerts fire *after* the commit; push protection blocks at push time but the auto-commit bot cannot click the interactive web bypass, so a CI-committed secret just fails the job — treat it as a real finding, not a flake. The free tier also covers provider patterns only, not every generic secret.
+- **"Require signed commits is free hardening."** It blocks the bot, which pushes unsigned via git CLI. Keeping both requires an API-based commit action.
+- **"Swap `GITHUB_TOKEN` for a broad PAT to get past protection."** A PAT is long-lived and account-wide — a strict privilege escalation over the ephemeral repo-scoped token. Prefer an App or deploy key.
+- **"Buy GHAS to secure a public repo."** Those features are already free on public repos; the paid split targets private/org repos only.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Bot push `403`s after enabling required checks / require-PR | The default `GITHUB_TOKEN` cannot be a bypass actor and cannot push to a protected branch | Provision a GitHub App token (or deploy key) and add that identity to the ruleset `bypass_actors`; pass the token to checkout + `git-auto-commit-action` |
+| Cannot add the App (or any actor) to the ruleset bypass list on a personal repo | The bypass-actor picker historically did not appear on user-owned repos; without it, required-checks/required-PR + a direct-push bot is unsatisfiable | Verify the picker under Settings > Rules > Rulesets > Bypass list; if it is absent, move the repo under a free organization (GitHub's documented workaround) or keep the default branch at the essential-tier baseline only |
+| PR opened by the bot is stuck on a check that shows "expected"/pending forever | A PR created with the default `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so checks never run | Create the PR with a GitHub App token (or PAT), which fires both event types; then the checks actually run and can gate the merge |
+| Solo maintainer cannot merge own PR | `required_approving_review_count >= 1` (or `require_code_owner_review`) — you cannot approve your own PR, and a ruleset does not auto-exempt you as admin | Set `required_approving_review_count: 0`, or add a second reviewer / a second trusted App as a bypass path |
+| New branch cannot be created; "required status check is expected" | Required checks block branch *creation* — CI cannot have run on a branch that does not exist (catch-22); or checks only trigger on `pull_request` and never report on a push | Set `do_not_enforce_on_create: true` on the `required_status_checks` rule, and make the check run on `push`, not only `pull_request` |
+| `sha_pinning_required` breaks every workflow run | The policy fails any `uses:` not pinned to a full 40-char SHA, including `actions/checkout@v4` | Convert *all* `uses:` to full commit SHAs *before* enabling the policy |
+| `allowed_actions=selected` fails the auto-commit job | `github_owned_allowed=true` still blocks `git-auto-commit-action` — it is not GitHub-owned | Add `stefanzweifel/git-auto-commit-action@*` to `patterns_allowed` |
+| Bot loops / re-triggers itself after switching to an App token | App/PAT pushes re-trigger `on: push` (default `GITHUB_TOKEN` suppressed them) | Add a loop guard: `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]` in the commit message |
+
+## Related Resources
+
+- [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) — inventory the current posture **first**; run before any hardening
+- [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) — the executable procedure that applies this checklist and the bot bypass
+- [security-analyst](../agents/security-analyst.md) — the agent persona that owns repository hardening end-to-end
+- [WSL Maintenance & Claude Code Reference](wsl-maintenance.md) — periodic security-scan greps for leaked secrets and hardcoded paths
+- [Setting Up Your Environment](setting-up-your-environment.md) — first-time environment, shell, and Claude Code setup

--- a/i18n/ja/skills/assess-github-repo-security/SKILL.md
+++ b/i18n/ja/skills/assess-github-repo-security/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: assess-github-repo-security
+description: >
+  Read-only audit of a GitHub repository's security posture. Gathers ref
+  protection (rulesets AND classic branch protection), Actions token
+  permissions, code and supply-chain features (Dependabot, secret
+  scanning, push protection, CodeQL), and repo hygiene toggles via
+  `gh api`, then classifies findings against essential / recommended /
+  advanced tiers into a PASS/GAP report. Makes NO changes. Use when
+  reviewing a repo before open-sourcing or a release, auditing a public
+  user-owned repo whose CI auto-commits to the default branch, verifying
+  a hardening change actually took effect, or producing a baseline
+  security posture report for a repository.
+license: MIT
+allowed-tools: Read Bash Grep
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: intermediate
+  language: multi
+  tags: github, security, audit, rulesets, branch-protection, dependabot, actions
+  locale: ja
+  source_locale: en
+  source_commit: 84a3c915
+  translator: "Claude + human review"
+  translation_date: "2026-07-16"
+---
+
+# Assess GitHub Repository Security
+
+Audit a GitHub repository's security posture, read-only, and classify it
+against tiered best practices. This skill only reads — it never enables,
+disables, or changes any setting. Remediation is a separate concern (see
+`harden-github-repo-security`).
+
+## When to Use
+
+- Reviewing a repo before open-sourcing it or cutting a release
+- Auditing a public, user-owned repo whose CI auto-commits to the default
+  branch (e.g. via `stefanzweifel/git-auto-commit-action` + the default
+  `GITHUB_TOKEN`)
+- Verifying that a hardening change actually took effect
+- Producing a baseline posture report to track over time
+
+## Inputs
+
+- **Required**: Target repository as `OWNER/REPO`
+- **Required**: `gh` CLI authenticated with an account that has the
+  **admin repository role** on the target repo (some endpoints 403
+  otherwise). This is a role requirement, not a need for a broad
+  write-capable token: a fine-grained, single-repo PAT scoped to
+  read-only Administration / Actions / Secret-scanning permissions
+  satisfies the same admin check with far less blast radius if the
+  audit credential is ever leaked or reused in automation
+- **Optional**: Branch to check for classic protection (defaults to the
+  repo's `default_branch`)
+- **Optional**: `security_events` token scope — needed only to count open
+  Dependabot alerts; the rest works without it
+
+Set a shorthand for every command below:
+
+```bash
+R="OWNER/REPO"   # e.g. pjt222/agent-almanac
+```
+
+## Procedure
+
+### Step 1: Preflight — auth and admin
+
+Confirm the CLI is authenticated and the account has admin on the repo.
+Non-admins get partial data (403 on rulesets, Actions, and security
+endpoints), which silently understates the posture.
+
+```bash
+gh auth status
+gh api "repos/$R" --jq '{full_name, admin: .permissions.admin, visibility}'
+```
+
+**Expected:** `gh auth status` shows a logged-in account; the second call
+prints `admin: true`.
+
+**On failure:** If not authenticated, run `gh auth login` (or set
+`GH_TOKEN`). If `admin: false`, stop and note in the report that findings
+are **incomplete** — a non-admin cannot read ruleset internals or Actions
+permissions, so absence of a control cannot be distinguished from lack of
+access.
+
+### Step 2: Repo basics — visibility, merge toggles, collaborators
+
+```bash
+gh api "repos/$R" --jq '{visibility, private, allow_forking,
+  default_branch, allow_merge_commit, allow_squash_merge,
+  allow_rebase_merge, delete_branch_on_merge}'
+
+# Direct collaborators and their effective role
+gh api "repos/$R/collaborators?affiliation=direct" \
+  --jq '.[] | {login, role_name}'
+```
+
+**Expected:** JSON for the repo toggles plus one line per direct
+collaborator with `role_name` (`admin`/`maintain`/`write`/`triage`/`read`).
+
+**On failure:** A 403 on `collaborators` means the token lacks admin; note
+it and continue. Record `visibility` — it changes which features are
+**free**: on **public** repos secret scanning, push protection, CodeQL,
+and dependency review are free; the paid GHAS/Secret Protection products
+are private/org-only, so their absence on a public repo is not a gap.
+
+### Step 3: Ref protection — check rulesets AND classic (both)
+
+A repo can be protected by a **ruleset**, by **classic branch
+protection**, by both, or by neither. Rulesets are the actively-developed
+path and are free on public user-owned repos. You MUST check both — a repo
+with only a ruleset returns 404 on the classic endpoint and vice versa.
+
+```bash
+b=$(gh api "repos/$R" --jq '.default_branch')
+
+# (a) Rulesets — list, then inspect each active one's rules + bypass list
+gh api "repos/$R/rulesets" --jq '.[] | {id, name, enforcement, target}'
+# For each id from above:
+#   gh api "repos/$R/rulesets/<id>" \
+#     --jq '{name, enforcement,
+#            rules: [.rules[].type],
+#            bypass: [.bypass_actors[] | {actor_type, bypass_mode}]}'
+
+# (b) Classic branch protection on the default branch (404 = none)
+gh api -i "repos/$R/branches/$b/protection" 2>/dev/null | head -1
+gh api "repos/$R/branches/$b/protection" \
+  --jq '{required_status_checks: .required_status_checks.checks,
+         strict: .required_status_checks.strict,
+         enforce_admins: .enforce_admins.enabled,
+         required_reviews: .required_pull_request_reviews.required_approving_review_count,
+         linear: .required_linear_history.enabled,
+         signatures: .required_signatures.enabled,
+         allow_force_pushes: .allow_force_pushes.enabled,
+         allow_deletions: .allow_deletions.enabled}' 2>/dev/null \
+  || echo "no classic branch protection"
+```
+
+**Expected:** Either a ruleset with rules such as `deletion`,
+`non_fast_forward`, `pull_request`, `required_status_checks`, or a classic
+protection object, or an explicit "none" from both.
+
+**On failure:** A `404` on either endpoint means that mechanism is **not
+configured** — it is a valid data point, not an error; record "none" for
+that mechanism. Note the rule set from the ruleset `rules[].type` list and
+the `bypass_actors`. Remember: the default `GITHUB_TOKEN` /
+`github-actions[bot]` can never be a bypass actor by design — if the repo
+auto-commits AND has `required_status_checks`/`pull_request` rules with no
+`Integration` (GitHub App) or `DeployKey` bypass actor, flag that the bot
+push must be 403ing (a real finding).
+
+### Step 4: Actions security — token defaults and PR approval
+
+```bash
+# Actions enablement + allowed-actions policy (+ SHA-pinning policy)
+gh api "repos/$R/actions/permissions" \
+  --jq '{enabled, allowed_actions, sha_pinning_required}'
+
+# Default GITHUB_TOKEN permissions + can-the-bot-approve-PRs
+gh api "repos/$R/actions/permissions/workflow" \
+  --jq '{default_workflow_permissions, can_approve_pull_request_reviews}'
+```
+
+**Expected:** `default_workflow_permissions` is `read` (hardened) or
+`write` (permissive default), and `can_approve_pull_request_reviews` is
+`false` (hardened) or `true` (a review-bypass vector).
+
+**On failure:** 403 means non-admin — note it. If
+`allowed_actions` is `all`, any action can run (looser); `selected` with a
+pinned allow-list is tighter — but note that `selected` +
+`github_owned_allowed` still blocks non-GitHub actions like
+`stefanzweifel/git-auto-commit-action` unless explicitly allow-listed.
+`sha_pinning_required` may be absent/`null` on repos that never set the
+2025-08 policy — record as "not enforced". Per-workflow `permissions:`
+blocks live in the YAML, not the API; note that the API shows only the
+repo **default**, which is a default (not a cap) for same-repo push
+events.
+
+### Step 5: Code and supply-chain features
+
+```bash
+# Dependabot alerts + dependency graph (204 = ON, 404 = OFF)
+gh api -i "repos/$R/vulnerability-alerts" 2>/dev/null | head -1
+
+# Dependabot security updates (auto fix PRs) — separate toggle
+gh api "repos/$R/automated-security-fixes" \
+  --jq '{enabled, paused}' 2>/dev/null || echo "automated-security-fixes: off/unavailable"
+
+# Secret scanning + push protection status (security_and_analysis has NO
+# code-scanning field — CodeQL is probed separately below)
+gh api "repos/$R" --jq '.security_and_analysis'
+
+# CodeQL code scanning — default setup state (its own endpoint)
+gh api "repos/$R/code-scanning/default-setup" --jq '.state' 2>/dev/null \
+  || echo "code-scanning default setup: not configured / no access"
+
+# Dependabot version updates config present?
+gh api -i "repos/$R/contents/.github/dependabot.yml" 2>/dev/null | head -1
+
+# SECURITY.md — GitHub auto-detects it at root, docs/, OR .github/.
+# Present if ANY of the three returns 200; only a GAP if all three 404.
+for p in SECURITY.md docs/SECURITY.md .github/SECURITY.md; do
+  echo "$p: $(gh api -i "repos/$R/contents/$p" 2>/dev/null | head -1)"
+done
+
+# Private vulnerability reporting — status is a 200 body {"enabled": bool},
+# NOT a 204/404 toggle, so read the field directly.
+gh api "repos/$R/private-vulnerability-reporting" --jq '.enabled' 2>/dev/null \
+  || echo "PVR: not accessible"
+
+# Open Dependabot alert count — needs security_events scope; may 403
+gh api "repos/$R/dependabot/alerts?state=open" --jq 'length' 2>/dev/null \
+  || echo "dependabot/alerts: 403 (needs security_events scope) — skipped"
+```
+
+**Expected:** `vulnerability-alerts` → `HTTP/2.0 204` when enabled;
+`security_and_analysis` shows `secret_scanning.status` and
+`secret_scanning_push_protection.status` as `enabled` on a hardened public
+repo; `code-scanning/default-setup` `.state` is `configured` when CodeQL
+default setup is on; `automated-security-fixes` → `enabled: true`; the
+`dependabot.yml` probe returns `200` when present; at least one of the
+three SECURITY.md paths returns `200` when a policy file exists;
+`private-vulnerability-reporting` `.enabled` prints `true` when PVR is on.
+
+**On failure:** `vulnerability-alerts` returning `404` = Dependabot alerts
+OFF (a gap). Remember **alerts != fixes**: alerts on with
+`automated-security-fixes` off means nothing is auto-remediated — flag
+both separately. On **public** repos `secret_scanning` is usually already
+`enabled` by default; if `security_and_analysis` omits the field entirely,
+treat it as advisory (public-repo default on) but note the API did not
+confirm it. `code-scanning/default-setup` `404`/non-`configured` = CodeQL
+default setup not enabled (a recommended-tier gap on a public repo, where
+code scanning is free). For SECURITY.md, record a GAP **only if all three
+paths 404** — a `200` on root, `docs/`, or `.github/` all count as
+present. `private-vulnerability-reporting` empty/`false` = PVR off; a
+non-JSON or error response = not accessible. `dependabot/alerts` 403 is
+expected without `security_events` scope — record "not assessed", not "0".
+
+### Step 6: Produce the tiered PASS/GAP report
+
+Classify every gathered fact into three tiers and mark **PASS** (control
+present), **GAP** (control absent), or **N/A** (not applicable, e.g. a paid
+private-repo feature on a public repo). Distinguish a **required** check
+from an **advisory** one: a status check that runs but is not listed in the
+ruleset's `required_status_checks` does not gate anything — it is advisory
+only.
+
+**Interpret the solo-maintainer lockout.** Cross-reference the Step 2
+direct-collaborator count with the Step 3 `required_approving_review_count`.
+On a single-maintainer repo, `required_approving_review_count >= 1` (and
+`require_code_owner_review` with a sole owner) is **unsatisfiable** — you
+cannot approve your own PR — so on an auto-commit repo it is a self-lockout
+/ functional breakage, **not** a PASS. Flag it as a GAP-with-caveat, and
+note that a **ruleset** (unlike classic branch protection's `enforce_admins`)
+does **not** auto-exempt the admin: the sole maintainer stays blocked unless
+explicitly added to the ruleset `bypass_actors`.
+
+**Do not publish the raw report into the audited repo.** The PASS/GAP list
+enumerates exact, admin-only-visible gaps (no ruleset, `GITHUB_TOKEN` can
+approve PRs, no push protection) — a pre-remediation vulnerability roadmap.
+While any GAP is open, keep the findings **local/private** (a gitignored
+file, a private gist, or a draft GitHub Security Advisory); never commit it
+into the public repo being audited (contrast `security-audit-codebase`,
+which writes `SECURITY_AUDIT_REPORT.md` into the project root — do NOT copy
+that pattern here). Redact ruleset / App ID / bypass-actor identifiers
+before any public write.
+
+```text
+# GitHub Repo Security Assessment — OWNER/REPO
+Date: YYYY-MM-DD   Visibility: public   Auditor role: admin
+
+## Essential
+- [PASS] Ruleset with deletion + non_fast_forward on default branch
+- [GAP]  default_workflow_permissions = write (should be read)
+- [PASS] can_approve_pull_request_reviews = false
+- [GAP]  actions/checkout pinned to @v4 tag, not a 40-char SHA
+- [PASS] Dependabot alerts (204) + security updates (enabled)
+- [GAP]  No .github/dependabot.yml (version updates off — keeps
+         github-actions action pins fresh; essential supply-chain hygiene)
+- [PASS] Secret scanning + push protection enabled
+
+## Recommended
+- [N/A]  required_status_checks — none (no CI gate configured)
+- [PASS] CodeQL default setup: configured
+- [PASS] SECURITY.md present (.github/) + PVR enabled
+
+## Advanced
+- [GAP]  sha_pinning_required: not enforced
+- [N/A]  Required signed commits — would block the auto-commit bot
+- [N/A]  Paid GHAS / Secret Protection — public repo, features free
+
+## Notes
+- Auto-commit bot: ruleset has NO App/DeployKey bypass actor; if
+  required_status_checks were added the github-actions[bot] push would 403.
+- Solo maintainer (1 direct collaborator): required_approving_review_count
+  is 0 — correct; any value >= 1 would be an unsatisfiable self-lockout and
+  a ruleset would NOT auto-exempt the admin.
+- Dependabot open alerts: not assessed (token lacks security_events).
+- This report is kept local/private — not committed into the audited repo
+  while GAPs remain open.
+```
+
+**Expected:** A written report with every fact placed in a tier and
+marked PASS / GAP / N/A, plus a Notes section for auth gaps, advisory-only
+checks, and the auto-commit-bot bypass interaction.
+
+**On failure:** If some endpoints 403'd, still emit the report but mark
+those rows "not assessed" and state the missing scope/role at the top —
+never record an unreadable control as a GAP (absence of access is not
+absence of the control).
+
+## Validation
+
+- [ ] `gh auth status` confirmed and admin on the repo verified (or the
+      report is explicitly flagged incomplete)
+- [ ] `visibility` recorded (drives which features are free vs N/A)
+- [ ] BOTH rulesets AND classic branch protection were queried (not just one)
+- [ ] Actions `permissions` and `permissions/workflow` both read
+- [ ] Dependabot alerts, security updates, secret scanning, and push
+      protection each checked as **separate** toggles
+- [ ] CodeQL default setup queried via `code-scanning/default-setup`
+      (not inferred from `security_and_analysis`, which has no such field)
+- [ ] SECURITY.md checked at all three auto-detected paths (root, `docs/`,
+      `.github/`) — GAP only if all three 404
+- [ ] Private vulnerability reporting read from the `.enabled` body field
+      (not a 204/404 toggle)
+- [ ] Solo-maintainer lockout interpreted: collaborator count cross-referenced
+      with `required_approving_review_count`
+- [ ] Every finding is tiered and marked PASS / GAP / N/A
+- [ ] Report kept local/private while GAPs are open — NOT committed into
+      the audited public repo
+- [ ] No setting was changed — this audit is strictly read-only
+
+## Common Pitfalls
+
+- **Checking only rulesets or only classic protection**: They are
+  independent mechanisms. A repo protected by a ruleset returns `404` on
+  `branches/{b}/protection`; concluding "unprotected" from that alone is
+  wrong. Always query both.
+- **Some endpoints 403 without security scope/admin**: `dependabot/alerts`
+  needs `security_events`; rulesets and Actions permissions need admin. A
+  403 is "not assessed", not a GAP — recording it as a gap fabricates a
+  finding.
+- **A green check that is not REQUIRED is advisory only**: A CI job that
+  runs and passes gates nothing unless its context is in the ruleset's
+  `required_status_checks`. Do not report a running check as a protective
+  control.
+- **Alerts != fixes**: Dependabot **alerts** (`vulnerability-alerts`, 204)
+  only detect; **security updates** (`automated-security-fixes`) open the
+  fix PRs. Enabling one does not enable the other — assess both.
+- **Treating paid-feature absence as a gap on a public repo**: Secret
+  scanning, push protection, CodeQL, and dependency review are free on
+  public repos; GHAS / Secret Protection / Code Security are private/org
+  products. Their absence on a public repo is N/A, not a gap.
+- **Misreading the auto-commit-bot bypass**: The default `GITHUB_TOKEN` /
+  `github-actions[bot]` can never be a ruleset bypass actor. If a repo
+  auto-commits to a branch that has `required_status_checks` or a
+  `pull_request` rule with no `Integration`/`DeployKey` bypass actor, the
+  bot push is being rejected — surface it as a real finding.
+- **Reading the API default as a hard cap**: `default_workflow_permissions`
+  is the repo default; per-job `permissions:` in the workflow YAML can
+  raise or drop it for same-repo events. The API cannot show the effective
+  per-workflow grant — note that limitation.
+- **Probing SECURITY.md at only one path**: GitHub auto-detects the policy
+  at the repo root, `docs/`, OR `.github/`. Checking only one path and
+  recording a 404 as a GAP fabricates a finding — a repo with SECURITY.md
+  at root is fully compliant. Only record a GAP if all three 404.
+- **Inferring CodeQL from `security_and_analysis`**: that object carries
+  `secret_scanning*`, `dependabot_security_updates`, and `advanced_security`
+  — but **no** code-scanning field. CodeQL default-setup state comes only
+  from the `code-scanning/default-setup` endpoint; never claim a CodeQL
+  PASS/GAP the skill did not actually probe.
+- **Marking a solo review requirement as PASS**: on a one-maintainer repo,
+  `required_approving_review_count >= 1` is an unsatisfiable self-lockout,
+  not a protective control — and a ruleset (unlike classic `enforce_admins`)
+  will not auto-exempt the admin. Report it as a functional-breakage GAP.
+
+## Related Skills
+
+- `harden-github-repo-security` - apply the fixes this audit surfaces
+- `security-audit-codebase` - complementary in-tree secret/dependency scan
+- `configure-git-repository` - foundational repo + `.gitignore` setup

--- a/i18n/ja/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/ja/skills/harden-github-repo-security/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: harden-github-repo-security
+description: >
+  Apply GitHub repository security protections tier by tier — rulesets,
+  read-only Actions token, secret scanning + push protection, Dependabot,
+  and (gated) required status checks / required PR with a GitHub App bypass
+  for a CI auto-commit bot. Mutating and confirmation-gated: always assess
+  first, apply the zero-downside baseline, then decide required checks
+  separately. Use when hardening a public user-owned repo after an audit,
+  when a repo has no branch protection, when adding required checks without
+  breaking a bot that pushes to the default branch, or when provisioning a
+  GitHub App bypass actor for trusted automation.
+license: MIT
+allowed-tools: Read Write Edit Bash
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: advanced
+  language: multi
+  tags: github, security, rulesets, branch-protection, github-actions, hardening
+  locale: ja
+  source_locale: en
+  source_commit: 84a3c915
+  translator: "Claude + human review"
+  translation_date: "2026-07-16"
+---
+
+# Harden GitHub Repository Security
+
+Apply GitHub protections in order of blast radius: assess, then a zero-downside
+baseline that never breaks CI, then a gated decision on required checks / PR.
+Every mutating step is confirmation-gated. Running example: a **public,
+user-owned** repo whose CI auto-commits to the default branch via
+`stefanzweifel/git-auto-commit-action` with the default `GITHUB_TOKEN`.
+
+Throughout, `R` = `OWNER/REPO` (e.g. `pjt222/agent-almanac`). Set it once:
+`R=OWNER/REPO`. All `gh api` writes require repo admin.
+
+## When to Use
+
+- Hardening a public user-owned repo after `assess-github-repo-security`
+- A repo has no ruleset / branch protection and you want a safe baseline
+- Adding required status checks or required PR **without** breaking a bot that
+  pushes to the default branch
+- Provisioning a GitHub App (or deploy key) bypass actor for trusted automation
+
+## Inputs
+
+- **Required**: `OWNER/REPO` and admin access (`gh auth status` shows admin)
+- **Required**: whether a CI bot pushes to the default branch (and which action/identity)
+- **Optional**: assessment report from `assess-github-repo-security`
+- **Optional**: exact CI check `context` name(s) to require (must run on `push`)
+- **Optional**: GitHub App id + private key if going to required checks/PR
+
+## Procedure
+
+### Step 1: Assess First and Confirm Scope
+
+Never mutate blind. Run the read-only assessment and confirm the plan with the user.
+
+```bash
+# 1. Run the companion read-only skill first (or its core probes):
+gh api /repos/$R --jq '{visibility,default_branch,is_org:.organization!=null}'
+gh api /repos/$R/rulesets --jq '.[] | {id,name,enforcement}'
+gh api /repos/$R/actions/permissions/workflow
+
+# 2. Confirm the two decisive facts before any write:
+#    - Is the repo PUBLIC and USER-OWNED?  (rulesets are free here)
+#    - Does a bot push to the default branch?  (gates Step 3 entirely)
+```
+
+Confirm with the user: baseline (Step 2) is always safe; Step 3 (required
+checks / PR) is a separate opt-in that **will** block a default-branch bot
+unless a bypass is provisioned first.
+
+**Expected:** You know visibility, owner type, current rulesets, current token
+default, and whether a bot pushes to the default branch. The user has approved
+applying at least the baseline.
+
+**On failure:** If the repo is **private and user-owned**, rulesets need GitHub
+Pro — stop and surface that. If not admin, stop (writes will 403). If a bot
+pushes to the default branch, flag that Step 3 is blocked until Step 3a runs.
+
+### Step 2: Apply the Zero-Downside Baseline (never breaks a CI auto-commit)
+
+This tier hardens the repo without breaking a direct-push bot. Apply after
+confirmation. Force-push/deletion protection, a read-only token default, the
+free security features, and policy files.
+
+```bash
+# 2a. Default-branch ruleset: force-push + deletion protection ONLY.
+#     These do NOT block the bot's direct push.
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+
+# 2b. Actions token: read-only default + no token PR approval.
+#     A DEFAULT (not a cap) for same-repo push events, so the bot still works
+#     once its job declares contents: write.
+gh api --method PUT /repos/$R/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=false
+
+# 2c. Free security features (all free on public repos):
+gh api -X PUT repos/$R/vulnerability-alerts          # alerts + dependency graph
+gh api -X PUT repos/$R/automated-security-fixes      # Dependabot fix PRs (separate toggle!)
+gh api -X PATCH repos/$R --input - <<'JSON'
+{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}
+JSON
+gh api -X PUT repos/$R/private-vulnerability-reporting
+```
+
+Leave **Settings > Actions > General** fork-PR approval at the public-repo
+default ("Require approval for first-time contributors"). Fork `pull_request`
+runs already receive a read-only `GITHUB_TOKEN` with no access to secrets, so a
+fork cannot auto-commit to the default branch (no REST toggle — this is a UI
+setting; tighten to "all external contributors" only if the repo has secrets or
+self-hosted runners).
+
+Then add two tracked files (commit them):
+
+`.github/dependabot.yml` — include a `github-actions` block so action SHAs stay fresh:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+`.github/SECURITY.md` — a short disclosure policy pointing reporters at the
+"Report a vulnerability" button (private vulnerability reporting, enabled above).
+
+Flipping the token default to `read` silently strips write from **every**
+workflow that assumed a write default, not just the auto-commit job. Audit
+**all** files in `.github/workflows/` and declare the minimal `permissions:` each
+job actually needs — common scopes are `contents`, `packages`, `pull-requests`,
+`pages`, and `id-token`. For the running example: top-level `permissions: {}`,
+`contents: write` only on the auto-commit job, and every `uses:` pinned to a
+full 40-char commit SHA with the version in a trailing comment.
+
+**Expected:** `gh api /repos/$R/rulesets` shows `protect-default` active;
+`.../actions/permissions/workflow` shows `default_workflow_permissions: read`
+and `can_approve_pull_request_reviews: false`; secret scanning + push protection
++ Dependabot + private reporting are on; `.github/dependabot.yml` and
+`.github/SECURITY.md` are committed. The bot's next run still pushes.
+
+**On failure:** If 2b makes an existing bot push 403 — or any other workflow
+fails after losing a write scope it silently relied on — the job is missing the
+explicit `permissions:` it needs (e.g. `contents: write`, `packages: write`,
+`pull-requests: write`); add the minimal scope back (the read-only default is not
+a hard cap for same-repo pushes). If `automated-security-fixes` seems to do nothing, verify
+`vulnerability-alerts` (2c line 1) ran first — alerts are a separate prerequisite
+toggle from fixes. If push protection later fails a bot run, treat the flagged
+secret as a **real finding** — the bot cannot click the interactive web bypass.
+
+### Step 3: Decision Gate — Required Status Checks / Required PR
+
+STOP. Required checks and required PR **block direct pushes to the ref**, not
+just PR merges. If a bot pushes to the default branch, turning either on **will
+break it** unless you first provision a bypass. The default `GITHUB_TOKEN` /
+`github-actions[bot]` **cannot** be a bypass actor (GitHub design). Do not enable
+this tier on a bot-pushing branch without a bypass in place.
+
+Also, on a **solo** repo, `required_approving_review_count >= 1` is a self-lockout
+(you cannot approve your own PR) — keep it `0`. And a required check that only
+runs on `pull_request` never reports on a direct push, so it **permanently**
+blocks the bot. Ensure the check runs on `push`.
+
+**Step 3a — provision the bot bypass FIRST (if a bot pushes to this branch).**
+Recommended: a GitHub App installation token. (Deploy key is a narrower
+single-repo alternative: add an SSH deploy key with write access and use
+`actor_type: DeployKey` in 3b.)
+
+```bash
+# Create a GitHub App (personal account, Settings > Developer settings >
+# GitHub Apps), permission Repository > Contents: Read and write; install it
+# on THIS repo. Store the App id as a repo variable and the private key as an
+# Actions secret. In the workflow, mint a token and pass it to checkout + the
+# commit action:
+#   - uses: actions/create-github-app-token@<sha>   # v2
+#     id: app-token
+#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+#   - uses: actions/checkout@<sha>
+#     with: { token: ${{ steps.app-token.outputs.token }} }
+#   - uses: stefanzweifel/git-auto-commit-action@<sha>
+#     with: { ... }   # inherits the app token via the checkout credentials
+#
+# The numeric App id used in Step 3b is shown on the App's own page:
+# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+# It is unrelated to the repository id and cannot be derived from /repos/$R.
+```
+
+**Higher-assurance alternative (no standing bypass actor).** If a manual merge
+click is acceptable, convert the job to open a PR with the App token (e.g.
+`peter-evans/create-pull-request`) and let a human merge. No bypass actor is
+needed and every rule stays enforced even against the automation's identity. The
+App token is still required: a PR opened with the plain `GITHUB_TOKEN` does not
+trigger `pull_request`/`push` workflows, so required checks never run and it sits
+`expected` forever (see Common Pitfalls).
+
+**Step 3b — apply the hardened ruleset with the App as an `Integration` bypass
+actor.** Replace `RULESET_ID` with the id from Step 2a, `<APP_ID>` with your App
+id, and `build` with your real check context. `bypass_mode: always` because the
+action pushes directly (use `pull_request` only if the bot opens PRs).
+
+```bash
+gh api --method PUT /repos/$R/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "pull_request", "parameters": { "required_approving_review_count": 0, "dismiss_stale_reviews_on_push": true, "require_code_owner_review": false, "require_last_push_approval": false, "required_review_thread_resolution": false, "allowed_merge_methods": ["merge"] } },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+
+# Verify the bypass actor is present:
+gh api /repos/$R/rulesets/RULESET_ID --jq '.bypass_actors'
+```
+
+`do_not_enforce_on_create: true` avoids the new-branch catch-22 (CI can't have
+run on a branch that does not exist yet). If there is **no** bot on this branch,
+you may skip 3a and omit `bypass_actors`.
+
+Trade-off: `strict_required_status_checks_policy: true` ("branch must be
+up to date") forces every open human PR to be re-updated each time the bot
+auto-commits to the default branch, and `dismiss_stale_reviews_on_push: true`
+compounds the churn — a chatty bot can make PRs perpetually unmergeable. On a
+frequently-auto-committed branch prefer `strict_required_status_checks_policy:
+false` (loose) unless up-to-date-before-merge is genuinely required.
+
+**Expected:** The ruleset now enforces the required check and required-PR rule
+for humans and forks, `.bypass_actors` lists the App (`Integration`), and the
+bot's next run still lands on the default branch (via the App token). Humans
+must open a PR; the check must be green.
+
+**On failure:** If the bot 403s after 3b, the App identity is not actually the
+bypass actor — confirm the workflow passes the App token to **checkout** (not
+just to the commit action) and that `<APP_ID>` in `bypass_actors` matches. If
+the bot's push sits `expected`/`pending` forever, the required check does not run
+on `push` — make it trigger on `push` or drop it from the required list. If the
+bypass-actor picker does not appear on your personal repo, the required-PR +
+auto-commit combination is unsatisfiable here; GitHub's workaround is a free org.
+If merges are blocked on a solo repo, `required_approving_review_count` is `>= 1`
+— set it to `0`.
+
+### Step 4: Optional Advanced Hardening
+
+Apply individually, each still confirmation-gated. None of these are needed for
+the baseline; several have sharp edges.
+
+```bash
+# 4a. Tag ruleset — protect release tags (classic tag protection is deprecated):
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{ "name": "protect-tags", "target": "tag", "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/tags/v*"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ] }
+JSON
+
+# 4b. Merge-method toggles (e.g. merge-commits-only to preserve per-commit history):
+gh api -X PATCH repos/$R -F allow_merge_commit=true -F allow_squash_merge=false \
+  -F allow_rebase_merge=false -F delete_branch_on_merge=true
+
+# 4c. CodeQL "default setup" (server-managed — commits NO workflow YAML):
+gh api -X PATCH repos/$R/code-scanning/default-setup -f state=configured -f query_suite=default
+
+# 4d. sha_pinning_required — ONLY after every `uses:` is a full 40-char SHA,
+#     or every workflow run fails (including actions/checkout):
+gh api --method PUT /repos/$R/actions/permissions -F enabled=true \
+  -f allowed_actions=selected -F sha_pinning_required=true
+# selected mode also gates WHICH actions may run: github_owned covers actions/*,
+# but git-auto-commit-action is NOT GitHub-owned — allow-list it in the SAME
+# step or the bot fails with "actions are not allowed":
+gh api --method PUT /repos/$R/actions/permissions/selected-actions \
+  -F github_owned_allowed=true -F verified_allowed=false \
+  -f 'patterns_allowed[]=stefanzweifel/git-auto-commit-action@*'
+gh api /repos/$R/actions/permissions --jq '.sha_pinning_required'   # verify
+```
+
+Note: `allowed_actions=selected` with `github_owned_allowed=true` still blocks
+`stefanzweifel/git-auto-commit-action` until it is in `patterns_allowed` (the 4d
+allow-list command handles this). Require-signed-commits and require-linear-history
+are intentionally omitted here:
+signing blocks the unsigned git-CLI bot push, and linear history is mutually
+exclusive with a merge-commits-only policy.
+
+**Expected:** Each selected advanced control is applied and verified without
+breaking the bot: tag ruleset lists on `.../rulesets`, merge toggles reflect on
+the repo object, CodeQL default setup shows `state: configured`,
+`sha_pinning_required` reads `true` only after all actions are SHA-pinned, and
+`git-auto-commit-action` is in `patterns_allowed` so the bot still runs.
+
+**On failure:** If every workflow fails right after 4d, an action is still
+tag-pinned — convert all `uses:` to SHAs or revert `sha_pinning_required` to
+`false`. If the bot fails with "actions are not allowed" after restricting
+allowed actions, add `git-auto-commit-action` to `patterns_allowed`. If 4c
+errors, the repo may have no CodeQL-supported language — skip it.
+
+## Validation
+
+- [ ] Assessment ran and scope (public/user-owned, bot-on-default-branch) confirmed before any write
+- [ ] `protect-default` ruleset active with `deletion` + `non_fast_forward`
+- [ ] `default_workflow_permissions=read` and `can_approve_pull_request_reviews=false`
+- [ ] Secret scanning + push protection + Dependabot alerts + fixes + private reporting enabled
+- [ ] `.github/dependabot.yml` (github-actions ecosystem) and `.github/SECURITY.md` committed
+- [ ] Auto-commit bot's next run still pushes successfully (baseline did not break it)
+- [ ] Required checks/PR enabled ONLY with a GitHub App (or deploy key) bypass in place first
+- [ ] Solo repo keeps `required_approving_review_count: 0`; required checks run on `push`
+- [ ] Loop guard added if a bot now pushes with an App token or PAT
+
+## Common Pitfalls
+
+- **GITHUB_TOKEN is not a bypass actor**: `github-actions[bot]` / the default
+  token cannot be added to any ruleset bypass list and cannot push to a
+  protected branch, by design. "Just add the Actions bot to the bypass list"
+  has no such option — the push 403s. Use a GitHub App or deploy key.
+- **PAT bypass is an anti-pattern**: an admin/personal PAT in the bypass list
+  (or classic BP with `enforce_admins=false`) exempts ALL admin actions
+  including your own interactive pushes — role-wide, not automation-scoped, and
+  long-lived. Prefer an App (`Integration`) or deploy key (`DeployKey`).
+- **Required checks only on `pull_request`**: a check that never runs on `push`
+  never reports on the bot's direct push, so it **permanently** blocks the bot
+  and new-branch creation. Make the check run on `push` and set
+  `do_not_enforce_on_create: true`.
+- **Loop guard once an App token replaces GITHUB_TOKEN**: the default token
+  suppresses downstream `push`/`pull_request` triggers; an App token or PAT does
+  not, so the auto-commit workflow can re-trigger itself indefinitely. Guard with
+  `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`.
+- **PR via the default GITHUB_TOKEN is a false fix**: a PR opened by
+  `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so required
+  checks never run and it sits `expected` forever. Create the PR with the App token.
+- **Alerts != fixes**: `vulnerability-alerts` and `automated-security-fixes` are
+  separate toggles; enabling alerts opens no PRs. Enable both.
+- **Don't buy GHAS on a public repo**: secret scanning, push protection, CodeQL,
+  and dependency review are already free on public repos; the paid Secret
+  Protection / Code Security products target private/org repos.
+
+## Related Skills
+
+- `assess-github-repo-security` - the read-only companion; always run this first
+- `configure-git-repository` - baseline .gitignore, branches, remotes, hooks
+- `setup-github-actions-ci` - the CI workflow whose token/permissions this hardens

--- a/i18n/ja/translation_status.yml
+++ b/i18n/ja/translation_status.yml
@@ -3,10 +3,10 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 123
-    stubs: 11
+    stubs: 13
   agents:
     translated: 3
     total: 73
@@ -21,13 +21,13 @@ coverage:
     stubs: 1
   guides:
     translated: 3
-    total: 33
-    pct: 9.1
+    total: 34
+    pct: 8.8
     stale: 2
-    stubs: 1
+    stubs: 2
   total:
     translated: 359
-    total: 490
-    pct: 73.3
+    total: 493
+    pct: 72.8
     stale: 129
-    stubs: 14
+    stubs: 17

--- a/i18n/wenyan-lite/translation_status.yml
+++ b/i18n/wenyan-lite/translation_status.yml
@@ -3,8 +3,8 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 296
     stubs: 0
   agents:
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 33
+    total: 34
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 490
-    pct: 71.8
+    total: 493
+    pct: 71.4
     stale: 296
     stubs: 0

--- a/i18n/wenyan-ultra/translation_status.yml
+++ b/i18n/wenyan-ultra/translation_status.yml
@@ -3,8 +3,8 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 293
     stubs: 0
   agents:
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 33
+    total: 34
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 490
-    pct: 71.8
+    total: 493
+    pct: 71.4
     stale: 293
     stubs: 0

--- a/i18n/wenyan/translation_status.yml
+++ b/i18n/wenyan/translation_status.yml
@@ -3,8 +3,8 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 296
     stubs: 0
   agents:
@@ -21,13 +21,13 @@ coverage:
     stubs: 0
   guides:
     translated: 0
-    total: 33
+    total: 34
     pct: 0
     stale: 0
     stubs: 0
   total:
     translated: 352
-    total: 490
-    pct: 71.8
+    total: 493
+    pct: 71.4
     stale: 296
     stubs: 0

--- a/i18n/zh-CN/guides/protecting-github-repositories.md
+++ b/i18n/zh-CN/guides/protecting-github-repositories.md
@@ -1,0 +1,246 @@
+---
+title: "Protecting GitHub Repositories"
+description: "Honest threat model, tiered checklist, rulesets vs branch protection, and the CI-bot bypass problem for hardening a public GitHub repo"
+category: infrastructure
+agents: [security-analyst]
+teams: []
+skills: [assess-github-repo-security, harden-github-repo-security]
+locale: zh-CN
+source_locale: en
+source_commit: 84a3c915
+translator: "Claude + human review"
+translation_date: "2026-07-16"
+---
+
+# Protecting GitHub Repositories
+
+Hardening a GitHub repository is mostly a sequence of small, well-understood toggles — but a handful of them silently change *who* is gated, break a CI auto-commit bot, or provide a false sense of security while protecting almost nothing. This guide is the human-facing walkthrough: it explains the honest threat model behind ref protection, gives a tiered checklist you can apply in order, contrasts rulesets with classic branch protection, and walks through the single hardest problem — letting trusted automation write to a protected branch. Assess first, then harden.
+
+The running example throughout is the concrete case that trips most people up: a **public, user-owned** repository (like this one, `pjt222/agent-almanac`) whose CI **auto-commits to the default branch** via `stefanzweifel/git-auto-commit-action` using the default `GITHUB_TOKEN`. Everything here is grounded in current GitHub behavior; where a control interacts badly with that bot, it is called out explicitly.
+
+## When to Use This Guide
+
+- You own a public repository and want to harden it without breaking a working CI pipeline that pushes to `main`.
+- You are about to turn on branch protection or a ruleset and want to know what it actually stops — and what it does not.
+- Your CI bot suddenly started getting `403` on its push, or your PRs are stuck on a check that never runs.
+- You are choosing between classic branch protection and repository rulesets and want the honest tradeoffs.
+- A single-maintainer repo locked you out of merging your own pull requests.
+
+## Prerequisites
+
+- Admin access to the repository (most controls require it).
+- The [`gh` CLI](https://cli.github.com) authenticated (`gh auth status`) — every command here uses it, and the API is the source of truth over the UI.
+- A completed **assessment** of the repo's current posture — run the [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) skill *before* changing anything, so you know your baseline and do not toggle controls you already have.
+- If your CI writes to a protected branch, know which action does the push and which token it uses.
+
+## Workflow Overview
+
+The order matters. Hardening blind is how you break the bot or lock yourself out.
+
+1. **Assess** — inventory the current state with [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md): existing rules, token defaults, enabled security features, and how CI pushes.
+2. **Apply the zero-downside baseline** — the essential tier below hardens the repo *without* touching anything the bot depends on.
+3. **Decide on required checks / required PR** — this is the fork in the road. It is the single control most in tension with a direct-push bot; if you want it, you must first provision a bypass identity for the bot (see the bypass matrix).
+4. **Harden the automation path** — swap the bot to a GitHub App token and add the App as a ruleset bypass actor, or route it through a pull request.
+5. **Verify** — re-run the assessment; confirm the bot still pushes and humans/forks are still gated.
+
+The [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) skill drives steps 2–4 as an executable procedure; the [security-analyst](../agents/security-analyst.md) agent is the persona that owns this end-to-end.
+
+## The Honest Threat Model
+
+Ref protection — whether you call it a *ruleset* or a *branch protection rule* — protects **one ref**, not the repository. Internalizing that sentence prevents most false-security mistakes.
+
+**What ref protection does stop:** rewriting, force-pushing, or deleting the protected branch; landing changes to it without a pull request (if you require one); merging before required status checks pass. It gates the *history of one branch*.
+
+**What it does NOT stop:**
+
+- A write collaborator pushing to any **unprotected** branch, then adding a malicious workflow that runs with your repo's token.
+- Moving or creating **tags** (unless you also protect tags with a tag ruleset).
+- Introducing a **compromised or typo-squatted action** into a workflow that holds `contents: write`.
+- A workflow triggered on **`pull_request_target`** that checks out the PR head. This trigger runs in the *base-repo* context with secrets and a write token regardless of branch protection, so checking out untrusted code under it is a documented privilege-escalation / RCE pattern. Avoid `pull_request_target` for anything that checks out untrusted code, and never interpolate `${{ github.event.pull_request.* }}` fields directly into a `run:` shell step (route them through an intermediate `env:` var). Ref protection does nothing about this.
+- Secrets already committed (protection is about refs, not content) — that is what secret scanning and push protection are for.
+
+So a branch rule is one layer. Ruleset scope, an allowed-actions policy, fork-PR approval, and secret scanning matter as much as the branch rule itself. Treat "the branch is protected" as *necessary, not sufficient*.
+
+### The mental-model shift that catches everyone
+
+Here is the subtle part. Under **classic branch protection**, repository admins bypass the rules **by default** — the rule simply does not apply to them unless you also check *"Do not allow bypassing the above settings"* (`enforce_admins=true`). That toggle is all-or-nothing: it applies the rules to *every* admin or *no* admin, with no per-actor granularity.
+
+**Rulesets invert this default.** A ruleset applies to admins too — nobody is exempt *unless they are explicitly added to the ruleset's `bypass_actors` list*. There is no `enforce_admins` toggle on a ruleset.
+
+Porting the classic "admins can always bypass" mental model to a ruleset **silently changes who is gated**:
+
+- If you *assume* you (as admin) can always push past a ruleset, you will be surprised by a `403` — the ruleset gates you unless you added your admin role to the bypass list.
+- Conversely, if you migrate from classic BP where admins were quietly exempt, a ruleset will now enforce against those same admins — usually what you wanted, but a behavior change to be aware of.
+
+This is why the assessment step matters: the same words ("branch protection") describe two systems with opposite default answers to "does this apply to me?"
+
+## Rulesets vs Classic Branch Protection
+
+**Prefer repository rulesets. Treat classic branch protection as legacy.** GitHub's own docs position classic BP as the thing rulesets are an "alternative" to, and rulesets are the actively developed path.
+
+| Capability | Repository Ruleset | Classic Branch Protection |
+|---|---|---|
+| Availability on free public user-owned repo | Yes, fully free | Yes |
+| Multiple rules stack (most-restrictive wins) | Yes | No — one rule matches |
+| Per-actor bypass list (roles, teams, Apps, deploy keys) | Yes | No |
+| Exempt a *specific actor* from required status checks | Yes | **No — impossible** |
+| Admin exemption model | Per-actor via bypass list | All-or-nothing (`enforce_admins`) |
+| Target multiple branches / tags by pattern | Yes (`~DEFAULT_BRANCH`, `~ALL`, fnmatch) | Limited |
+| Tag protection | Tag ruleset (`target: tag`) | Deprecated 2024-08-30, auto-migrated |
+
+Two facts do the heavy lifting for the running example:
+
+- **Rulesets are free on public user-owned repos.** The docs are explicit — do not tell a free personal-public-repo owner to upgrade. (Only *private* personal repos need GitHub Pro for rulesets; org-wide rulesets and the "Evaluate" dry-run mode are the Team/Enterprise-gated pieces.)
+- **Classic BP cannot exempt any actor from required status checks.** Its push allowlist ("Restrict who can push") is organization-only and, even where available, governs *who may push*, not *who may skip checks*. GitHub staff redirected the multi-year feature request for this to rulesets. For any "let one specific bot through required checks" need — exactly the auto-commit case — rulesets are mandatory.
+
+A minimal, safe default-branch ruleset (force-push + deletion protection only — this does **not** break a direct-push bot):
+
+```bash
+gh api --method POST /repos/OWNER/REPO/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+```
+
+Inspect what exists before and after: `gh api /repos/OWNER/REPO/rulesets` and `gh api /repos/OWNER/REPO/rulesets/RULESET_ID --jq '.bypass_actors'`.
+
+## The Tiered Hardening Checklist
+
+Apply top to bottom. The **essential** tier is zero-downside and does not break the auto-commit bot; **recommended** introduces the bot-bypass decision; **advanced** is high-friction or niche.
+
+### Essential (zero-downside baseline)
+
+- **Force-push + deletion protection** via a default-branch ruleset (`non_fast_forward` + `deletion`). The cheapest, no-downside hardening; safe for a direct-push bot.
+- **Set the default `GITHUB_TOKEN` to read-only** and disable token PR approval. This is a *default*, not a hard cap, for same-repo push events — so it does not break the bot **provided the committing job grants `contents: write` back** (the next bullet). If your workflow has no explicit `permissions:` block and relied on the ambient write default, add that grant *first* or the `git-auto-commit-action` push `403`s.
+  ```bash
+  gh api --method PUT /repos/OWNER/REPO/actions/permissions/workflow \
+    -f default_workflow_permissions=read -F can_approve_pull_request_reviews=false
+  ```
+- **Least-privilege per-workflow permissions.** Top-level `permissions: {}` in the workflow YAML, then grant `contents: write` back only on the job that commits — `git-auto-commit-action` needs nothing more.
+- **Pin every action to a full 40-char commit SHA** (including `actions/checkout` and `stefanzweifel/git-auto-commit-action`), with the human-readable version in a trailing comment. A mutable tag is a supply-chain hole on a workflow that holds `contents: write`.
+  ```yaml
+  - uses: stefanzweifel/git-auto-commit-action@<40-char-sha>  # v6.x.x
+  ```
+- **Leave fork-PR approval at the public-repo default** ("Require approval for first-time contributors"). Fork `pull_request` runs already get a read-only token and no secrets.
+- **Enable Dependabot alerts + security updates + a `.github/dependabot.yml`.** Alerts and fixes are *separate* toggles — enable both, or you detect vulnerabilities and fix nothing. Include a `github-actions` ecosystem block to keep action SHAs fresh.
+  ```bash
+  gh api -X PUT repos/OWNER/REPO/vulnerability-alerts      # alerts + dependency graph
+  gh api -X PUT repos/OWNER/REPO/automated-security-fixes  # Dependabot fix PRs
+  ```
+- **Enable secret scanning + push protection** (free and usually already on for public repos); add `.github/SECURITY.md` and private vulnerability reporting (both per-repo, no org needed).
+  ```bash
+  gh api -X PATCH repos/OWNER/REPO --input - <<<'{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}'
+  gh api -X PUT repos/OWNER/REPO/private-vulnerability-reporting
+  ```
+- **Do NOT purchase GHAS / Secret Protection / Code Security for a public repo.** Secret scanning, push protection, CodeQL, and dependency review are already free on public repos; those paid products are private/org-only.
+
+### Recommended
+
+- **Add `required_status_checks`** to the ruleset with `do_not_enforce_on_create=true` and `strict_required_status_checks_policy=true`. **Critical:** this blocks the bot's direct push unless you provision a bypass (next item), *and* the checks must run on `push`, not only `pull_request`, or they never report and the push is permanently blocked.
+- **Add a `pull_request` rule** if you want a review surface. On a solo repo keep `required_approving_review_count: 0` — you cannot approve your own PR, and `>= 1` is an unsatisfiable self-lockout.
+- **Provision a GitHub App bypass for the bot** (Contents: read/write) via `actions/create-github-app-token`, pass the token to checkout + `git-auto-commit-action`, and add the App as an `Integration` bypass actor with `bypass_mode: always`. This is the correct realization of "let the bot through" once required checks/PR are on.
+- **Enable CodeQL "default setup"** (server-managed) rather than advanced setup, so no extra workflow YAML is committed into a repo that auto-commits.
+- **Set merge-method toggles to match policy** (e.g. merge-commits-only: `allow_squash_merge=false`, `allow_rebase_merge=false`) and auto-delete head branches on merge.
+- **Restrict the allowed-actions policy** to GitHub-owned + an explicit allow-list that *includes* `stefanzweifel/git-auto-commit-action` (it is not GitHub-owned; omitting it silently fails the workflow).
+
+### Advanced
+
+- **Protect release tags** with a tag ruleset (`target: tag`, e.g. `v*`).
+- **Enable the `sha_pinning_required` repo policy** (2025-08-15) — but only *after* converting every `uses:` to a full SHA, or every run fails. First confirm the field is actually exposed on a free user-owned public repo (it may be org/enterprise-gated): `gh api /repos/OWNER/REPO/actions/permissions --jq '.sha_pinning_required'`.
+- **`dismiss_stale_reviews_on_push` + require conversation resolution + `require_last_push_approval`** — only meaningful once you run human PR reviews; a chatty auto-commit bot pushing into open PRs can make them perpetually unmergeable.
+- **CODEOWNERS + `require_code_owner_review`** — low value on a solo repo (you can only list `@users`, and the sole owner cannot satisfy it as PR author).
+- **Require signed commits** — high friction: `git-auto-commit-action` pushes unsigned via git CLI, so this blocks the bot. `GITHUB_TOKEN` commits are auto-verified only via the Contents API, not `git push`.
+- **Require linear history** — mutually exclusive with a merge-commits-only policy; pick one.
+
+## Automation Through Protection: The Bot Bypass Problem
+
+This is the crux of the running example. Once you turn on required checks or require-a-PR, a push to the default branch must either satisfy the rules or come from a **bypass actor**. And here is the hard constraint that no toggle removes:
+
+> The default `GITHUB_TOKEN` / `github-actions[bot]` **cannot** be added to any bypass list and **cannot** push to a protected branch. This is by GitHub design — otherwise any collaborator could ship a workflow that writes to any branch. Any plan phrased as "just add the Actions bot to bypass" silently has no such option, and the bot's push `403`s.
+
+So to let trusted automation through, you must give it a *real* bypass-eligible identity. Ranked from best to worst:
+
+| Approach | Keeps checks enforced for humans? | Least-privilege rank | Verdict |
+|---|---|---|---|
+| PR-based (create-pull-request) with a **GitHub App token**, human clicks merge — no standing bypass | Yes | 1 | Strongest separation of duties. App token makes checks actually fire on the bot's change; no standing branch bypass. Not fully hands-off — a human merges. |
+| **GitHub App** installation token (Contents: read/write) + App as `Integration` bypass actor, `bypass_mode: always` | Yes | 2 | **Recommended default for full automation.** Repo-scoped, ~1h ephemeral, identity-scoped bypass; humans/forks/admins stay gated. Crown-jewel risk shifts to the App private key. |
+| SSH **deploy key** (write) + `DeployKey` bypass actor, push over SSH | Yes | 3 | Good narrow single-repo alternative — no App to maintain, no API scope. One private key per repo to rotate. Slightly coarser identity than an App. |
+| Bot-account **PAT** as a `User` bypass actor | Yes | 4 | Anti-pattern. Long-lived, tied to a maintained account; rotation/offboarding risk; re-triggers workflows (needs a loop guard). Stopgap only. |
+| Admin/fine-grained **PAT** + `Repository admin` role in bypass | **No** | 5 | Worst. Role-wide hole — exempts *all* admin actions including your own interactive pushes, not just automation. A leaked PAT = admin bypass-write. |
+| Add the default **`GITHUB_TOKEN`** to the bypass list | — | 6 | **Impossible.** Not a selectable actor by design; the push `403`s. |
+
+> **Verify the bypass-actor picker before you commit to this.** Historically the ruleset bypass-actor UI did **not** appear on user-owned (personal) repositories — the exact repo class this guide centers on. Before you build the App and flip on required checks / require-a-PR for real, open **Settings > Rules > Rulesets > (your ruleset) > Bypass list > Add bypass** and confirm the App is actually selectable. If it is not, the required-checks / required-PR combination is **unsatisfiable** on a personal repo — the bot's direct push cannot be let through by any means — and GitHub's documented workaround is to move the repo under a (free) **organization**, where App and role bypass actors are reliably available. This is version-dependent, so check your own repo rather than assuming the App route works.
+
+The **GitHub App** route (rank 2) is the recommended default *once you have confirmed the App is addable as a bypass actor*. Mint the token at runtime and wire it through the bot:
+
+```yaml
+- uses: actions/create-github-app-token@<sha>  # official
+  id: app-token
+  with:
+    app-id: ${{ vars.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+- uses: actions/checkout@<sha>
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+- uses: stefanzweifel/git-auto-commit-action@<sha>  # inherits the App token
+```
+
+Then add the App to the ruleset bypass list:
+
+```bash
+gh api --method PUT /repos/OWNER/REPO/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+```
+
+Two follow-ups once an App token or PAT is in play: (1) the crown-jewel secret is now the **App private key** — store it as an Actions secret, scope the App install to the single repo, and rotate; (2) unlike the default `GITHUB_TOKEN` (which suppresses downstream triggers), an App/PAT push **re-triggers** `on: push` workflows, so add a loop guard (`if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`).
+
+## Common False-Security Traps
+
+These are the beliefs that feel like security but are not.
+
+- **"Just add the github-actions bot to the ruleset bypass list."** It is not a selectable actor; the push `403`s. Use a GitHub App or deploy key identity.
+- **"Convert the bot from push to a PR to satisfy the rules."** A PR opened by the default `GITHUB_TOKEN` does **not** trigger `pull_request`/`push` workflows, so required checks never run and the PR sits on "expected/pending" forever. The PR must be created with an App token or PAT.
+- **"Required status checks mean nothing unreviewed lands."** Without a *required-PR* rule, anyone with write can still push directly if a check reports on push; and in classic BP admins bypass by default unless `enforce_admins=true`. Rulesets differ — they do not auto-exempt admins — so porting the classic mental model silently changes who is gated.
+- **"Branch protection protects the repo from a malicious collaborator."** It protects one ref. A write collaborator can push to unprotected branches, add a malicious workflow, or move tags. Scope, allowed-actions policy, and fork approval matter as much.
+- **"Public-repo secret scanning stops leaks."** Alerts fire *after* the commit; push protection blocks at push time but the auto-commit bot cannot click the interactive web bypass, so a CI-committed secret just fails the job — treat it as a real finding, not a flake. The free tier also covers provider patterns only, not every generic secret.
+- **"Require signed commits is free hardening."** It blocks the bot, which pushes unsigned via git CLI. Keeping both requires an API-based commit action.
+- **"Swap `GITHUB_TOKEN` for a broad PAT to get past protection."** A PAT is long-lived and account-wide — a strict privilege escalation over the ephemeral repo-scoped token. Prefer an App or deploy key.
+- **"Buy GHAS to secure a public repo."** Those features are already free on public repos; the paid split targets private/org repos only.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Bot push `403`s after enabling required checks / require-PR | The default `GITHUB_TOKEN` cannot be a bypass actor and cannot push to a protected branch | Provision a GitHub App token (or deploy key) and add that identity to the ruleset `bypass_actors`; pass the token to checkout + `git-auto-commit-action` |
+| Cannot add the App (or any actor) to the ruleset bypass list on a personal repo | The bypass-actor picker historically did not appear on user-owned repos; without it, required-checks/required-PR + a direct-push bot is unsatisfiable | Verify the picker under Settings > Rules > Rulesets > Bypass list; if it is absent, move the repo under a free organization (GitHub's documented workaround) or keep the default branch at the essential-tier baseline only |
+| PR opened by the bot is stuck on a check that shows "expected"/pending forever | A PR created with the default `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so checks never run | Create the PR with a GitHub App token (or PAT), which fires both event types; then the checks actually run and can gate the merge |
+| Solo maintainer cannot merge own PR | `required_approving_review_count >= 1` (or `require_code_owner_review`) — you cannot approve your own PR, and a ruleset does not auto-exempt you as admin | Set `required_approving_review_count: 0`, or add a second reviewer / a second trusted App as a bypass path |
+| New branch cannot be created; "required status check is expected" | Required checks block branch *creation* — CI cannot have run on a branch that does not exist (catch-22); or checks only trigger on `pull_request` and never report on a push | Set `do_not_enforce_on_create: true` on the `required_status_checks` rule, and make the check run on `push`, not only `pull_request` |
+| `sha_pinning_required` breaks every workflow run | The policy fails any `uses:` not pinned to a full 40-char SHA, including `actions/checkout@v4` | Convert *all* `uses:` to full commit SHAs *before* enabling the policy |
+| `allowed_actions=selected` fails the auto-commit job | `github_owned_allowed=true` still blocks `git-auto-commit-action` — it is not GitHub-owned | Add `stefanzweifel/git-auto-commit-action@*` to `patterns_allowed` |
+| Bot loops / re-triggers itself after switching to an App token | App/PAT pushes re-trigger `on: push` (default `GITHUB_TOKEN` suppressed them) | Add a loop guard: `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]` in the commit message |
+
+## Related Resources
+
+- [`assess-github-repo-security`](../skills/assess-github-repo-security/SKILL.md) — inventory the current posture **first**; run before any hardening
+- [`harden-github-repo-security`](../skills/harden-github-repo-security/SKILL.md) — the executable procedure that applies this checklist and the bot bypass
+- [security-analyst](../agents/security-analyst.md) — the agent persona that owns repository hardening end-to-end
+- [WSL Maintenance & Claude Code Reference](wsl-maintenance.md) — periodic security-scan greps for leaked secrets and hardcoded paths
+- [Setting Up Your Environment](setting-up-your-environment.md) — first-time environment, shell, and Claude Code setup

--- a/i18n/zh-CN/skills/assess-github-repo-security/SKILL.md
+++ b/i18n/zh-CN/skills/assess-github-repo-security/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: assess-github-repo-security
+description: >
+  Read-only audit of a GitHub repository's security posture. Gathers ref
+  protection (rulesets AND classic branch protection), Actions token
+  permissions, code and supply-chain features (Dependabot, secret
+  scanning, push protection, CodeQL), and repo hygiene toggles via
+  `gh api`, then classifies findings against essential / recommended /
+  advanced tiers into a PASS/GAP report. Makes NO changes. Use when
+  reviewing a repo before open-sourcing or a release, auditing a public
+  user-owned repo whose CI auto-commits to the default branch, verifying
+  a hardening change actually took effect, or producing a baseline
+  security posture report for a repository.
+license: MIT
+allowed-tools: Read Bash Grep
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: intermediate
+  language: multi
+  tags: github, security, audit, rulesets, branch-protection, dependabot, actions
+  locale: zh-CN
+  source_locale: en
+  source_commit: 84a3c915
+  translator: "Claude + human review"
+  translation_date: "2026-07-16"
+---
+
+# Assess GitHub Repository Security
+
+Audit a GitHub repository's security posture, read-only, and classify it
+against tiered best practices. This skill only reads — it never enables,
+disables, or changes any setting. Remediation is a separate concern (see
+`harden-github-repo-security`).
+
+## When to Use
+
+- Reviewing a repo before open-sourcing it or cutting a release
+- Auditing a public, user-owned repo whose CI auto-commits to the default
+  branch (e.g. via `stefanzweifel/git-auto-commit-action` + the default
+  `GITHUB_TOKEN`)
+- Verifying that a hardening change actually took effect
+- Producing a baseline posture report to track over time
+
+## Inputs
+
+- **Required**: Target repository as `OWNER/REPO`
+- **Required**: `gh` CLI authenticated with an account that has the
+  **admin repository role** on the target repo (some endpoints 403
+  otherwise). This is a role requirement, not a need for a broad
+  write-capable token: a fine-grained, single-repo PAT scoped to
+  read-only Administration / Actions / Secret-scanning permissions
+  satisfies the same admin check with far less blast radius if the
+  audit credential is ever leaked or reused in automation
+- **Optional**: Branch to check for classic protection (defaults to the
+  repo's `default_branch`)
+- **Optional**: `security_events` token scope — needed only to count open
+  Dependabot alerts; the rest works without it
+
+Set a shorthand for every command below:
+
+```bash
+R="OWNER/REPO"   # e.g. pjt222/agent-almanac
+```
+
+## Procedure
+
+### Step 1: Preflight — auth and admin
+
+Confirm the CLI is authenticated and the account has admin on the repo.
+Non-admins get partial data (403 on rulesets, Actions, and security
+endpoints), which silently understates the posture.
+
+```bash
+gh auth status
+gh api "repos/$R" --jq '{full_name, admin: .permissions.admin, visibility}'
+```
+
+**Expected:** `gh auth status` shows a logged-in account; the second call
+prints `admin: true`.
+
+**On failure:** If not authenticated, run `gh auth login` (or set
+`GH_TOKEN`). If `admin: false`, stop and note in the report that findings
+are **incomplete** — a non-admin cannot read ruleset internals or Actions
+permissions, so absence of a control cannot be distinguished from lack of
+access.
+
+### Step 2: Repo basics — visibility, merge toggles, collaborators
+
+```bash
+gh api "repos/$R" --jq '{visibility, private, allow_forking,
+  default_branch, allow_merge_commit, allow_squash_merge,
+  allow_rebase_merge, delete_branch_on_merge}'
+
+# Direct collaborators and their effective role
+gh api "repos/$R/collaborators?affiliation=direct" \
+  --jq '.[] | {login, role_name}'
+```
+
+**Expected:** JSON for the repo toggles plus one line per direct
+collaborator with `role_name` (`admin`/`maintain`/`write`/`triage`/`read`).
+
+**On failure:** A 403 on `collaborators` means the token lacks admin; note
+it and continue. Record `visibility` — it changes which features are
+**free**: on **public** repos secret scanning, push protection, CodeQL,
+and dependency review are free; the paid GHAS/Secret Protection products
+are private/org-only, so their absence on a public repo is not a gap.
+
+### Step 3: Ref protection — check rulesets AND classic (both)
+
+A repo can be protected by a **ruleset**, by **classic branch
+protection**, by both, or by neither. Rulesets are the actively-developed
+path and are free on public user-owned repos. You MUST check both — a repo
+with only a ruleset returns 404 on the classic endpoint and vice versa.
+
+```bash
+b=$(gh api "repos/$R" --jq '.default_branch')
+
+# (a) Rulesets — list, then inspect each active one's rules + bypass list
+gh api "repos/$R/rulesets" --jq '.[] | {id, name, enforcement, target}'
+# For each id from above:
+#   gh api "repos/$R/rulesets/<id>" \
+#     --jq '{name, enforcement,
+#            rules: [.rules[].type],
+#            bypass: [.bypass_actors[] | {actor_type, bypass_mode}]}'
+
+# (b) Classic branch protection on the default branch (404 = none)
+gh api -i "repos/$R/branches/$b/protection" 2>/dev/null | head -1
+gh api "repos/$R/branches/$b/protection" \
+  --jq '{required_status_checks: .required_status_checks.checks,
+         strict: .required_status_checks.strict,
+         enforce_admins: .enforce_admins.enabled,
+         required_reviews: .required_pull_request_reviews.required_approving_review_count,
+         linear: .required_linear_history.enabled,
+         signatures: .required_signatures.enabled,
+         allow_force_pushes: .allow_force_pushes.enabled,
+         allow_deletions: .allow_deletions.enabled}' 2>/dev/null \
+  || echo "no classic branch protection"
+```
+
+**Expected:** Either a ruleset with rules such as `deletion`,
+`non_fast_forward`, `pull_request`, `required_status_checks`, or a classic
+protection object, or an explicit "none" from both.
+
+**On failure:** A `404` on either endpoint means that mechanism is **not
+configured** — it is a valid data point, not an error; record "none" for
+that mechanism. Note the rule set from the ruleset `rules[].type` list and
+the `bypass_actors`. Remember: the default `GITHUB_TOKEN` /
+`github-actions[bot]` can never be a bypass actor by design — if the repo
+auto-commits AND has `required_status_checks`/`pull_request` rules with no
+`Integration` (GitHub App) or `DeployKey` bypass actor, flag that the bot
+push must be 403ing (a real finding).
+
+### Step 4: Actions security — token defaults and PR approval
+
+```bash
+# Actions enablement + allowed-actions policy (+ SHA-pinning policy)
+gh api "repos/$R/actions/permissions" \
+  --jq '{enabled, allowed_actions, sha_pinning_required}'
+
+# Default GITHUB_TOKEN permissions + can-the-bot-approve-PRs
+gh api "repos/$R/actions/permissions/workflow" \
+  --jq '{default_workflow_permissions, can_approve_pull_request_reviews}'
+```
+
+**Expected:** `default_workflow_permissions` is `read` (hardened) or
+`write` (permissive default), and `can_approve_pull_request_reviews` is
+`false` (hardened) or `true` (a review-bypass vector).
+
+**On failure:** 403 means non-admin — note it. If
+`allowed_actions` is `all`, any action can run (looser); `selected` with a
+pinned allow-list is tighter — but note that `selected` +
+`github_owned_allowed` still blocks non-GitHub actions like
+`stefanzweifel/git-auto-commit-action` unless explicitly allow-listed.
+`sha_pinning_required` may be absent/`null` on repos that never set the
+2025-08 policy — record as "not enforced". Per-workflow `permissions:`
+blocks live in the YAML, not the API; note that the API shows only the
+repo **default**, which is a default (not a cap) for same-repo push
+events.
+
+### Step 5: Code and supply-chain features
+
+```bash
+# Dependabot alerts + dependency graph (204 = ON, 404 = OFF)
+gh api -i "repos/$R/vulnerability-alerts" 2>/dev/null | head -1
+
+# Dependabot security updates (auto fix PRs) — separate toggle
+gh api "repos/$R/automated-security-fixes" \
+  --jq '{enabled, paused}' 2>/dev/null || echo "automated-security-fixes: off/unavailable"
+
+# Secret scanning + push protection status (security_and_analysis has NO
+# code-scanning field — CodeQL is probed separately below)
+gh api "repos/$R" --jq '.security_and_analysis'
+
+# CodeQL code scanning — default setup state (its own endpoint)
+gh api "repos/$R/code-scanning/default-setup" --jq '.state' 2>/dev/null \
+  || echo "code-scanning default setup: not configured / no access"
+
+# Dependabot version updates config present?
+gh api -i "repos/$R/contents/.github/dependabot.yml" 2>/dev/null | head -1
+
+# SECURITY.md — GitHub auto-detects it at root, docs/, OR .github/.
+# Present if ANY of the three returns 200; only a GAP if all three 404.
+for p in SECURITY.md docs/SECURITY.md .github/SECURITY.md; do
+  echo "$p: $(gh api -i "repos/$R/contents/$p" 2>/dev/null | head -1)"
+done
+
+# Private vulnerability reporting — status is a 200 body {"enabled": bool},
+# NOT a 204/404 toggle, so read the field directly.
+gh api "repos/$R/private-vulnerability-reporting" --jq '.enabled' 2>/dev/null \
+  || echo "PVR: not accessible"
+
+# Open Dependabot alert count — needs security_events scope; may 403
+gh api "repos/$R/dependabot/alerts?state=open" --jq 'length' 2>/dev/null \
+  || echo "dependabot/alerts: 403 (needs security_events scope) — skipped"
+```
+
+**Expected:** `vulnerability-alerts` → `HTTP/2.0 204` when enabled;
+`security_and_analysis` shows `secret_scanning.status` and
+`secret_scanning_push_protection.status` as `enabled` on a hardened public
+repo; `code-scanning/default-setup` `.state` is `configured` when CodeQL
+default setup is on; `automated-security-fixes` → `enabled: true`; the
+`dependabot.yml` probe returns `200` when present; at least one of the
+three SECURITY.md paths returns `200` when a policy file exists;
+`private-vulnerability-reporting` `.enabled` prints `true` when PVR is on.
+
+**On failure:** `vulnerability-alerts` returning `404` = Dependabot alerts
+OFF (a gap). Remember **alerts != fixes**: alerts on with
+`automated-security-fixes` off means nothing is auto-remediated — flag
+both separately. On **public** repos `secret_scanning` is usually already
+`enabled` by default; if `security_and_analysis` omits the field entirely,
+treat it as advisory (public-repo default on) but note the API did not
+confirm it. `code-scanning/default-setup` `404`/non-`configured` = CodeQL
+default setup not enabled (a recommended-tier gap on a public repo, where
+code scanning is free). For SECURITY.md, record a GAP **only if all three
+paths 404** — a `200` on root, `docs/`, or `.github/` all count as
+present. `private-vulnerability-reporting` empty/`false` = PVR off; a
+non-JSON or error response = not accessible. `dependabot/alerts` 403 is
+expected without `security_events` scope — record "not assessed", not "0".
+
+### Step 6: Produce the tiered PASS/GAP report
+
+Classify every gathered fact into three tiers and mark **PASS** (control
+present), **GAP** (control absent), or **N/A** (not applicable, e.g. a paid
+private-repo feature on a public repo). Distinguish a **required** check
+from an **advisory** one: a status check that runs but is not listed in the
+ruleset's `required_status_checks` does not gate anything — it is advisory
+only.
+
+**Interpret the solo-maintainer lockout.** Cross-reference the Step 2
+direct-collaborator count with the Step 3 `required_approving_review_count`.
+On a single-maintainer repo, `required_approving_review_count >= 1` (and
+`require_code_owner_review` with a sole owner) is **unsatisfiable** — you
+cannot approve your own PR — so on an auto-commit repo it is a self-lockout
+/ functional breakage, **not** a PASS. Flag it as a GAP-with-caveat, and
+note that a **ruleset** (unlike classic branch protection's `enforce_admins`)
+does **not** auto-exempt the admin: the sole maintainer stays blocked unless
+explicitly added to the ruleset `bypass_actors`.
+
+**Do not publish the raw report into the audited repo.** The PASS/GAP list
+enumerates exact, admin-only-visible gaps (no ruleset, `GITHUB_TOKEN` can
+approve PRs, no push protection) — a pre-remediation vulnerability roadmap.
+While any GAP is open, keep the findings **local/private** (a gitignored
+file, a private gist, or a draft GitHub Security Advisory); never commit it
+into the public repo being audited (contrast `security-audit-codebase`,
+which writes `SECURITY_AUDIT_REPORT.md` into the project root — do NOT copy
+that pattern here). Redact ruleset / App ID / bypass-actor identifiers
+before any public write.
+
+```text
+# GitHub Repo Security Assessment — OWNER/REPO
+Date: YYYY-MM-DD   Visibility: public   Auditor role: admin
+
+## Essential
+- [PASS] Ruleset with deletion + non_fast_forward on default branch
+- [GAP]  default_workflow_permissions = write (should be read)
+- [PASS] can_approve_pull_request_reviews = false
+- [GAP]  actions/checkout pinned to @v4 tag, not a 40-char SHA
+- [PASS] Dependabot alerts (204) + security updates (enabled)
+- [GAP]  No .github/dependabot.yml (version updates off — keeps
+         github-actions action pins fresh; essential supply-chain hygiene)
+- [PASS] Secret scanning + push protection enabled
+
+## Recommended
+- [N/A]  required_status_checks — none (no CI gate configured)
+- [PASS] CodeQL default setup: configured
+- [PASS] SECURITY.md present (.github/) + PVR enabled
+
+## Advanced
+- [GAP]  sha_pinning_required: not enforced
+- [N/A]  Required signed commits — would block the auto-commit bot
+- [N/A]  Paid GHAS / Secret Protection — public repo, features free
+
+## Notes
+- Auto-commit bot: ruleset has NO App/DeployKey bypass actor; if
+  required_status_checks were added the github-actions[bot] push would 403.
+- Solo maintainer (1 direct collaborator): required_approving_review_count
+  is 0 — correct; any value >= 1 would be an unsatisfiable self-lockout and
+  a ruleset would NOT auto-exempt the admin.
+- Dependabot open alerts: not assessed (token lacks security_events).
+- This report is kept local/private — not committed into the audited repo
+  while GAPs remain open.
+```
+
+**Expected:** A written report with every fact placed in a tier and
+marked PASS / GAP / N/A, plus a Notes section for auth gaps, advisory-only
+checks, and the auto-commit-bot bypass interaction.
+
+**On failure:** If some endpoints 403'd, still emit the report but mark
+those rows "not assessed" and state the missing scope/role at the top —
+never record an unreadable control as a GAP (absence of access is not
+absence of the control).
+
+## Validation
+
+- [ ] `gh auth status` confirmed and admin on the repo verified (or the
+      report is explicitly flagged incomplete)
+- [ ] `visibility` recorded (drives which features are free vs N/A)
+- [ ] BOTH rulesets AND classic branch protection were queried (not just one)
+- [ ] Actions `permissions` and `permissions/workflow` both read
+- [ ] Dependabot alerts, security updates, secret scanning, and push
+      protection each checked as **separate** toggles
+- [ ] CodeQL default setup queried via `code-scanning/default-setup`
+      (not inferred from `security_and_analysis`, which has no such field)
+- [ ] SECURITY.md checked at all three auto-detected paths (root, `docs/`,
+      `.github/`) — GAP only if all three 404
+- [ ] Private vulnerability reporting read from the `.enabled` body field
+      (not a 204/404 toggle)
+- [ ] Solo-maintainer lockout interpreted: collaborator count cross-referenced
+      with `required_approving_review_count`
+- [ ] Every finding is tiered and marked PASS / GAP / N/A
+- [ ] Report kept local/private while GAPs are open — NOT committed into
+      the audited public repo
+- [ ] No setting was changed — this audit is strictly read-only
+
+## Common Pitfalls
+
+- **Checking only rulesets or only classic protection**: They are
+  independent mechanisms. A repo protected by a ruleset returns `404` on
+  `branches/{b}/protection`; concluding "unprotected" from that alone is
+  wrong. Always query both.
+- **Some endpoints 403 without security scope/admin**: `dependabot/alerts`
+  needs `security_events`; rulesets and Actions permissions need admin. A
+  403 is "not assessed", not a GAP — recording it as a gap fabricates a
+  finding.
+- **A green check that is not REQUIRED is advisory only**: A CI job that
+  runs and passes gates nothing unless its context is in the ruleset's
+  `required_status_checks`. Do not report a running check as a protective
+  control.
+- **Alerts != fixes**: Dependabot **alerts** (`vulnerability-alerts`, 204)
+  only detect; **security updates** (`automated-security-fixes`) open the
+  fix PRs. Enabling one does not enable the other — assess both.
+- **Treating paid-feature absence as a gap on a public repo**: Secret
+  scanning, push protection, CodeQL, and dependency review are free on
+  public repos; GHAS / Secret Protection / Code Security are private/org
+  products. Their absence on a public repo is N/A, not a gap.
+- **Misreading the auto-commit-bot bypass**: The default `GITHUB_TOKEN` /
+  `github-actions[bot]` can never be a ruleset bypass actor. If a repo
+  auto-commits to a branch that has `required_status_checks` or a
+  `pull_request` rule with no `Integration`/`DeployKey` bypass actor, the
+  bot push is being rejected — surface it as a real finding.
+- **Reading the API default as a hard cap**: `default_workflow_permissions`
+  is the repo default; per-job `permissions:` in the workflow YAML can
+  raise or drop it for same-repo events. The API cannot show the effective
+  per-workflow grant — note that limitation.
+- **Probing SECURITY.md at only one path**: GitHub auto-detects the policy
+  at the repo root, `docs/`, OR `.github/`. Checking only one path and
+  recording a 404 as a GAP fabricates a finding — a repo with SECURITY.md
+  at root is fully compliant. Only record a GAP if all three 404.
+- **Inferring CodeQL from `security_and_analysis`**: that object carries
+  `secret_scanning*`, `dependabot_security_updates`, and `advanced_security`
+  — but **no** code-scanning field. CodeQL default-setup state comes only
+  from the `code-scanning/default-setup` endpoint; never claim a CodeQL
+  PASS/GAP the skill did not actually probe.
+- **Marking a solo review requirement as PASS**: on a one-maintainer repo,
+  `required_approving_review_count >= 1` is an unsatisfiable self-lockout,
+  not a protective control — and a ruleset (unlike classic `enforce_admins`)
+  will not auto-exempt the admin. Report it as a functional-breakage GAP.
+
+## Related Skills
+
+- `harden-github-repo-security` - apply the fixes this audit surfaces
+- `security-audit-codebase` - complementary in-tree secret/dependency scan
+- `configure-git-repository` - foundational repo + `.gitignore` setup

--- a/i18n/zh-CN/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/zh-CN/skills/harden-github-repo-security/SKILL.md
@@ -1,0 +1,358 @@
+---
+name: harden-github-repo-security
+description: >
+  Apply GitHub repository security protections tier by tier — rulesets,
+  read-only Actions token, secret scanning + push protection, Dependabot,
+  and (gated) required status checks / required PR with a GitHub App bypass
+  for a CI auto-commit bot. Mutating and confirmation-gated: always assess
+  first, apply the zero-downside baseline, then decide required checks
+  separately. Use when hardening a public user-owned repo after an audit,
+  when a repo has no branch protection, when adding required checks without
+  breaking a bot that pushes to the default branch, or when provisioning a
+  GitHub App bypass actor for trusted automation.
+license: MIT
+allowed-tools: Read Write Edit Bash
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: advanced
+  language: multi
+  tags: github, security, rulesets, branch-protection, github-actions, hardening
+  locale: zh-CN
+  source_locale: en
+  source_commit: 84a3c915
+  translator: "Claude + human review"
+  translation_date: "2026-07-16"
+---
+
+# Harden GitHub Repository Security
+
+Apply GitHub protections in order of blast radius: assess, then a zero-downside
+baseline that never breaks CI, then a gated decision on required checks / PR.
+Every mutating step is confirmation-gated. Running example: a **public,
+user-owned** repo whose CI auto-commits to the default branch via
+`stefanzweifel/git-auto-commit-action` with the default `GITHUB_TOKEN`.
+
+Throughout, `R` = `OWNER/REPO` (e.g. `pjt222/agent-almanac`). Set it once:
+`R=OWNER/REPO`. All `gh api` writes require repo admin.
+
+## When to Use
+
+- Hardening a public user-owned repo after `assess-github-repo-security`
+- A repo has no ruleset / branch protection and you want a safe baseline
+- Adding required status checks or required PR **without** breaking a bot that
+  pushes to the default branch
+- Provisioning a GitHub App (or deploy key) bypass actor for trusted automation
+
+## Inputs
+
+- **Required**: `OWNER/REPO` and admin access (`gh auth status` shows admin)
+- **Required**: whether a CI bot pushes to the default branch (and which action/identity)
+- **Optional**: assessment report from `assess-github-repo-security`
+- **Optional**: exact CI check `context` name(s) to require (must run on `push`)
+- **Optional**: GitHub App id + private key if going to required checks/PR
+
+## Procedure
+
+### Step 1: Assess First and Confirm Scope
+
+Never mutate blind. Run the read-only assessment and confirm the plan with the user.
+
+```bash
+# 1. Run the companion read-only skill first (or its core probes):
+gh api /repos/$R --jq '{visibility,default_branch,is_org:.organization!=null}'
+gh api /repos/$R/rulesets --jq '.[] | {id,name,enforcement}'
+gh api /repos/$R/actions/permissions/workflow
+
+# 2. Confirm the two decisive facts before any write:
+#    - Is the repo PUBLIC and USER-OWNED?  (rulesets are free here)
+#    - Does a bot push to the default branch?  (gates Step 3 entirely)
+```
+
+Confirm with the user: baseline (Step 2) is always safe; Step 3 (required
+checks / PR) is a separate opt-in that **will** block a default-branch bot
+unless a bypass is provisioned first.
+
+**Expected:** You know visibility, owner type, current rulesets, current token
+default, and whether a bot pushes to the default branch. The user has approved
+applying at least the baseline.
+
+**On failure:** If the repo is **private and user-owned**, rulesets need GitHub
+Pro — stop and surface that. If not admin, stop (writes will 403). If a bot
+pushes to the default branch, flag that Step 3 is blocked until Step 3a runs.
+
+### Step 2: Apply the Zero-Downside Baseline (never breaks a CI auto-commit)
+
+This tier hardens the repo without breaking a direct-push bot. Apply after
+confirmation. Force-push/deletion protection, a read-only token default, the
+free security features, and policy files.
+
+```bash
+# 2a. Default-branch ruleset: force-push + deletion protection ONLY.
+#     These do NOT block the bot's direct push.
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+
+# 2b. Actions token: read-only default + no token PR approval.
+#     A DEFAULT (not a cap) for same-repo push events, so the bot still works
+#     once its job declares contents: write.
+gh api --method PUT /repos/$R/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=false
+
+# 2c. Free security features (all free on public repos):
+gh api -X PUT repos/$R/vulnerability-alerts          # alerts + dependency graph
+gh api -X PUT repos/$R/automated-security-fixes      # Dependabot fix PRs (separate toggle!)
+gh api -X PATCH repos/$R --input - <<'JSON'
+{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}
+JSON
+gh api -X PUT repos/$R/private-vulnerability-reporting
+```
+
+Leave **Settings > Actions > General** fork-PR approval at the public-repo
+default ("Require approval for first-time contributors"). Fork `pull_request`
+runs already receive a read-only `GITHUB_TOKEN` with no access to secrets, so a
+fork cannot auto-commit to the default branch (no REST toggle — this is a UI
+setting; tighten to "all external contributors" only if the repo has secrets or
+self-hosted runners).
+
+Then add two tracked files (commit them):
+
+`.github/dependabot.yml` — include a `github-actions` block so action SHAs stay fresh:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+`.github/SECURITY.md` — a short disclosure policy pointing reporters at the
+"Report a vulnerability" button (private vulnerability reporting, enabled above).
+
+Flipping the token default to `read` silently strips write from **every**
+workflow that assumed a write default, not just the auto-commit job. Audit
+**all** files in `.github/workflows/` and declare the minimal `permissions:` each
+job actually needs — common scopes are `contents`, `packages`, `pull-requests`,
+`pages`, and `id-token`. For the running example: top-level `permissions: {}`,
+`contents: write` only on the auto-commit job, and every `uses:` pinned to a
+full 40-char commit SHA with the version in a trailing comment.
+
+**Expected:** `gh api /repos/$R/rulesets` shows `protect-default` active;
+`.../actions/permissions/workflow` shows `default_workflow_permissions: read`
+and `can_approve_pull_request_reviews: false`; secret scanning + push protection
++ Dependabot + private reporting are on; `.github/dependabot.yml` and
+`.github/SECURITY.md` are committed. The bot's next run still pushes.
+
+**On failure:** If 2b makes an existing bot push 403 — or any other workflow
+fails after losing a write scope it silently relied on — the job is missing the
+explicit `permissions:` it needs (e.g. `contents: write`, `packages: write`,
+`pull-requests: write`); add the minimal scope back (the read-only default is not
+a hard cap for same-repo pushes). If `automated-security-fixes` seems to do nothing, verify
+`vulnerability-alerts` (2c line 1) ran first — alerts are a separate prerequisite
+toggle from fixes. If push protection later fails a bot run, treat the flagged
+secret as a **real finding** — the bot cannot click the interactive web bypass.
+
+### Step 3: Decision Gate — Required Status Checks / Required PR
+
+STOP. Required checks and required PR **block direct pushes to the ref**, not
+just PR merges. If a bot pushes to the default branch, turning either on **will
+break it** unless you first provision a bypass. The default `GITHUB_TOKEN` /
+`github-actions[bot]` **cannot** be a bypass actor (GitHub design). Do not enable
+this tier on a bot-pushing branch without a bypass in place.
+
+Also, on a **solo** repo, `required_approving_review_count >= 1` is a self-lockout
+(you cannot approve your own PR) — keep it `0`. And a required check that only
+runs on `pull_request` never reports on a direct push, so it **permanently**
+blocks the bot. Ensure the check runs on `push`.
+
+**Step 3a — provision the bot bypass FIRST (if a bot pushes to this branch).**
+Recommended: a GitHub App installation token. (Deploy key is a narrower
+single-repo alternative: add an SSH deploy key with write access and use
+`actor_type: DeployKey` in 3b.)
+
+```bash
+# Create a GitHub App (personal account, Settings > Developer settings >
+# GitHub Apps), permission Repository > Contents: Read and write; install it
+# on THIS repo. Store the App id as a repo variable and the private key as an
+# Actions secret. In the workflow, mint a token and pass it to checkout + the
+# commit action:
+#   - uses: actions/create-github-app-token@<sha>   # v2
+#     id: app-token
+#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+#   - uses: actions/checkout@<sha>
+#     with: { token: ${{ steps.app-token.outputs.token }} }
+#   - uses: stefanzweifel/git-auto-commit-action@<sha>
+#     with: { ... }   # inherits the app token via the checkout credentials
+#
+# The numeric App id used in Step 3b is shown on the App's own page:
+# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+# It is unrelated to the repository id and cannot be derived from /repos/$R.
+```
+
+**Higher-assurance alternative (no standing bypass actor).** If a manual merge
+click is acceptable, convert the job to open a PR with the App token (e.g.
+`peter-evans/create-pull-request`) and let a human merge. No bypass actor is
+needed and every rule stays enforced even against the automation's identity. The
+App token is still required: a PR opened with the plain `GITHUB_TOKEN` does not
+trigger `pull_request`/`push` workflows, so required checks never run and it sits
+`expected` forever (see Common Pitfalls).
+
+**Step 3b — apply the hardened ruleset with the App as an `Integration` bypass
+actor.** Replace `RULESET_ID` with the id from Step 2a, `<APP_ID>` with your App
+id, and `build` with your real check context. `bypass_mode: always` because the
+action pushes directly (use `pull_request` only if the bot opens PRs).
+
+```bash
+gh api --method PUT /repos/$R/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "pull_request", "parameters": { "required_approving_review_count": 0, "dismiss_stale_reviews_on_push": true, "require_code_owner_review": false, "require_last_push_approval": false, "required_review_thread_resolution": false, "allowed_merge_methods": ["merge"] } },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+
+# Verify the bypass actor is present:
+gh api /repos/$R/rulesets/RULESET_ID --jq '.bypass_actors'
+```
+
+`do_not_enforce_on_create: true` avoids the new-branch catch-22 (CI can't have
+run on a branch that does not exist yet). If there is **no** bot on this branch,
+you may skip 3a and omit `bypass_actors`.
+
+Trade-off: `strict_required_status_checks_policy: true` ("branch must be
+up to date") forces every open human PR to be re-updated each time the bot
+auto-commits to the default branch, and `dismiss_stale_reviews_on_push: true`
+compounds the churn — a chatty bot can make PRs perpetually unmergeable. On a
+frequently-auto-committed branch prefer `strict_required_status_checks_policy:
+false` (loose) unless up-to-date-before-merge is genuinely required.
+
+**Expected:** The ruleset now enforces the required check and required-PR rule
+for humans and forks, `.bypass_actors` lists the App (`Integration`), and the
+bot's next run still lands on the default branch (via the App token). Humans
+must open a PR; the check must be green.
+
+**On failure:** If the bot 403s after 3b, the App identity is not actually the
+bypass actor — confirm the workflow passes the App token to **checkout** (not
+just to the commit action) and that `<APP_ID>` in `bypass_actors` matches. If
+the bot's push sits `expected`/`pending` forever, the required check does not run
+on `push` — make it trigger on `push` or drop it from the required list. If the
+bypass-actor picker does not appear on your personal repo, the required-PR +
+auto-commit combination is unsatisfiable here; GitHub's workaround is a free org.
+If merges are blocked on a solo repo, `required_approving_review_count` is `>= 1`
+— set it to `0`.
+
+### Step 4: Optional Advanced Hardening
+
+Apply individually, each still confirmation-gated. None of these are needed for
+the baseline; several have sharp edges.
+
+```bash
+# 4a. Tag ruleset — protect release tags (classic tag protection is deprecated):
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{ "name": "protect-tags", "target": "tag", "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/tags/v*"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ] }
+JSON
+
+# 4b. Merge-method toggles (e.g. merge-commits-only to preserve per-commit history):
+gh api -X PATCH repos/$R -F allow_merge_commit=true -F allow_squash_merge=false \
+  -F allow_rebase_merge=false -F delete_branch_on_merge=true
+
+# 4c. CodeQL "default setup" (server-managed — commits NO workflow YAML):
+gh api -X PATCH repos/$R/code-scanning/default-setup -f state=configured -f query_suite=default
+
+# 4d. sha_pinning_required — ONLY after every `uses:` is a full 40-char SHA,
+#     or every workflow run fails (including actions/checkout):
+gh api --method PUT /repos/$R/actions/permissions -F enabled=true \
+  -f allowed_actions=selected -F sha_pinning_required=true
+# selected mode also gates WHICH actions may run: github_owned covers actions/*,
+# but git-auto-commit-action is NOT GitHub-owned — allow-list it in the SAME
+# step or the bot fails with "actions are not allowed":
+gh api --method PUT /repos/$R/actions/permissions/selected-actions \
+  -F github_owned_allowed=true -F verified_allowed=false \
+  -f 'patterns_allowed[]=stefanzweifel/git-auto-commit-action@*'
+gh api /repos/$R/actions/permissions --jq '.sha_pinning_required'   # verify
+```
+
+Note: `allowed_actions=selected` with `github_owned_allowed=true` still blocks
+`stefanzweifel/git-auto-commit-action` until it is in `patterns_allowed` (the 4d
+allow-list command handles this). Require-signed-commits and require-linear-history
+are intentionally omitted here:
+signing blocks the unsigned git-CLI bot push, and linear history is mutually
+exclusive with a merge-commits-only policy.
+
+**Expected:** Each selected advanced control is applied and verified without
+breaking the bot: tag ruleset lists on `.../rulesets`, merge toggles reflect on
+the repo object, CodeQL default setup shows `state: configured`,
+`sha_pinning_required` reads `true` only after all actions are SHA-pinned, and
+`git-auto-commit-action` is in `patterns_allowed` so the bot still runs.
+
+**On failure:** If every workflow fails right after 4d, an action is still
+tag-pinned — convert all `uses:` to SHAs or revert `sha_pinning_required` to
+`false`. If the bot fails with "actions are not allowed" after restricting
+allowed actions, add `git-auto-commit-action` to `patterns_allowed`. If 4c
+errors, the repo may have no CodeQL-supported language — skip it.
+
+## Validation
+
+- [ ] Assessment ran and scope (public/user-owned, bot-on-default-branch) confirmed before any write
+- [ ] `protect-default` ruleset active with `deletion` + `non_fast_forward`
+- [ ] `default_workflow_permissions=read` and `can_approve_pull_request_reviews=false`
+- [ ] Secret scanning + push protection + Dependabot alerts + fixes + private reporting enabled
+- [ ] `.github/dependabot.yml` (github-actions ecosystem) and `.github/SECURITY.md` committed
+- [ ] Auto-commit bot's next run still pushes successfully (baseline did not break it)
+- [ ] Required checks/PR enabled ONLY with a GitHub App (or deploy key) bypass in place first
+- [ ] Solo repo keeps `required_approving_review_count: 0`; required checks run on `push`
+- [ ] Loop guard added if a bot now pushes with an App token or PAT
+
+## Common Pitfalls
+
+- **GITHUB_TOKEN is not a bypass actor**: `github-actions[bot]` / the default
+  token cannot be added to any ruleset bypass list and cannot push to a
+  protected branch, by design. "Just add the Actions bot to the bypass list"
+  has no such option — the push 403s. Use a GitHub App or deploy key.
+- **PAT bypass is an anti-pattern**: an admin/personal PAT in the bypass list
+  (or classic BP with `enforce_admins=false`) exempts ALL admin actions
+  including your own interactive pushes — role-wide, not automation-scoped, and
+  long-lived. Prefer an App (`Integration`) or deploy key (`DeployKey`).
+- **Required checks only on `pull_request`**: a check that never runs on `push`
+  never reports on the bot's direct push, so it **permanently** blocks the bot
+  and new-branch creation. Make the check run on `push` and set
+  `do_not_enforce_on_create: true`.
+- **Loop guard once an App token replaces GITHUB_TOKEN**: the default token
+  suppresses downstream `push`/`pull_request` triggers; an App token or PAT does
+  not, so the auto-commit workflow can re-trigger itself indefinitely. Guard with
+  `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`.
+- **PR via the default GITHUB_TOKEN is a false fix**: a PR opened by
+  `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so required
+  checks never run and it sits `expected` forever. Create the PR with the App token.
+- **Alerts != fixes**: `vulnerability-alerts` and `automated-security-fixes` are
+  separate toggles; enabling alerts opens no PRs. Enable both.
+- **Don't buy GHAS on a public repo**: secret scanning, push protection, CodeQL,
+  and dependency review are already free on public repos; the paid Secret
+  Protection / Code Security products target private/org repos.
+
+## Related Skills
+
+- `assess-github-repo-security` - the read-only companion; always run this first
+- `configure-git-repository` - baseline .gitignore, branches, remotes, hooks
+- `setup-github-actions-ci` - the CI workflow whose token/permissions this hardens

--- a/i18n/zh-CN/translation_status.yml
+++ b/i18n/zh-CN/translation_status.yml
@@ -3,10 +3,10 @@ last_updated: '2026-07-16'
 coverage:
   skills:
     translated: 352
-    total: 366
-    pct: 96.2
+    total: 368
+    pct: 95.7
     stale: 130
-    stubs: 11
+    stubs: 13
   agents:
     translated: 3
     total: 73
@@ -21,13 +21,13 @@ coverage:
     stubs: 1
   guides:
     translated: 3
-    total: 33
-    pct: 9.1
+    total: 34
+    pct: 8.8
     stale: 2
-    stubs: 1
+    stubs: 2
   total:
     translated: 359
-    total: 490
-    pct: 73.3
+    total: 493
+    pct: 72.8
     stale: 136
-    stubs: 14
+    stubs: 17

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,7 +1,7 @@
 # Skills Library for Agentic Systems
 
 <!-- AUTO:START:skills-intro -->
-A collection of 366 task-level skills following the [Agent Skills open standard](https://agentskills.io) (`SKILL.md` format). These skills provide structured, executable procedures that agentic systems (Claude Code, Codex, Cursor, Gemini CLI, etc.) can consume to perform specific development tasks.
+A collection of 368 task-level skills following the [Agent Skills open standard](https://agentskills.io) (`SKILL.md` format). These skills provide structured, executable procedures that agentic systems (Claude Code, Codex, Cursor, Gemini CLI, etc.) can consume to perform specific development tasks.
 <!-- AUTO:END:skills-intro -->
 
 ## How Skills Differ from Guides and Agents
@@ -28,7 +28,7 @@ Browse by domain:
 | [Compliance](compliance/) | 17 | GxP regulatory and validation skills |
 | [Mcp Integration](mcp-integration/) | 6 | MCP server setup and troubleshooting skills |
 | [Web Dev](web-dev/) | 5 | Web development skills for Next.js and modern frontend |
-| [Git](git/) | 8 | Git version control and GitHub workflow skills |
+| [Git](git/) | 10 | Git version control and GitHub workflow skills |
 | [General](general/) | 24 | Cross-cutting development environment and workflow skills |
 | [Citations](citations/) | 3 | Academic and software citation management with R and BibTeX |
 | [Data Serialization](data-serialization/) | 2 | Data serialization formats, schemas, and evolution strategies |

--- a/skills/_registry.yml
+++ b/skills/_registry.yml
@@ -1,7 +1,7 @@
 version: "1.6"
 generated: "2026-04-07"
 standard: "agentskills.io/specification"
-total_skills: 366
+total_skills: 368
 
 domains:
   r-packages:
@@ -365,6 +365,16 @@ domains:
         complexity: intermediate
         language: multi
         description: Drive a GitHub Copilot PR review to a clean pass — fix, reply with the sha, resolve the thread, re-request the bot, and poll the async re-review
+      - id: assess-github-repo-security
+        path: assess-github-repo-security/SKILL.md
+        complexity: intermediate
+        language: multi
+        description: Read-only audit of a GitHub repo's security posture — rulesets, Actions token, secret scanning, Dependabot, bot-push exposure
+      - id: harden-github-repo-security
+        path: harden-github-repo-security/SKILL.md
+        complexity: advanced
+        language: multi
+        description: Apply GitHub repo protections tier by tier — rulesets, read-only Actions token, secret scanning, Dependabot, and gated required checks with a GitHub App bypass for a CI auto-commit bot
 
   general:
     description: Cross-cutting development environment and workflow skills

--- a/skills/assess-github-repo-security/SKILL.md
+++ b/skills/assess-github-repo-security/SKILL.md
@@ -1,0 +1,380 @@
+---
+name: assess-github-repo-security
+description: >
+  Read-only audit of a GitHub repository's security posture. Gathers ref
+  protection (rulesets AND classic branch protection), Actions token
+  permissions, code and supply-chain features (Dependabot, secret
+  scanning, push protection, CodeQL), and repo hygiene toggles via
+  `gh api`, then classifies findings against essential / recommended /
+  advanced tiers into a PASS/GAP report. Makes NO changes. Use when
+  reviewing a repo before open-sourcing or a release, auditing a public
+  user-owned repo whose CI auto-commits to the default branch, verifying
+  a hardening change actually took effect, or producing a baseline
+  security posture report for a repository.
+license: MIT
+allowed-tools: Read Bash Grep
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: intermediate
+  language: multi
+  tags: github, security, audit, rulesets, branch-protection, dependabot, actions
+---
+
+# Assess GitHub Repository Security
+
+Audit a GitHub repository's security posture, read-only, and classify it
+against tiered best practices. This skill only reads — it never enables,
+disables, or changes any setting. Remediation is a separate concern (see
+`harden-github-repo-security`).
+
+## When to Use
+
+- Reviewing a repo before open-sourcing it or cutting a release
+- Auditing a public, user-owned repo whose CI auto-commits to the default
+  branch (e.g. via `stefanzweifel/git-auto-commit-action` + the default
+  `GITHUB_TOKEN`)
+- Verifying that a hardening change actually took effect
+- Producing a baseline posture report to track over time
+
+## Inputs
+
+- **Required**: Target repository as `OWNER/REPO`
+- **Required**: `gh` CLI authenticated with an account that has the
+  **admin repository role** on the target repo (some endpoints 403
+  otherwise). This is a role requirement, not a need for a broad
+  write-capable token: a fine-grained, single-repo PAT scoped to
+  read-only Administration / Actions / Secret-scanning permissions
+  satisfies the same admin check with far less blast radius if the
+  audit credential is ever leaked or reused in automation
+- **Optional**: Branch to check for classic protection (defaults to the
+  repo's `default_branch`)
+- **Optional**: `security_events` token scope — needed only to count open
+  Dependabot alerts; the rest works without it
+
+Set a shorthand for every command below:
+
+```bash
+R="OWNER/REPO"   # e.g. pjt222/agent-almanac
+```
+
+## Procedure
+
+### Step 1: Preflight — auth and admin
+
+Confirm the CLI is authenticated and the account has admin on the repo.
+Non-admins get partial data (403 on rulesets, Actions, and security
+endpoints), which silently understates the posture.
+
+```bash
+gh auth status
+gh api "repos/$R" --jq '{full_name, admin: .permissions.admin, visibility}'
+```
+
+**Expected:** `gh auth status` shows a logged-in account; the second call
+prints `admin: true`.
+
+**On failure:** If not authenticated, run `gh auth login` (or set
+`GH_TOKEN`). If `admin: false`, stop and note in the report that findings
+are **incomplete** — a non-admin cannot read ruleset internals or Actions
+permissions, so absence of a control cannot be distinguished from lack of
+access.
+
+### Step 2: Repo basics — visibility, merge toggles, collaborators
+
+```bash
+gh api "repos/$R" --jq '{visibility, private, allow_forking,
+  default_branch, allow_merge_commit, allow_squash_merge,
+  allow_rebase_merge, delete_branch_on_merge}'
+
+# Direct collaborators and their effective role
+gh api "repos/$R/collaborators?affiliation=direct" \
+  --jq '.[] | {login, role_name}'
+```
+
+**Expected:** JSON for the repo toggles plus one line per direct
+collaborator with `role_name` (`admin`/`maintain`/`write`/`triage`/`read`).
+
+**On failure:** A 403 on `collaborators` means the token lacks admin; note
+it and continue. Record `visibility` — it changes which features are
+**free**: on **public** repos secret scanning, push protection, CodeQL,
+and dependency review are free; the paid GHAS/Secret Protection products
+are private/org-only, so their absence on a public repo is not a gap.
+
+### Step 3: Ref protection — check rulesets AND classic (both)
+
+A repo can be protected by a **ruleset**, by **classic branch
+protection**, by both, or by neither. Rulesets are the actively-developed
+path and are free on public user-owned repos. You MUST check both — a repo
+with only a ruleset returns 404 on the classic endpoint and vice versa.
+
+```bash
+b=$(gh api "repos/$R" --jq '.default_branch')
+
+# (a) Rulesets — list, then inspect each active one's rules + bypass list
+gh api "repos/$R/rulesets" --jq '.[] | {id, name, enforcement, target}'
+# For each id from above:
+#   gh api "repos/$R/rulesets/<id>" \
+#     --jq '{name, enforcement,
+#            rules: [.rules[].type],
+#            bypass: [.bypass_actors[] | {actor_type, bypass_mode}]}'
+
+# (b) Classic branch protection on the default branch (404 = none)
+gh api -i "repos/$R/branches/$b/protection" 2>/dev/null | head -1
+gh api "repos/$R/branches/$b/protection" \
+  --jq '{required_status_checks: .required_status_checks.checks,
+         strict: .required_status_checks.strict,
+         enforce_admins: .enforce_admins.enabled,
+         required_reviews: .required_pull_request_reviews.required_approving_review_count,
+         linear: .required_linear_history.enabled,
+         signatures: .required_signatures.enabled,
+         allow_force_pushes: .allow_force_pushes.enabled,
+         allow_deletions: .allow_deletions.enabled}' 2>/dev/null \
+  || echo "no classic branch protection"
+```
+
+**Expected:** Either a ruleset with rules such as `deletion`,
+`non_fast_forward`, `pull_request`, `required_status_checks`, or a classic
+protection object, or an explicit "none" from both.
+
+**On failure:** A `404` on either endpoint means that mechanism is **not
+configured** — it is a valid data point, not an error; record "none" for
+that mechanism. Note the rule set from the ruleset `rules[].type` list and
+the `bypass_actors`. Remember: the default `GITHUB_TOKEN` /
+`github-actions[bot]` can never be a bypass actor by design — if the repo
+auto-commits AND has `required_status_checks`/`pull_request` rules with no
+`Integration` (GitHub App) or `DeployKey` bypass actor, flag that the bot
+push must be 403ing (a real finding).
+
+### Step 4: Actions security — token defaults and PR approval
+
+```bash
+# Actions enablement + allowed-actions policy (+ SHA-pinning policy)
+gh api "repos/$R/actions/permissions" \
+  --jq '{enabled, allowed_actions, sha_pinning_required}'
+
+# Default GITHUB_TOKEN permissions + can-the-bot-approve-PRs
+gh api "repos/$R/actions/permissions/workflow" \
+  --jq '{default_workflow_permissions, can_approve_pull_request_reviews}'
+```
+
+**Expected:** `default_workflow_permissions` is `read` (hardened) or
+`write` (permissive default), and `can_approve_pull_request_reviews` is
+`false` (hardened) or `true` (a review-bypass vector).
+
+**On failure:** 403 means non-admin — note it. If
+`allowed_actions` is `all`, any action can run (looser); `selected` with a
+pinned allow-list is tighter — but note that `selected` +
+`github_owned_allowed` still blocks non-GitHub actions like
+`stefanzweifel/git-auto-commit-action` unless explicitly allow-listed.
+`sha_pinning_required` may be absent/`null` on repos that never set the
+2025-08 policy — record as "not enforced". Per-workflow `permissions:`
+blocks live in the YAML, not the API; note that the API shows only the
+repo **default**, which is a default (not a cap) for same-repo push
+events.
+
+### Step 5: Code and supply-chain features
+
+```bash
+# Dependabot alerts + dependency graph (204 = ON, 404 = OFF)
+gh api -i "repos/$R/vulnerability-alerts" 2>/dev/null | head -1
+
+# Dependabot security updates (auto fix PRs) — separate toggle
+gh api "repos/$R/automated-security-fixes" \
+  --jq '{enabled, paused}' 2>/dev/null || echo "automated-security-fixes: off/unavailable"
+
+# Secret scanning + push protection status (security_and_analysis has NO
+# code-scanning field — CodeQL is probed separately below)
+gh api "repos/$R" --jq '.security_and_analysis'
+
+# CodeQL code scanning — default setup state (its own endpoint)
+gh api "repos/$R/code-scanning/default-setup" --jq '.state' 2>/dev/null \
+  || echo "code-scanning default setup: not configured / no access"
+
+# Dependabot version updates config present?
+gh api -i "repos/$R/contents/.github/dependabot.yml" 2>/dev/null | head -1
+
+# SECURITY.md — GitHub auto-detects it at root, docs/, OR .github/.
+# Present if ANY of the three returns 200; only a GAP if all three 404.
+for p in SECURITY.md docs/SECURITY.md .github/SECURITY.md; do
+  echo "$p: $(gh api -i "repos/$R/contents/$p" 2>/dev/null | head -1)"
+done
+
+# Private vulnerability reporting — status is a 200 body {"enabled": bool},
+# NOT a 204/404 toggle, so read the field directly.
+gh api "repos/$R/private-vulnerability-reporting" --jq '.enabled' 2>/dev/null \
+  || echo "PVR: not accessible"
+
+# Open Dependabot alert count — needs security_events scope; may 403
+gh api "repos/$R/dependabot/alerts?state=open" --jq 'length' 2>/dev/null \
+  || echo "dependabot/alerts: 403 (needs security_events scope) — skipped"
+```
+
+**Expected:** `vulnerability-alerts` → `HTTP/2.0 204` when enabled;
+`security_and_analysis` shows `secret_scanning.status` and
+`secret_scanning_push_protection.status` as `enabled` on a hardened public
+repo; `code-scanning/default-setup` `.state` is `configured` when CodeQL
+default setup is on; `automated-security-fixes` → `enabled: true`; the
+`dependabot.yml` probe returns `200` when present; at least one of the
+three SECURITY.md paths returns `200` when a policy file exists;
+`private-vulnerability-reporting` `.enabled` prints `true` when PVR is on.
+
+**On failure:** `vulnerability-alerts` returning `404` = Dependabot alerts
+OFF (a gap). Remember **alerts != fixes**: alerts on with
+`automated-security-fixes` off means nothing is auto-remediated — flag
+both separately. On **public** repos `secret_scanning` is usually already
+`enabled` by default; if `security_and_analysis` omits the field entirely,
+treat it as advisory (public-repo default on) but note the API did not
+confirm it. `code-scanning/default-setup` `404`/non-`configured` = CodeQL
+default setup not enabled (a recommended-tier gap on a public repo, where
+code scanning is free). For SECURITY.md, record a GAP **only if all three
+paths 404** — a `200` on root, `docs/`, or `.github/` all count as
+present. `private-vulnerability-reporting` empty/`false` = PVR off; a
+non-JSON or error response = not accessible. `dependabot/alerts` 403 is
+expected without `security_events` scope — record "not assessed", not "0".
+
+### Step 6: Produce the tiered PASS/GAP report
+
+Classify every gathered fact into three tiers and mark **PASS** (control
+present), **GAP** (control absent), or **N/A** (not applicable, e.g. a paid
+private-repo feature on a public repo). Distinguish a **required** check
+from an **advisory** one: a status check that runs but is not listed in the
+ruleset's `required_status_checks` does not gate anything — it is advisory
+only.
+
+**Interpret the solo-maintainer lockout.** Cross-reference the Step 2
+direct-collaborator count with the Step 3 `required_approving_review_count`.
+On a single-maintainer repo, `required_approving_review_count >= 1` (and
+`require_code_owner_review` with a sole owner) is **unsatisfiable** — you
+cannot approve your own PR — so on an auto-commit repo it is a self-lockout
+/ functional breakage, **not** a PASS. Flag it as a GAP-with-caveat, and
+note that a **ruleset** (unlike classic branch protection's `enforce_admins`)
+does **not** auto-exempt the admin: the sole maintainer stays blocked unless
+explicitly added to the ruleset `bypass_actors`.
+
+**Do not publish the raw report into the audited repo.** The PASS/GAP list
+enumerates exact, admin-only-visible gaps (no ruleset, `GITHUB_TOKEN` can
+approve PRs, no push protection) — a pre-remediation vulnerability roadmap.
+While any GAP is open, keep the findings **local/private** (a gitignored
+file, a private gist, or a draft GitHub Security Advisory); never commit it
+into the public repo being audited (contrast `security-audit-codebase`,
+which writes `SECURITY_AUDIT_REPORT.md` into the project root — do NOT copy
+that pattern here). Redact ruleset / App ID / bypass-actor identifiers
+before any public write.
+
+```text
+# GitHub Repo Security Assessment — OWNER/REPO
+Date: YYYY-MM-DD   Visibility: public   Auditor role: admin
+
+## Essential
+- [PASS] Ruleset with deletion + non_fast_forward on default branch
+- [GAP]  default_workflow_permissions = write (should be read)
+- [PASS] can_approve_pull_request_reviews = false
+- [GAP]  actions/checkout pinned to @v4 tag, not a 40-char SHA
+- [PASS] Dependabot alerts (204) + security updates (enabled)
+- [GAP]  No .github/dependabot.yml (version updates off — keeps
+         github-actions action pins fresh; essential supply-chain hygiene)
+- [PASS] Secret scanning + push protection enabled
+
+## Recommended
+- [N/A]  required_status_checks — none (no CI gate configured)
+- [PASS] CodeQL default setup: configured
+- [PASS] SECURITY.md present (.github/) + PVR enabled
+
+## Advanced
+- [GAP]  sha_pinning_required: not enforced
+- [N/A]  Required signed commits — would block the auto-commit bot
+- [N/A]  Paid GHAS / Secret Protection — public repo, features free
+
+## Notes
+- Auto-commit bot: ruleset has NO App/DeployKey bypass actor; if
+  required_status_checks were added the github-actions[bot] push would 403.
+- Solo maintainer (1 direct collaborator): required_approving_review_count
+  is 0 — correct; any value >= 1 would be an unsatisfiable self-lockout and
+  a ruleset would NOT auto-exempt the admin.
+- Dependabot open alerts: not assessed (token lacks security_events).
+- This report is kept local/private — not committed into the audited repo
+  while GAPs remain open.
+```
+
+**Expected:** A written report with every fact placed in a tier and
+marked PASS / GAP / N/A, plus a Notes section for auth gaps, advisory-only
+checks, and the auto-commit-bot bypass interaction.
+
+**On failure:** If some endpoints 403'd, still emit the report but mark
+those rows "not assessed" and state the missing scope/role at the top —
+never record an unreadable control as a GAP (absence of access is not
+absence of the control).
+
+## Validation
+
+- [ ] `gh auth status` confirmed and admin on the repo verified (or the
+      report is explicitly flagged incomplete)
+- [ ] `visibility` recorded (drives which features are free vs N/A)
+- [ ] BOTH rulesets AND classic branch protection were queried (not just one)
+- [ ] Actions `permissions` and `permissions/workflow` both read
+- [ ] Dependabot alerts, security updates, secret scanning, and push
+      protection each checked as **separate** toggles
+- [ ] CodeQL default setup queried via `code-scanning/default-setup`
+      (not inferred from `security_and_analysis`, which has no such field)
+- [ ] SECURITY.md checked at all three auto-detected paths (root, `docs/`,
+      `.github/`) — GAP only if all three 404
+- [ ] Private vulnerability reporting read from the `.enabled` body field
+      (not a 204/404 toggle)
+- [ ] Solo-maintainer lockout interpreted: collaborator count cross-referenced
+      with `required_approving_review_count`
+- [ ] Every finding is tiered and marked PASS / GAP / N/A
+- [ ] Report kept local/private while GAPs are open — NOT committed into
+      the audited public repo
+- [ ] No setting was changed — this audit is strictly read-only
+
+## Common Pitfalls
+
+- **Checking only rulesets or only classic protection**: They are
+  independent mechanisms. A repo protected by a ruleset returns `404` on
+  `branches/{b}/protection`; concluding "unprotected" from that alone is
+  wrong. Always query both.
+- **Some endpoints 403 without security scope/admin**: `dependabot/alerts`
+  needs `security_events`; rulesets and Actions permissions need admin. A
+  403 is "not assessed", not a GAP — recording it as a gap fabricates a
+  finding.
+- **A green check that is not REQUIRED is advisory only**: A CI job that
+  runs and passes gates nothing unless its context is in the ruleset's
+  `required_status_checks`. Do not report a running check as a protective
+  control.
+- **Alerts != fixes**: Dependabot **alerts** (`vulnerability-alerts`, 204)
+  only detect; **security updates** (`automated-security-fixes`) open the
+  fix PRs. Enabling one does not enable the other — assess both.
+- **Treating paid-feature absence as a gap on a public repo**: Secret
+  scanning, push protection, CodeQL, and dependency review are free on
+  public repos; GHAS / Secret Protection / Code Security are private/org
+  products. Their absence on a public repo is N/A, not a gap.
+- **Misreading the auto-commit-bot bypass**: The default `GITHUB_TOKEN` /
+  `github-actions[bot]` can never be a ruleset bypass actor. If a repo
+  auto-commits to a branch that has `required_status_checks` or a
+  `pull_request` rule with no `Integration`/`DeployKey` bypass actor, the
+  bot push is being rejected — surface it as a real finding.
+- **Reading the API default as a hard cap**: `default_workflow_permissions`
+  is the repo default; per-job `permissions:` in the workflow YAML can
+  raise or drop it for same-repo events. The API cannot show the effective
+  per-workflow grant — note that limitation.
+- **Probing SECURITY.md at only one path**: GitHub auto-detects the policy
+  at the repo root, `docs/`, OR `.github/`. Checking only one path and
+  recording a 404 as a GAP fabricates a finding — a repo with SECURITY.md
+  at root is fully compliant. Only record a GAP if all three 404.
+- **Inferring CodeQL from `security_and_analysis`**: that object carries
+  `secret_scanning*`, `dependabot_security_updates`, and `advanced_security`
+  — but **no** code-scanning field. CodeQL default-setup state comes only
+  from the `code-scanning/default-setup` endpoint; never claim a CodeQL
+  PASS/GAP the skill did not actually probe.
+- **Marking a solo review requirement as PASS**: on a one-maintainer repo,
+  `required_approving_review_count >= 1` is an unsatisfiable self-lockout,
+  not a protective control — and a ruleset (unlike classic `enforce_admins`)
+  will not auto-exempt the admin. Report it as a functional-breakage GAP.
+
+## Related Skills
+
+- `harden-github-repo-security` - apply the fixes this audit surfaces
+- `security-audit-codebase` - complementary in-tree secret/dependency scan
+- `configure-git-repository` - foundational repo + `.gitignore` setup

--- a/skills/harden-github-repo-security/SKILL.md
+++ b/skills/harden-github-repo-security/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: harden-github-repo-security
+description: >
+  Apply GitHub repository security protections tier by tier — rulesets,
+  read-only Actions token, secret scanning + push protection, Dependabot,
+  and (gated) required status checks / required PR with a GitHub App bypass
+  for a CI auto-commit bot. Mutating and confirmation-gated: always assess
+  first, apply the zero-downside baseline, then decide required checks
+  separately. Use when hardening a public user-owned repo after an audit,
+  when a repo has no branch protection, when adding required checks without
+  breaking a bot that pushes to the default branch, or when provisioning a
+  GitHub App bypass actor for trusted automation.
+license: MIT
+allowed-tools: Read Write Edit Bash
+metadata:
+  author: Philipp Thoss
+  version: "1.0"
+  domain: git
+  complexity: advanced
+  language: multi
+  tags: github, security, rulesets, branch-protection, github-actions, hardening
+---
+
+# Harden GitHub Repository Security
+
+Apply GitHub protections in order of blast radius: assess, then a zero-downside
+baseline that never breaks CI, then a gated decision on required checks / PR.
+Every mutating step is confirmation-gated. Running example: a **public,
+user-owned** repo whose CI auto-commits to the default branch via
+`stefanzweifel/git-auto-commit-action` with the default `GITHUB_TOKEN`.
+
+Throughout, `R` = `OWNER/REPO` (e.g. `pjt222/agent-almanac`). Set it once:
+`R=OWNER/REPO`. All `gh api` writes require repo admin.
+
+## When to Use
+
+- Hardening a public user-owned repo after `assess-github-repo-security`
+- A repo has no ruleset / branch protection and you want a safe baseline
+- Adding required status checks or required PR **without** breaking a bot that
+  pushes to the default branch
+- Provisioning a GitHub App (or deploy key) bypass actor for trusted automation
+
+## Inputs
+
+- **Required**: `OWNER/REPO` and admin access (`gh auth status` shows admin)
+- **Required**: whether a CI bot pushes to the default branch (and which action/identity)
+- **Optional**: assessment report from `assess-github-repo-security`
+- **Optional**: exact CI check `context` name(s) to require (must run on `push`)
+- **Optional**: GitHub App id + private key if going to required checks/PR
+
+## Procedure
+
+### Step 1: Assess First and Confirm Scope
+
+Never mutate blind. Run the read-only assessment and confirm the plan with the user.
+
+```bash
+# 1. Run the companion read-only skill first (or its core probes):
+gh api /repos/$R --jq '{visibility,default_branch,is_org:.organization!=null}'
+gh api /repos/$R/rulesets --jq '.[] | {id,name,enforcement}'
+gh api /repos/$R/actions/permissions/workflow
+
+# 2. Confirm the two decisive facts before any write:
+#    - Is the repo PUBLIC and USER-OWNED?  (rulesets are free here)
+#    - Does a bot push to the default branch?  (gates Step 3 entirely)
+```
+
+Confirm with the user: baseline (Step 2) is always safe; Step 3 (required
+checks / PR) is a separate opt-in that **will** block a default-branch bot
+unless a bypass is provisioned first.
+
+**Expected:** You know visibility, owner type, current rulesets, current token
+default, and whether a bot pushes to the default branch. The user has approved
+applying at least the baseline.
+
+**On failure:** If the repo is **private and user-owned**, rulesets need GitHub
+Pro — stop and surface that. If not admin, stop (writes will 403). If a bot
+pushes to the default branch, flag that Step 3 is blocked until Step 3a runs.
+
+### Step 2: Apply the Zero-Downside Baseline (never breaks a CI auto-commit)
+
+This tier hardens the repo without breaking a direct-push bot. Apply after
+confirmation. Force-push/deletion protection, a read-only token default, the
+free security features, and policy files.
+
+```bash
+# 2a. Default-branch ruleset: force-push + deletion protection ONLY.
+#     These do NOT block the bot's direct push.
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ]
+}
+JSON
+
+# 2b. Actions token: read-only default + no token PR approval.
+#     A DEFAULT (not a cap) for same-repo push events, so the bot still works
+#     once its job declares contents: write.
+gh api --method PUT /repos/$R/actions/permissions/workflow \
+  -f default_workflow_permissions=read \
+  -F can_approve_pull_request_reviews=false
+
+# 2c. Free security features (all free on public repos):
+gh api -X PUT repos/$R/vulnerability-alerts          # alerts + dependency graph
+gh api -X PUT repos/$R/automated-security-fixes      # Dependabot fix PRs (separate toggle!)
+gh api -X PATCH repos/$R --input - <<'JSON'
+{"security_and_analysis":{"secret_scanning":{"status":"enabled"},"secret_scanning_push_protection":{"status":"enabled"}}}
+JSON
+gh api -X PUT repos/$R/private-vulnerability-reporting
+```
+
+Leave **Settings > Actions > General** fork-PR approval at the public-repo
+default ("Require approval for first-time contributors"). Fork `pull_request`
+runs already receive a read-only `GITHUB_TOKEN` with no access to secrets, so a
+fork cannot auto-commit to the default branch (no REST toggle — this is a UI
+setting; tighten to "all external contributors" only if the repo has secrets or
+self-hosted runners).
+
+Then add two tracked files (commit them):
+
+`.github/dependabot.yml` — include a `github-actions` block so action SHAs stay fresh:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+`.github/SECURITY.md` — a short disclosure policy pointing reporters at the
+"Report a vulnerability" button (private vulnerability reporting, enabled above).
+
+Flipping the token default to `read` silently strips write from **every**
+workflow that assumed a write default, not just the auto-commit job. Audit
+**all** files in `.github/workflows/` and declare the minimal `permissions:` each
+job actually needs — common scopes are `contents`, `packages`, `pull-requests`,
+`pages`, and `id-token`. For the running example: top-level `permissions: {}`,
+`contents: write` only on the auto-commit job, and every `uses:` pinned to a
+full 40-char commit SHA with the version in a trailing comment.
+
+**Expected:** `gh api /repos/$R/rulesets` shows `protect-default` active;
+`.../actions/permissions/workflow` shows `default_workflow_permissions: read`
+and `can_approve_pull_request_reviews: false`; secret scanning + push protection
++ Dependabot + private reporting are on; `.github/dependabot.yml` and
+`.github/SECURITY.md` are committed. The bot's next run still pushes.
+
+**On failure:** If 2b makes an existing bot push 403 — or any other workflow
+fails after losing a write scope it silently relied on — the job is missing the
+explicit `permissions:` it needs (e.g. `contents: write`, `packages: write`,
+`pull-requests: write`); add the minimal scope back (the read-only default is not
+a hard cap for same-repo pushes). If `automated-security-fixes` seems to do nothing, verify
+`vulnerability-alerts` (2c line 1) ran first — alerts are a separate prerequisite
+toggle from fixes. If push protection later fails a bot run, treat the flagged
+secret as a **real finding** — the bot cannot click the interactive web bypass.
+
+### Step 3: Decision Gate — Required Status Checks / Required PR
+
+STOP. Required checks and required PR **block direct pushes to the ref**, not
+just PR merges. If a bot pushes to the default branch, turning either on **will
+break it** unless you first provision a bypass. The default `GITHUB_TOKEN` /
+`github-actions[bot]` **cannot** be a bypass actor (GitHub design). Do not enable
+this tier on a bot-pushing branch without a bypass in place.
+
+Also, on a **solo** repo, `required_approving_review_count >= 1` is a self-lockout
+(you cannot approve your own PR) — keep it `0`. And a required check that only
+runs on `pull_request` never reports on a direct push, so it **permanently**
+blocks the bot. Ensure the check runs on `push`.
+
+**Step 3a — provision the bot bypass FIRST (if a bot pushes to this branch).**
+Recommended: a GitHub App installation token. (Deploy key is a narrower
+single-repo alternative: add an SSH deploy key with write access and use
+`actor_type: DeployKey` in 3b.)
+
+```bash
+# Create a GitHub App (personal account, Settings > Developer settings >
+# GitHub Apps), permission Repository > Contents: Read and write; install it
+# on THIS repo. Store the App id as a repo variable and the private key as an
+# Actions secret. In the workflow, mint a token and pass it to checkout + the
+# commit action:
+#   - uses: actions/create-github-app-token@<sha>   # v2
+#     id: app-token
+#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+#   - uses: actions/checkout@<sha>
+#     with: { token: ${{ steps.app-token.outputs.token }} }
+#   - uses: stefanzweifel/git-auto-commit-action@<sha>
+#     with: { ... }   # inherits the app token via the checkout credentials
+#
+# The numeric App id used in Step 3b is shown on the App's own page:
+# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+# It is unrelated to the repository id and cannot be derived from /repos/$R.
+```
+
+**Higher-assurance alternative (no standing bypass actor).** If a manual merge
+click is acceptable, convert the job to open a PR with the App token (e.g.
+`peter-evans/create-pull-request`) and let a human merge. No bypass actor is
+needed and every rule stays enforced even against the automation's identity. The
+App token is still required: a PR opened with the plain `GITHUB_TOKEN` does not
+trigger `pull_request`/`push` workflows, so required checks never run and it sits
+`expected` forever (see Common Pitfalls).
+
+**Step 3b — apply the hardened ruleset with the App as an `Integration` bypass
+actor.** Replace `RULESET_ID` with the id from Step 2a, `<APP_ID>` with your App
+id, and `build` with your real check context. `bypass_mode: always` because the
+action pushes directly (use `pull_request` only if the bot opens PRs).
+
+```bash
+gh api --method PUT /repos/$R/rulesets/RULESET_ID --input - <<'JSON'
+{
+  "name": "protect-default",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "bypass_actors": [ { "actor_id": <APP_ID>, "actor_type": "Integration", "bypass_mode": "always" } ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "pull_request", "parameters": { "required_approving_review_count": 0, "dismiss_stale_reviews_on_push": true, "require_code_owner_review": false, "require_last_push_approval": false, "required_review_thread_resolution": false, "allowed_merge_methods": ["merge"] } },
+    { "type": "required_status_checks", "parameters": { "strict_required_status_checks_policy": true, "do_not_enforce_on_create": true, "required_status_checks": [ { "context": "build" } ] } }
+  ]
+}
+JSON
+
+# Verify the bypass actor is present:
+gh api /repos/$R/rulesets/RULESET_ID --jq '.bypass_actors'
+```
+
+`do_not_enforce_on_create: true` avoids the new-branch catch-22 (CI can't have
+run on a branch that does not exist yet). If there is **no** bot on this branch,
+you may skip 3a and omit `bypass_actors`.
+
+Trade-off: `strict_required_status_checks_policy: true` ("branch must be
+up to date") forces every open human PR to be re-updated each time the bot
+auto-commits to the default branch, and `dismiss_stale_reviews_on_push: true`
+compounds the churn — a chatty bot can make PRs perpetually unmergeable. On a
+frequently-auto-committed branch prefer `strict_required_status_checks_policy:
+false` (loose) unless up-to-date-before-merge is genuinely required.
+
+**Expected:** The ruleset now enforces the required check and required-PR rule
+for humans and forks, `.bypass_actors` lists the App (`Integration`), and the
+bot's next run still lands on the default branch (via the App token). Humans
+must open a PR; the check must be green.
+
+**On failure:** If the bot 403s after 3b, the App identity is not actually the
+bypass actor — confirm the workflow passes the App token to **checkout** (not
+just to the commit action) and that `<APP_ID>` in `bypass_actors` matches. If
+the bot's push sits `expected`/`pending` forever, the required check does not run
+on `push` — make it trigger on `push` or drop it from the required list. If the
+bypass-actor picker does not appear on your personal repo, the required-PR +
+auto-commit combination is unsatisfiable here; GitHub's workaround is a free org.
+If merges are blocked on a solo repo, `required_approving_review_count` is `>= 1`
+— set it to `0`.
+
+### Step 4: Optional Advanced Hardening
+
+Apply individually, each still confirmation-gated. None of these are needed for
+the baseline; several have sharp edges.
+
+```bash
+# 4a. Tag ruleset — protect release tags (classic tag protection is deprecated):
+gh api --method POST /repos/$R/rulesets --input - <<'JSON'
+{ "name": "protect-tags", "target": "tag", "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["refs/tags/v*"], "exclude": [] } },
+  "rules": [ { "type": "deletion" }, { "type": "non_fast_forward" } ] }
+JSON
+
+# 4b. Merge-method toggles (e.g. merge-commits-only to preserve per-commit history):
+gh api -X PATCH repos/$R -F allow_merge_commit=true -F allow_squash_merge=false \
+  -F allow_rebase_merge=false -F delete_branch_on_merge=true
+
+# 4c. CodeQL "default setup" (server-managed — commits NO workflow YAML):
+gh api -X PATCH repos/$R/code-scanning/default-setup -f state=configured -f query_suite=default
+
+# 4d. sha_pinning_required — ONLY after every `uses:` is a full 40-char SHA,
+#     or every workflow run fails (including actions/checkout):
+gh api --method PUT /repos/$R/actions/permissions -F enabled=true \
+  -f allowed_actions=selected -F sha_pinning_required=true
+# selected mode also gates WHICH actions may run: github_owned covers actions/*,
+# but git-auto-commit-action is NOT GitHub-owned — allow-list it in the SAME
+# step or the bot fails with "actions are not allowed":
+gh api --method PUT /repos/$R/actions/permissions/selected-actions \
+  -F github_owned_allowed=true -F verified_allowed=false \
+  -f 'patterns_allowed[]=stefanzweifel/git-auto-commit-action@*'
+gh api /repos/$R/actions/permissions --jq '.sha_pinning_required'   # verify
+```
+
+Note: `allowed_actions=selected` with `github_owned_allowed=true` still blocks
+`stefanzweifel/git-auto-commit-action` until it is in `patterns_allowed` (the 4d
+allow-list command handles this). Require-signed-commits and require-linear-history
+are intentionally omitted here:
+signing blocks the unsigned git-CLI bot push, and linear history is mutually
+exclusive with a merge-commits-only policy.
+
+**Expected:** Each selected advanced control is applied and verified without
+breaking the bot: tag ruleset lists on `.../rulesets`, merge toggles reflect on
+the repo object, CodeQL default setup shows `state: configured`,
+`sha_pinning_required` reads `true` only after all actions are SHA-pinned, and
+`git-auto-commit-action` is in `patterns_allowed` so the bot still runs.
+
+**On failure:** If every workflow fails right after 4d, an action is still
+tag-pinned — convert all `uses:` to SHAs or revert `sha_pinning_required` to
+`false`. If the bot fails with "actions are not allowed" after restricting
+allowed actions, add `git-auto-commit-action` to `patterns_allowed`. If 4c
+errors, the repo may have no CodeQL-supported language — skip it.
+
+## Validation
+
+- [ ] Assessment ran and scope (public/user-owned, bot-on-default-branch) confirmed before any write
+- [ ] `protect-default` ruleset active with `deletion` + `non_fast_forward`
+- [ ] `default_workflow_permissions=read` and `can_approve_pull_request_reviews=false`
+- [ ] Secret scanning + push protection + Dependabot alerts + fixes + private reporting enabled
+- [ ] `.github/dependabot.yml` (github-actions ecosystem) and `.github/SECURITY.md` committed
+- [ ] Auto-commit bot's next run still pushes successfully (baseline did not break it)
+- [ ] Required checks/PR enabled ONLY with a GitHub App (or deploy key) bypass in place first
+- [ ] Solo repo keeps `required_approving_review_count: 0`; required checks run on `push`
+- [ ] Loop guard added if a bot now pushes with an App token or PAT
+
+## Common Pitfalls
+
+- **GITHUB_TOKEN is not a bypass actor**: `github-actions[bot]` / the default
+  token cannot be added to any ruleset bypass list and cannot push to a
+  protected branch, by design. "Just add the Actions bot to the bypass list"
+  has no such option — the push 403s. Use a GitHub App or deploy key.
+- **PAT bypass is an anti-pattern**: an admin/personal PAT in the bypass list
+  (or classic BP with `enforce_admins=false`) exempts ALL admin actions
+  including your own interactive pushes — role-wide, not automation-scoped, and
+  long-lived. Prefer an App (`Integration`) or deploy key (`DeployKey`).
+- **Required checks only on `pull_request`**: a check that never runs on `push`
+  never reports on the bot's direct push, so it **permanently** blocks the bot
+  and new-branch creation. Make the check run on `push` and set
+  `do_not_enforce_on_create: true`.
+- **Loop guard once an App token replaces GITHUB_TOKEN**: the default token
+  suppresses downstream `push`/`pull_request` triggers; an App token or PAT does
+  not, so the auto-commit workflow can re-trigger itself indefinitely. Guard with
+  `if: github.actor != '<app>[bot]'`, `paths-ignore`, or `[skip ci]`.
+- **PR via the default GITHUB_TOKEN is a false fix**: a PR opened by
+  `GITHUB_TOKEN` does not trigger `pull_request`/`push` workflows, so required
+  checks never run and it sits `expected` forever. Create the PR with the App token.
+- **Alerts != fixes**: `vulnerability-alerts` and `automated-security-fixes` are
+  separate toggles; enabling alerts opens no PRs. Enable both.
+- **Don't buy GHAS on a public repo**: secret scanning, push protection, CodeQL,
+  and dependency review are already free on public repos; the paid Secret
+  Protection / Code Security products target private/org repos.
+
+## Related Skills
+
+- `assess-github-repo-security` - the read-only companion; always run this first
+- `configure-git-repository` - baseline .gitignore, branches, remotes, hooks
+- `setup-github-actions-ci` - the CI workflow whose token/permissions this hardens

--- a/viz/README.md
+++ b/viz/README.md
@@ -1,6 +1,6 @@
 # Interactive Skills Visualization
 
-Force-graph explorer for the 366-skill, 73-agent, 18-team agent-almanac platform. Nodes are skills, agents, and teams; edges express domain membership and cross-references. Each node renders a domain-colored WebP pictogram produced by an R/ggplot2 icon pipeline. Built with [force-graph](https://github.com/vasturiano/force-graph), 9 color themes, and 5 locales.
+Force-graph explorer for the 368-skill, 73-agent, 18-team agent-almanac platform. Nodes are skills, agents, and teams; edges express domain membership and cross-references. Each node renders a domain-colored WebP pictogram produced by an R/ggplot2 icon pipeline. Built with [force-graph](https://github.com/vasturiano/force-graph), 9 color themes, and 5 locales.
 
 ## Quick Start
 


### PR DESCRIPTION
## What

A best-practices **guide** plus a repeatable **assess → harden skill pair** for securing a GitHub repository — so this can be applied to other repos, not just `agent-almanac`.

- **`guides/protecting-github-repositories.md`** (infrastructure) — honest threat model (what ref protection does *not* stop), tiered checklist (essential/recommended/advanced), rulesets vs classic branch protection, the automation-through-protection bypass matrix, a false-security-traps section, and a troubleshooting table.
- **`skills/assess-github-repo-security`** (git domain, read-only) — audits posture via `gh api` (rulesets + classic protection, Actions token perms, secret scanning, Dependabot, CodeQL) into a tiered PASS/GAP report; keeps the report private while gaps are open.
- **`skills/harden-github-repo-security`** (git domain, mutating, confirmation-gated) — applies protections tier by tier, assess-first, with the bot-bypass decision gated behind an explicit warning.

## How it was authored

1. **Research** — a 6-agent workflow web-verified current (2026) GitHub mechanics against `docs.github.com` (rulesets, required-check push behavior, bypass actors, secret scanning), producing a cited, tiered spec.
2. **Draft → adversarial refine** — a second workflow drafted all three files, then ran **advocatus-diaboli + security-analyst** passes on each, and revised. 12 agents, 0 errors.
3. **Human review** — I read all three files end-to-end and fixed conventions.

## Correctness points the content nails

- Prefer **rulesets** over classic branch protection; rulesets are **free on public user-owned repos**.
- **Required status checks block direct pushes**, not only PR merges — the #1 footgun for a CI auto-commit workflow.
- The **default `GITHUB_TOKEN` cannot be a ruleset bypass actor** (GitHub design). To let trusted automation write to a protected default branch: a **GitHub App token** (recommended) or **deploy key** — a user/admin **PAT bypass is an anti-pattern**.
- A **zero-downside baseline** (force-push + deletion ruleset, read-only token default, secret scanning + push protection, Dependabot) hardens a repo **without breaking the bot**.
- Solo-repo self-lockout (`required_approving_review_count >= 1`), the new-branch catch-22, and the loop-guard-after-App-token are all documented.

## Plumbing

- Registered both skills (git domain, `total_skills` 366 → 368) + the guide (`total_guides` 33 → 34); symlinked skills into `.claude/skills`; READMEs regenerated.
- Scaffolded translations (de/zh-CN/ja/es × 3) and refreshed `translation_status.yml` for **all 10 locales** (the 6 caveman/wenyan proactively, since the CI auto-commit only covers the 4 primary — avoids post-merge drift).

## Verification

`validate:integrity` **PASSED** (no orphans) · `check-readmes` clean · `content-style --added` 0 blocking · `validate:line-endings` LF · skill line counts 380/353 (< 500).

## Note

This supersedes the earlier "keep-bot-via-PAT" plan for `agent-almanac`'s own `line-endings` enforcement — the bypass matrix here shows a **GitHub App** (or deploy key) is the correct route, and the safe baseline can be applied without touching the auto-commit bot. Repo enforcement stays parked on that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
