### PR TITLE
docs: repair 15 broken Related Skills links + stale domain count (#364)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ The guides serve as the human entry point to the agentic system: practical walkt
 
 1. **Guides** (`guides/` directory): Human-readable documentation organized into five categories (workflow, infrastructure, reference, design, investigation). Each guide has YAML frontmatter (`title`, `description`, `category`, `agents`, `teams`, `skills`) and follows a standard template (`guides/_template.md`). Guides serve as the human entry point to the agentic system.
 
-2. **Skills** (`skills/` directory): Machine-consumable structured procedures that agentic systems execute. Each skill lives at `skills/<skill-name>/SKILL.md` with YAML frontmatter (`name`, `description`, `allowed-tools`, `metadata`) and standardized sections (When to Use, Inputs, Procedure, Validation, Common Pitfalls, Related Skills). Skills are organized into 65 logical domains via metadata tags, but the directory structure is flat.
+2. **Skills** (`skills/` directory): Machine-consumable structured procedures that agentic systems execute. Each skill lives at `skills/<skill-name>/SKILL.md` with YAML frontmatter (`name`, `description`, `allowed-tools`, `metadata`) and standardized sections (When to Use, Inputs, Procedure, Validation, Common Pitfalls, Related Skills). Skills are organized into logical domains via metadata tags (live count in the auto-generated registries section below), but the directory structure is flat.
 
 3. **Agents** (`agents/` directory): Persona definitions for Claude Code subagents. Each agent is a markdown file with YAML frontmatter (`name`, `description`, `tools`, `model`, `priority`) defining *who* handles a task. Agents span development, compliance, review, project management, DevOps, MLOps, workflow visualization, esoteric, and specialty domains.
 

--- a/skills/clean-codebase/SKILL.md
+++ b/skills/clean-codebase/SKILL.md
@@ -281,5 +281,4 @@ After cleanup:
 - [tidy-project-structure](../tidy-project-structure/SKILL.md) — Organize directory layout, update READMEs
 - [repair-broken-references](../repair-broken-references/SKILL.md) — Fix dead links and imports
 - [escalate-issues](../escalate-issues/SKILL.md) — Route complex problems to specialists
-- [r-packages/run-r-cmd-check](../../r-packages/run-r-cmd-check/SKILL.md) — Run full R package checks
-- [devops/dependency-audit](../../devops/dependency-audit/SKILL.md) — Check for outdated dependencies
+- [audit-dependency-versions](../audit-dependency-versions/SKILL.md) — Check for outdated dependencies

--- a/skills/create-2d-composition/SKILL.md
+++ b/skills/create-2d-composition/SKILL.md
@@ -410,5 +410,5 @@ def svg_to_pdf(svg_path, pdf_path):
 ## Related Skills
 
 - **[render-publication-graphic](../render-publication-graphic/SKILL.md)**: Publication-specific output requirements
-- **[create-3d-scene](../../blender/create-3d-scene/SKILL.md)**: Similar programmatic approach for 3D
-- **[generate-quarto-report](../../reporting/generate-quarto-report/SKILL.md)**: Integrating graphics into reports
+- **[create-3d-scene](../create-3d-scene/SKILL.md)**: Similar programmatic approach for 3D
+- **[create-quarto-report](../create-quarto-report/SKILL.md)**: Integrating graphics into reports

--- a/skills/create-3d-scene/SKILL.md
+++ b/skills/create-3d-scene/SKILL.md
@@ -377,4 +377,4 @@ def organize_collections():
 
 - **[script-blender-automation](../script-blender-automation/SKILL.md)**: Advanced scripting patterns for procedural modeling and batch operations
 - **[render-blender-output](../render-blender-output/SKILL.md)**: Configure rendering pipeline and execute renders
-- **[create-2d-composition](../../visualization/create-2d-composition/SKILL.md)**: 2D graphics composition using similar scripting approaches
+- **[create-2d-composition](../create-2d-composition/SKILL.md)**: 2D graphics composition using similar scripting approaches

--- a/skills/escalate-issues/SKILL.md
+++ b/skills/escalate-issues/SKILL.md
@@ -329,5 +329,5 @@ After escalation:
 - [clean-codebase](../clean-codebase/SKILL.md) — Often triggers escalations when uncertain
 - [tidy-project-structure](../tidy-project-structure/SKILL.md) — May discover complex organizational issues
 - [repair-broken-references](../repair-broken-references/SKILL.md) — Escalate when unclear if reference should be fixed or removed
-- [compliance/security-scan](../../compliance/security-scan/SKILL.md) — Escalate security findings
-- [general/issue-triage](../../general/issue-triage/SKILL.md) — General issue classification patterns
+- [security-audit-codebase](../security-audit-codebase/SKILL.md) — Escalate security findings
+- [manage-backlog](../manage-backlog/SKILL.md) — Classify and prioritize escalated items in the backlog

--- a/skills/render-blender-output/SKILL.md
+++ b/skills/render-blender-output/SKILL.md
@@ -434,4 +434,4 @@ def optimize_performance():
 
 - **[create-3d-scene](../create-3d-scene/SKILL.md)**: Scene setup required before rendering
 - **[script-blender-automation](../script-blender-automation/SKILL.md)**: Batch rendering automation patterns
-- **[render-publication-graphic](../../visualization/render-publication-graphic/SKILL.md)**: Publication output requirements and formatting
+- **[render-publication-graphic](../render-publication-graphic/SKILL.md)**: Publication output requirements and formatting

--- a/skills/render-publication-graphic/SKILL.md
+++ b/skills/render-publication-graphic/SKILL.md
@@ -487,5 +487,5 @@ embed_metadata('figure1.png', 'figure1_with_metadata.png', metadata)
 ## Related Skills
 
 - **[create-2d-composition](../create-2d-composition/SKILL.md)**: Creating the source graphics
-- **[render-blender-output](../../blender/render-blender-output/SKILL.md)**: 3D rendering settings for publication
-- **[generate-quarto-report](../../reporting/generate-quarto-report/SKILL.md)**: Integrating graphics into documents
+- **[render-blender-output](../render-blender-output/SKILL.md)**: 3D rendering settings for publication
+- **[create-quarto-report](../create-quarto-report/SKILL.md)**: Integrating graphics into documents

--- a/skills/repair-broken-references/SKILL.md
+++ b/skills/repair-broken-references/SKILL.md
@@ -362,5 +362,4 @@ After repairs:
 - [clean-codebase](../clean-codebase/SKILL.md) — Remove dead code after confirming orphans
 - [tidy-project-structure](../tidy-project-structure/SKILL.md) — Reorganize files (may create broken references)
 - [escalate-issues](../escalate-issues/SKILL.md) — Route complex reference issues to specialists
-- [compliance/documentation-audit](../../compliance/documentation-audit/SKILL.md) — Comprehensive documentation review
-- [web-dev/link-checker](../../web-dev/link-checker/SKILL.md) — Advanced external URL validation
+- [validate-references](../validate-references/SKILL.md) — External URL and DOI validation for bibliographies

--- a/skills/script-blender-automation/SKILL.md
+++ b/skills/script-blender-automation/SKILL.md
@@ -469,4 +469,4 @@ def create_from_json(filepath):
 
 - **[create-3d-scene](../create-3d-scene/SKILL.md)**: Basic scene setup and object creation
 - **[render-blender-output](../render-blender-output/SKILL.md)**: Rendering workflows for automated output
-- **[create-r-package](../../r-packages/create-r-package/SKILL.md)**: Similar packaging patterns for code distribution
+- **[create-r-package](../create-r-package/SKILL.md)**: Similar packaging patterns for code distribution

--- a/skills/tidy-project-structure/SKILL.md
+++ b/skills/tidy-project-structure/SKILL.md
@@ -357,5 +357,3 @@ After tidying:
 - [clean-codebase](../clean-codebase/SKILL.md) — Remove dead code, fix lint warnings
 - [repair-broken-references](../repair-broken-references/SKILL.md) — Fix links and imports after moves
 - [escalate-issues](../escalate-issues/SKILL.md) — Route complex config issues to specialists
-- [devops/config-management](../../devops/config-management/SKILL.md) — Advanced config consolidation
-- [compliance/documentation-audit](../../compliance/documentation-audit/SKILL.md) — Comprehensive doc review


### PR DESCRIPTION
Fixes both findings of #364 (adversarially verified link-by-link before filing).

## Changes

- **5 path-rot links** rewritten from the obsolete nested-domain style `../../<domain>/<id>/SKILL.md` to the flat `../<id>/SKILL.md` — targets all exist (blender/visualization skill cluster).
- **10 phantom links** (no target under any path), judgment recorded per link in the commit message: 5 retargeted to the nearest real skill (`audit-dependency-versions`, `create-quarto-report` x2, `security-audit-codebase`, `manage-backlog`, `validate-references`), 4 removed where no existing skill covers the linked intent.
- **CLAUDE.md:19**: dropped the hardcoded "65 logical domains" (actual: 66) from manual prose — points at the auto-generated registries section instead, so the number cannot rot again.

## Verification

- `rg '\.\./\.\./[a-z0-9-]+/[a-z0-9-]+/SKILL\.md' skills/` → zero remaining nested-style links
- `node scripts/generate-readmes.js --check` → all files up to date (CLAUDE.md AUTO sections untouched)
- `node scripts/check-content-style.js --added origin/main` → 0 blocking errors
- Diff is line-level only (no CRLF churn): 10 files, +12/−16

Closes #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)