### PR TITLE
ci: fix trigger/coverage drift across four workflows + A8 hardening (#362)

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -10,6 +10,26 @@ on:
       - 'tests/_registry.yml'
       - 'i18n/_config.yml'
       - 'i18n/**/*.md'
+      # Staleness inputs: per-locale stale counts in translation_status.yml
+      # derive from git history of the English trees (git-freshness.js
+      # pathspecs) — a body-only English edit changes staleness but used to
+      # never trigger regeneration (#362). The negations exclude this job's
+      # own auto-committed outputs so the deploy-key push (which, unlike
+      # GITHUB_TOKEN, does re-trigger workflows) cannot re-trigger it.
+      - 'skills/**'
+      - 'agents/**'
+      - 'teams/**'
+      - 'guides/**'
+      - '!skills/README.md'
+      - '!agents/README.md'
+      - '!teams/README.md'
+      - '!guides/README.md'
+      - '!guides/quick-reference.md'
+      # Generator changes must regenerate committed output at the causing
+      # commit, not fail check-readmes at the next release (#362).
+      - 'scripts/generate-readmes.js'
+      - 'scripts/generate-translation-status.js'
+      - 'scripts/lib/git-freshness.js'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/validate-integrity.yml
+++ b/.github/workflows/validate-integrity.yml
@@ -11,6 +11,9 @@ on:
       - 'scripts/**'
       - '.claude/**'
       - '.github/workflows/update-readmes.yml'
+      # A8 derives its expected translation_status set from i18n/_config.yml and
+      # B6 reads i18n/*/ — without this, a new-locale PR bypasses both (#362).
+      - 'i18n/**'
       - 'viz/R/glyphs.R'
       - 'viz/R/agent_glyphs.R'
       - 'viz/R/palettes.R'
@@ -28,6 +31,7 @@ on:
       - 'scripts/**'
       - '.claude/**'
       - '.github/workflows/update-readmes.yml'
+      - 'i18n/**'
       - 'viz/R/glyphs.R'
       - 'viz/R/agent_glyphs.R'
       - 'viz/R/palettes.R'

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -15,6 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Full history: check-translation-freshness.js derives staleness from
+          # `git log <source_commit>..HEAD`; in a shallow clone every
+          # source_commit is unresolvable so every translation reads as fresh
+          # (stale: 0) and the warn step below is vacuously green — see #279/#362.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/validate-tests.yml
+++ b/.github/workflows/validate-tests.yml
@@ -2,9 +2,12 @@ name: Validate Tests
 on:
   push:
     branches: [main]
-    paths: ['tests/**']
+    # agents/teams/skills are included because the target-existence step below
+    # validates tests/scenarios targets against those trees — a PR deleting or
+    # renaming a target must re-run this check (#362).
+    paths: ['tests/**', 'agents/**', 'teams/**', 'skills/**']
   pull_request:
-    paths: ['tests/**']
+    paths: ['tests/**', 'agents/**', 'teams/**', 'skills/**']
   workflow_dispatch:
 
 permissions:
@@ -18,6 +21,10 @@ jobs:
 
       - name: Validate test scenario frontmatter
         run: |
+          # globstar: without it, ** degrades to one directory level while the
+          # registry-count step uses `find` (all depths) — a nested scenario
+          # would be counted but skip validation (#362).
+          shopt -s globstar nullglob
           failed=0
           required_fields="name test-level target"
           for f in tests/scenarios/**/*.md; do
@@ -33,6 +40,7 @@ jobs:
 
       - name: Validate required sections
         run: |
+          shopt -s globstar nullglob
           failed=0
           required_sections="Objective Pre-conditions Task Expected.Behaviors Acceptance.Criteria Observation.Protocol"
           for f in tests/scenarios/**/*.md; do

--- a/scripts/check-translation-freshness.js
+++ b/scripts/check-translation-freshness.js
@@ -14,7 +14,7 @@
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { resolve, dirname, basename, join } from 'path';
 import { fileURLToPath } from 'url';
-import { createFreshnessChecker, buildLatestCommitMap } from './lib/git-freshness.js';
+import { assertNotShallow, createFreshnessChecker, buildLatestCommitMap } from './lib/git-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -39,6 +39,9 @@ function extractLocale(filePath) {
     || content.match(/^locale:\s*["']?([a-zA-Z-]+)["']?/m);
   return match ? match[1] : null;
 }
+
+// A shallow clone would make every translation read as fresh (#279/#362).
+assertNotShallow(ROOT);
 
 // Batched staleness (#305): one `git log <source_commit>..HEAD` per DISTINCT
 // source_commit, plus one streaming pass for the path -> latest-hash map used

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -596,6 +596,53 @@ function generateTranslationsSection() {
 
 // ── Main ─────────────────────────────────────────────────────────
 
+// Single source of truth for every file this script manages. Each entry's
+// `path` is the repo-relative output path (single-quoted literal — integrity
+// check A8 static-parses this array, and `--list-outputs` prints it) and
+// `make` is a thunk that regenerates the file when invoked with the absolute
+// path. Keeping path and generator in one entry removes the label-vs-path
+// divergence class (#362).
+const MANAGED = [
+  // README.md (abbreviated — full tables live in sub-READMEs)
+  { path: 'README.md', make: (p) => processFile(p, {
+    stats: generateStats,
+    'plugin-discovery': generatePluginDiscovery,
+    dirmap: generateDirMap,
+    'plugin-table': generatePluginTable,
+    guides: generateGuidesSection,
+    translations: generateTranslationsSection,
+  }) },
+  { path: 'skills/README.md', make: (p) => processFile(p, {
+    'skills-intro': generateSkillsIntroStandalone,
+    'skills-table': () => generateSkillsTable(''),
+  }) },
+  { path: 'agents/README.md', make: (p) => processFile(p, {
+    'agents-intro': generateAgentsIntroStandalone,
+    'agents-table': () => generateAgentsTable(''),
+  }) },
+  { path: 'CLAUDE.md', make: (p) => processFile(p, {
+    overview: generateOverview,
+    registries: generateRegistries,
+  }) },
+  // AUTO section: teams roster
+  { path: 'guides/quick-reference.md', make: (p) => processFile(p, {
+    'quickref-teams': generateQuickRefTeams,
+  }) },
+  // Fully generated files
+  { path: 'guides/README.md', make: (p) => writeGeneratedFile(p, generateGuidesReadme()) },
+  { path: 'viz/README.md', make: (p) => writeGeneratedFile(p, generateVizReadme()) },
+  { path: 'teams/README.md', make: (p) => writeGeneratedFile(p, generateTeamsReadme()) },
+  { path: 'tests/README.md', make: (p) => writeGeneratedFile(p, generateTestsReadme()) },
+];
+
+// --list-outputs: print managed output paths (one per line) and exit without
+// generating anything. Consumed by tooling that needs the authoritative list
+// (e.g. auto-commit file_pattern maintenance).
+if (process.argv.includes('--list-outputs')) {
+  for (const entry of MANAGED) console.log(entry.path);
+  process.exit(0);
+}
+
 let staleCount = 0;
 
 function run(label, changed) {
@@ -607,77 +654,9 @@ function run(label, changed) {
   }
 }
 
-// README.md (abbreviated — full tables live in sub-READMEs)
-run(
-  'README.md',
-  processFile(resolve(ROOT, 'README.md'), {
-    stats: generateStats,
-    'plugin-discovery': generatePluginDiscovery,
-    dirmap: generateDirMap,
-    'plugin-table': generatePluginTable,
-    guides: generateGuidesSection,
-    translations: generateTranslationsSection,
-  })
-);
-
-// skills/README.md
-run(
-  'skills/README.md',
-  processFile(resolve(ROOT, 'skills/README.md'), {
-    'skills-intro': generateSkillsIntroStandalone,
-    'skills-table': () => generateSkillsTable(''),
-  })
-);
-
-// agents/README.md
-run(
-  'agents/README.md',
-  processFile(resolve(ROOT, 'agents/README.md'), {
-    'agents-intro': generateAgentsIntroStandalone,
-    'agents-table': () => generateAgentsTable(''),
-  })
-);
-
-// CLAUDE.md
-run(
-  'CLAUDE.md',
-  processFile(resolve(ROOT, 'CLAUDE.md'), {
-    overview: generateOverview,
-    registries: generateRegistries,
-  })
-);
-
-// guides/quick-reference.md (AUTO section: teams roster)
-run(
-  'guides/quick-reference.md',
-  processFile(resolve(ROOT, 'guides/quick-reference.md'), {
-    'quickref-teams': generateQuickRefTeams,
-  })
-);
-
-// guides/README.md (fully generated)
-run(
-  'guides/README.md',
-  writeGeneratedFile(resolve(ROOT, 'guides/README.md'), generateGuidesReadme())
-);
-
-// viz/README.md (fully generated)
-run(
-  'viz/README.md',
-  writeGeneratedFile(resolve(ROOT, 'viz/README.md'), generateVizReadme())
-);
-
-// teams/README.md (fully generated)
-run(
-  'teams/README.md',
-  writeGeneratedFile(resolve(ROOT, 'teams/README.md'), generateTeamsReadme())
-);
-
-// tests/README.md (fully generated)
-run(
-  'tests/README.md',
-  writeGeneratedFile(resolve(ROOT, 'tests/README.md'), generateTestsReadme())
-);
+for (const entry of MANAGED) {
+  run(entry.path, entry.make(resolve(ROOT, entry.path)));
+}
 
 // Summary
 console.log(

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -12,9 +12,8 @@
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { resolve, dirname, join, basename } from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
 import * as yaml from 'js-yaml';
-import { createFreshnessChecker } from './lib/git-freshness.js';
+import { assertNotShallow, createFreshnessChecker } from './lib/git-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -28,17 +27,8 @@ if (!existsSync(configPath)) {
 }
 const config = yaml.load(readFileSync(configPath, 'utf8'));
 
-// Staleness needs full history: per-file `git log` and `merge-base
-// --is-ancestor` both misreport in a shallow clone, so every translation
-// would read as fresh (stale: 0) — see #279.
-const isShallow = execSync('git rev-parse --is-shallow-repository', {
-  cwd: ROOT, encoding: 'utf8'
-}).trim();
-if (isShallow === 'true') {
-  console.error('ERROR: shallow clone detected — staleness would be silently wrong.');
-  console.error('Fetch full history first (actions/checkout fetch-depth: 0, or git fetch --unshallow).');
-  process.exit(1);
-}
+// Staleness needs full history — see the shared guard for rationale (#279).
+assertNotShallow(ROOT);
 
 // Derive source counts from registries (single source of truth)
 const skillsRegistry = yaml.load(readFileSync(resolve(ROOT, 'skills/_registry.yml'), 'utf8'));

--- a/scripts/lib/git-freshness.js
+++ b/scripts/lib/git-freshness.js
@@ -34,6 +34,8 @@ const GIT_BUFFER = 256 * 1024 * 1024;
  * `merge-base --is-ancestor` both misreport there, so every translation
  * would silently read as fresh (stale: 0) — see #279/#362. Call this before
  * any staleness use; it exits the process loudly instead of lying.
+ * Deliberately loud even for --warn callers: a "warn-only" run on a shallow
+ * clone would not warn less, it would lie — hard-exit is the honest mode.
  */
 export function assertNotShallow(root) {
   const isShallow = execFileSync('git', ['rev-parse', '--is-shallow-repository'], {

--- a/scripts/lib/git-freshness.js
+++ b/scripts/lib/git-freshness.js
@@ -30,6 +30,23 @@ import { execFileSync } from 'child_process';
 const GIT_BUFFER = 256 * 1024 * 1024;
 
 /**
+ * Refuse to compute staleness in a shallow clone. Per-file `git log` and
+ * `merge-base --is-ancestor` both misreport there, so every translation
+ * would silently read as fresh (stale: 0) — see #279/#362. Call this before
+ * any staleness use; it exits the process loudly instead of lying.
+ */
+export function assertNotShallow(root) {
+  const isShallow = execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
+    cwd: root, encoding: 'utf8'
+  }).trim();
+  if (isShallow === 'true') {
+    console.error('ERROR: shallow clone detected — staleness would be silently wrong.');
+    console.error('Fetch full history first (actions/checkout fetch-depth: 0, or git fetch --unshallow).');
+    process.exit(1);
+  }
+}
+
+/**
  * Create a staleness checker rooted at a git work tree.
  * `pathspecs` bounds every git walk to the content trees that matter.
  */

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -185,19 +185,24 @@ for f in workflows/*.mjs; do
 done
 [ "$a7_fail" -eq 0 ] && echo "OK: All $a7_count workflow(s) have a valid sidecar; filename == sidecar name == meta.name"
 
-# A8: Auto-commit file_pattern coverage (#357)
+# A8: Auto-commit file_pattern coverage (#357, hardened #362)
 # The git-auto-commit `file_pattern` in .github/workflows/update-readmes.yml is a
 # hand-maintained allowlist. Every file the push-to-main auto-commit regenerates must
 # be a token in it, or git-auto-commit-action regenerates the file in the runner but
 # never stages it -> silent re-drift. Two generators feed that job:
-#   1. generate-readmes.js -> the run() labels (static-parsed below; assumes each
-#      run()'s first arg is a single-quoted '<path>.md'/'.yml' on the run( line or the
-#      line beneath it -- keeps this check free of `npm ci` / js-yaml).
+#   1. generate-readmes.js -> the MANAGED array's `path:` literals (static-parsed
+#      below from the `const MANAGED = [` ... `];` block; the same literals drive
+#      the generator and `--list-outputs`, so path-vs-label divergence is
+#      impossible -- and the parse stays free of `npm ci` / js-yaml).
 #   2. generate-translation-status.js -> i18n/<code>/translation_status.yml for every
 #      `- code:` locale in i18n/_config.yml.
+# Both containment directions are checked: a generated file missing from
+# file_pattern (silent drop) and a file_pattern token no generator produces
+# (dead allowlist entry).
 echo "--- A8: Auto-commit file_pattern coverage ---"
 a8_fail=0
-a8_readmes=$(grep -A1 'run(' scripts/generate-readmes.js | grep -oE "'[^']+\.(md|yml)'" | tr -d "'" | sort -u || true)
+a8_readmes=$(sed -n '/^const MANAGED = \[/,/^\];/p' scripts/generate-readmes.js \
+  | grep -oE "path: ['\"][^'\"]+['\"]" | sed -E "s/^path: ['\"]//; s/['\"]\$//" | sort -u || true)
 a8_locales=$(grep -E '^[[:space:]]*-[[:space:]]*code:' i18n/_config.yml | sed -E 's/.*code:[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r' || true)
 a8_status=$(printf '%s\n' "$a8_locales" | sed -E '/^$/d; s#^#i18n/#; s#$#/translation_status.yml#' || true)
 a8_expected=$(printf '%s\n%s\n' "$a8_readmes" "$a8_status" | sed -E '/^$/d' | sort -u)
@@ -215,7 +220,15 @@ else
       *) echo "FAIL: generated file '$f' missing from update-readmes.yml file_pattern (auto-commit silently drops it -- #357)"; failed=1; a8_fail=1 ;;
     esac
   done <<< "$a8_expected"
-  [ "$a8_fail" -eq 0 ] && echo "OK: all $a8_count auto-generated files (readmes + per-locale translation_status) are in the auto-commit file_pattern"
+  # Reverse containment: flag dead file_pattern tokens no generator produces.
+  while IFS= read -r tok; do
+    [ -z "$tok" ] && continue
+    if ! printf '%s\n' "$a8_expected" | grep -Fxq "$tok"; then
+      echo "FAIL: file_pattern token '$tok' matches no generated file (dead allowlist entry -- remove it or fix the generator/A8 parse)"
+      failed=1; a8_fail=1
+    fi
+  done <<< "$(printf '%s' "$a8_fp" | tr ' ' '\n')"
+  [ "$a8_fail" -eq 0 ] && echo "OK: all $a8_count auto-generated files (readmes + per-locale translation_status) are in the auto-commit file_pattern, and no dead tokens"
 fi
 
 echo ""

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -198,7 +198,15 @@ done
 #      `- code:` locale in i18n/_config.yml.
 # Both containment directions are checked: a generated file missing from
 # file_pattern (silent drop) and a file_pattern token no generator produces
-# (dead allowlist entry).
+# (dead allowlist entry). file_pattern must remain LITERAL paths — the
+# containment checks compare exact tokens, so a glob there would FAIL both
+# directions even when semantically correct.
+# Also checked: anti-bounce negation sync. update-readmes.yml triggers on the
+# English content trees; its deploy-key auto-commit re-triggers workflows
+# (unlike GITHUB_TOKEN), so every MANAGED output under a triggering tree must
+# carry a matching `!`-negation in the paths list, or the auto-commit bounces
+# the workflow. Assumes the triggering trees are skills/ agents/ teams/
+# guides/ (matching the paths list in update-readmes.yml).
 echo "--- A8: Auto-commit file_pattern coverage ---"
 a8_fail=0
 a8_readmes=$(sed -n '/^const MANAGED = \[/,/^\];/p' scripts/generate-readmes.js \
@@ -228,7 +236,29 @@ else
       failed=1; a8_fail=1
     fi
   done <<< "$(printf '%s' "$a8_fp" | tr ' ' '\n')"
-  [ "$a8_fail" -eq 0 ] && echo "OK: all $a8_count auto-generated files (readmes + per-locale translation_status) are in the auto-commit file_pattern, and no dead tokens"
+  # Negation sync: every MANAGED output under a triggering content tree needs
+  # a `!`-negation in update-readmes.yml paths, or the auto-commit re-triggers
+  # the workflow (bounce).
+  a8_negations=$(grep -E "^[[:space:]]*-[[:space:]]*'\!" .github/workflows/update-readmes.yml | sed -E "s/^[[:space:]]*-[[:space:]]*'\!//; s/'[[:space:]]*$//" || true)
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    case "$f" in
+      skills/*|agents/*|teams/*|guides/*)
+        if ! printf '%s\n' "$a8_negations" | grep -Fxq "$f"; then
+          echo "FAIL: MANAGED output '$f' sits under a triggering content tree but has no '!$f' negation in update-readmes.yml paths (auto-commit would re-trigger the workflow)"
+          failed=1; a8_fail=1
+        fi ;;
+    esac
+  done <<< "$a8_readmes"
+  # Dead negations: a negation for a path no generator manages is stale.
+  while IFS= read -r n; do
+    [ -z "$n" ] && continue
+    if ! printf '%s\n' "$a8_readmes" | grep -Fxq "$n"; then
+      echo "FAIL: update-readmes.yml negation '!$n' matches no MANAGED output (stale negation -- remove it or fix the generator/A8 parse)"
+      failed=1; a8_fail=1
+    fi
+  done <<< "$a8_negations"
+  [ "$a8_fail" -eq 0 ] && echo "OK: all $a8_count auto-generated files (readmes + per-locale translation_status) are in the auto-commit file_pattern; no dead tokens; negations in sync"
 fi
 
 echo ""


### PR DESCRIPTION
Fixes 5 of the 6 findings in #362 (finding 6, A8 hardening, included; the deploy-pages mismatch is tracked separately in #363 pending a semantics decision).

## Changes

**`ci(#362)` — trigger/path-filter fixes (commit 1):**
- `validate-integrity.yml`: `i18n/**` added to push+PR paths. A8 derives its expected `translation_status.yml` set from `i18n/_config.yml` and B6 reads `i18n/*/` — a new-locale PR used to bypass both, reproducing the #357 failure mode post-merge (finding 1, HIGH).
- `validate-skills.yml`: `fetch-depth: 0`. The freshness warn step ran on a depth-1 clone where every `source_commit` is unresolvable → every translation reported fresh, always (finding 2).
- `update-readmes.yml`: English content trees (staleness inputs) + the three generator scripts added to `paths:`, with `!`-negations for the job's own auto-committed outputs — the deploy-key push re-triggers workflows (unlike GITHUB_TOKEN), so the negations prevent a re-trigger bounce (finding 3).
- `validate-tests.yml`: `agents/**`, `teams/**`, `skills/**` added so target deletion re-runs the target-existence check (finding 4); `shopt -s globstar nullglob` so the `**` loops match the `find`-based count depth (finding 5).

**`fix(#362)` — shallow guard (commit 2) + pure refactor (commit 3):**
- New `assertNotShallow()` in `scripts/lib/git-freshness.js`, wired into `check-translation-freshness.js` (previously unguarded — the #279 gotcha's second caller).
- `generate-translation-status.js` switched to the shared guard (pure refactor, no behavior change).

**`refactor(#362)` + `ci(#362)` — A8 hardening (commits 4–5):**
- `generate-readmes.js`: nine `run()` call sites collapsed into one `MANAGED` array carrying each repo-relative output path exactly once; adds `--list-outputs`. `--check` output verified byte-identical.
- A8 now parses the `MANAGED` `path:` literals (single or double quotes) instead of `run()` labels, and checks both containment directions — dead `file_pattern` tokens now FAIL.

## Verification

- `bash scripts/validate-integrity.sh` green (A8: 19 files, no dead tokens)
- A8 negative tests: dropped `README.md` token → FAIL (missing); injected `ghost.md` token → FAIL (dead entry); double-quoted MANAGED entry → still parsed
- `node scripts/generate-readmes.js --check` byte-identical before/after the MANAGED refactor; `--list-outputs` prints the 9 managed paths
- `node scripts/check-translation-freshness.js --warn` runs clean on a full clone (2,339 stale — consistent with #278 drift)
- `execSync` import removal verified unused

Closes #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
