### PR TITLE
fix: quick-reference teams roster (registry-derived) + team-skill allowed-tools (#353, #354)

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -42,4 +42,4 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d
         with:
           commit_message: "docs: auto-update README statistics and translation status"
-          file_pattern: "README.md skills/README.md agents/README.md teams/README.md CLAUDE.md guides/README.md viz/README.md tests/README.md i18n/de/translation_status.yml i18n/zh-CN/translation_status.yml i18n/ja/translation_status.yml i18n/es/translation_status.yml"
+          file_pattern: "README.md skills/README.md agents/README.md teams/README.md CLAUDE.md guides/README.md guides/quick-reference.md viz/README.md tests/README.md i18n/de/translation_status.yml i18n/zh-CN/translation_status.yml i18n/ja/translation_status.yml i18n/es/translation_status.yml"

--- a/guides/quick-reference.md
+++ b/guides/quick-reference.md
@@ -56,7 +56,9 @@ Teams are activated by asking Claude Code to use them. Claude reads the team def
 
 Note: Teams are **not** auto-discovered from `.claude/teams/` like agents and skills. Team definitions are blueprints that Claude reads directly from `teams/` when asked.
 
-Available teams: r-package-review, gxp-compliance-validation, fullstack-web-dev, ml-data-science-review, devops-platform-engineering, tending, dyad, scrum-team, opaque-team, agentskills-alignment, entomology, analytical-chemistry, physical-computing, translation-campaign, synoptic-mind.
+<!-- AUTO:START:quickref-teams -->
+Available teams: r-package-review, gxp-compliance-validation, fullstack-web-dev, ml-data-science-review, devops-platform-engineering, tending, dyad, scrum-team, opaque-team, agentskills-alignment, entomology, analytical-chemistry, gpu-acceleration, physical-computing, translation-campaign, synoptic-mind, caveman-spellbook, visual-pr-review.
+<!-- AUTO:END:quickref-teams -->
 
 ### Registry Lookups
 

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -264,6 +264,12 @@ function generateOverview() {
 The guides serve as the human entry point to the agentic system: practical walkthroughs explaining when, why, and how to interact with agents, teams, skills, and workflows through Claude Code.`;
 }
 
+// Quick-reference "Available teams:" roster (guides/quick-reference.md) —
+// derived from teams/_registry.yml so it can never drift out of sync.
+function generateQuickRefTeams() {
+  return `Available teams: ${teams.map((t) => t.id).join(', ')}.`;
+}
+
 function generateRegistries() {
   const domainList = Object.entries(domains)
     .map(([id, obj]) => `${id} (${obj.skills.length})`)
@@ -638,6 +644,14 @@ run(
   processFile(resolve(ROOT, 'CLAUDE.md'), {
     overview: generateOverview,
     registries: generateRegistries,
+  })
+);
+
+// guides/quick-reference.md (AUTO section: teams roster)
+run(
+  'guides/quick-reference.md',
+  processFile(resolve(ROOT, 'guides/quick-reference.md'), {
+    'quickref-teams': generateQuickRefTeams,
   })
 );
 

--- a/skills/create-team/SKILL.md
+++ b/skills/create-team/SKILL.md
@@ -9,7 +9,7 @@ description: >
   composing agents for a complex review process, or creating a
   coordinated group for recurring collaborative tasks.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/skills/test-team-coordination/SKILL.md
+++ b/skills/test-team-coordination/SKILL.md
@@ -8,7 +8,7 @@ description: >
   patterns on equivalent workloads, or establishing baseline performance
   for a team composition.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"


### PR DESCRIPTION
Closes #353. Closes #354. Two self-contained backlog quick-wins from the verified triage, both surfaced by the #352 adversarial review.

## #354 — team skills' `allowed-tools` omit orchestration tools they invoke

`create-team` and `test-team-coordination` procedures spawn members via the **Agent tool** (`subagent_type`), coordinate with **SendMessage**, and create tasks via **TaskCreate**, but both declared only `Read Write Edit Bash Grep Glob`. Appended `Agent SendMessage TaskCreate` to each (`unleash-the-agents` is the existing counter-example done right).

**Full sweep of all 368 skills** (distinctive-token grep + broader spawn/dispatch/delegate phrasings), blind-reverified by an adversarial agent: **these two are the only genuine cases.** Confirmed false positives, left unchanged:

| Skill | Matched token | Why it's not drift |
|---|---|---|
| `audit-discovery-symlinks` | `TeamCreate` | prose about `~/.claude/teams/` runtime-state / symlink collision |
| `evolve-team` | `subagent_type` | a field in the CONFIG YAML **schema template**, not a spawn |
| `implement-a2a-server` | `TaskGet` | the A2A `tasks/get` JSON-RPC method / `handleTaskGet` fn |
| `create-workflow` | `agent(` | the Workflow **in-script `agent()` primitive** (JS), not the Agent tool |

AC bullet 3 (a `validate-integrity` check) was **deliberately not added**: a naive token check false-positives at ~67% (the 4 rows above) and even the fixed skills legitimately keep `TeamCreate`/`ToolSearch` deprecation prose a token check would wrongly demand. Parked as #356 (narrower phrase-based heuristic, unproven).

## #353 — quick-reference teams roster stale (15/18) + made drift-proof

The hand-maintained `Available teams:` line in `guides/quick-reference.md` had drifted to 15 of 18 (missing `gpu-acceleration`, `caveman-spellbook`, `visual-pr-review`). Wrapped it in an `AUTO:START/END:quickref-teams` block generated by `scripts/generate-readmes.js` from `teams/_registry.yml`, so `npm run update-readmes` (already step 6 of "Adding a New Team") keeps it in sync — the durable fix over a checklist note.

**Adversarial review caught a blocking gap in the first cut** (now fixed): the durable guarantee needed `guides/quick-reference.md` added to the `git-auto-commit` `file_pattern` in `update-readmes.yml`. Without it the post-merge auto-commit would regenerate the roster in the runner but never stage the file, re-drifting on every registry push. Now at parity with the other 8 generated files. (The general risk that `file_pattern` can drift from the generator's output set is parked as #357.)

## Verification

- `npm run check-readmes` → **All files up to date** (generator output byte-exact; `--check` confirmed to flag a dropped team with exit 1).
- `bash scripts/validate-integrity.sh` → **PASSED** (A1–A7, B1–B12).
- `npm run validate:line-endings` → no CRLF. `check-content-style.js --added origin/main` → 0 blocking. Edited skills unchanged length, < 500 lines.
- Three-lens adversarial workflow: completeness (0 missed skills, high confidence), false-positive refutation (all 4 upheld), durable-fix critique (1 blocking → fixed, 2 deferrals judged defensible).

## Notes / follow-ups filed

- **i18n**: the 20 snapshot copies (10 locales × 2 skills) still carry the old `allowed-tools`. Left to the #278 wholesale re-scaffold (translations are `source_commit` snapshots; partial field-patching muddies freshness). Dependency flagged on #278.
- Filed **#356** (narrow tool-in-`allowed-tools` heuristic) and **#357** (`file_pattern` allowlist drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
