### PR TITLE
i18n: sync allowed-tools config field in 20 locale copies (#278 sub-item)

### DIFF
--- a/i18n/caveman-lite/skills/create-team/SKILL.md
+++ b/i18n/caveman-lite/skills/create-team/SKILL.md
@@ -14,7 +14,7 @@ description: >
   composing agents for a complex review process, or creating a
   coordinated group for recurring collaborative tasks.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/caveman-lite/skills/test-team-coordination/SKILL.md
+++ b/i18n/caveman-lite/skills/test-team-coordination/SKILL.md
@@ -13,7 +13,7 @@ description: >
   patterns on equivalent workloads, or establishing baseline performance
   for a team composition.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/caveman-ultra/skills/create-team/SKILL.md
+++ b/i18n/caveman-ultra/skills/create-team/SKILL.md
@@ -14,7 +14,7 @@ description: >
   composing agents for a complex review process, or creating a
   coordinated group for recurring collaborative tasks.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/caveman-ultra/skills/test-team-coordination/SKILL.md
+++ b/i18n/caveman-ultra/skills/test-team-coordination/SKILL.md
@@ -11,7 +11,7 @@ description: >
   team's coordination pattern produces expected behaviors during realistic
   task, compare patterns on equivalent workloads, establish baseline perf.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/caveman/skills/create-team/SKILL.md
+++ b/i18n/caveman/skills/create-team/SKILL.md
@@ -14,7 +14,7 @@ description: >
   composing agents for a complex review process, or creating a
   coordinated group for recurring collaborative tasks.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/caveman/skills/test-team-coordination/SKILL.md
+++ b/i18n/caveman/skills/test-team-coordination/SKILL.md
@@ -13,7 +13,7 @@ description: >
   patterns on equivalent workloads, or establishing baseline performance
   for a team composition.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/de/skills/create-team/SKILL.md
+++ b/i18n/de/skills/create-team/SKILL.md
@@ -15,7 +15,7 @@ source_commit: b4dd42cd # stale — source updated for teams infrastructure fix
 translator: claude-opus-4-6
 translation_date: 2026-03-16
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/de/skills/test-team-coordination/SKILL.md
+++ b/i18n/de/skills/test-team-coordination/SKILL.md
@@ -14,7 +14,7 @@ source_commit: befb7ac1 # stale — source updated for teams infrastructure fix
 translator: claude-opus-4-6
 translation_date: 2026-03-16
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/es/skills/create-team/SKILL.md
+++ b/i18n/es/skills/create-team/SKILL.md
@@ -10,7 +10,7 @@ description: >
   al componer agentes para un proceso de revisión complejo, o al crear un
   grupo coordinado para tareas colaborativas recurrentes.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/es/skills/test-team-coordination/SKILL.md
+++ b/i18n/es/skills/test-team-coordination/SKILL.md
@@ -14,7 +14,7 @@ source_commit: befb7ac1 # stale — source updated for teams infrastructure fix
 translator: claude-opus-4-6
 translation_date: 2026-03-16
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/ja/skills/create-team/SKILL.md
+++ b/i18n/ja/skills/create-team/SKILL.md
@@ -13,7 +13,7 @@ source_commit: b4dd42cd # stale — source updated for teams infrastructure fix
 translator: claude-opus-4-6
 translation_date: 2026-03-16
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/ja/skills/test-team-coordination/SKILL.md
+++ b/i18n/ja/skills/test-team-coordination/SKILL.md
@@ -12,7 +12,7 @@ source_commit: befb7ac1 # stale — source updated for teams infrastructure fix
 translator: claude-opus-4-6
 translation_date: 2026-03-16
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/wenyan-lite/skills/create-team/SKILL.md
+++ b/i18n/wenyan-lite/skills/create-team/SKILL.md
@@ -14,7 +14,7 @@ description: >
   composing agents for a complex review process, or creating a
   coordinated group for recurring collaborative tasks.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/wenyan-lite/skills/test-team-coordination/SKILL.md
+++ b/i18n/wenyan-lite/skills/test-team-coordination/SKILL.md
@@ -13,7 +13,7 @@ description: >
   patterns on equivalent workloads, or establishing baseline performance
   for a team composition.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/wenyan-ultra/skills/create-team/SKILL.md
+++ b/i18n/wenyan-ultra/skills/create-team/SKILL.md
@@ -14,7 +14,7 @@ description: >
   composing agents for a complex review process, or creating a
   coordinated group for recurring collaborative tasks.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/wenyan-ultra/skills/test-team-coordination/SKILL.md
+++ b/i18n/wenyan-ultra/skills/test-team-coordination/SKILL.md
@@ -13,7 +13,7 @@ description: >
   patterns on equivalent workloads, or establishing baseline performance
   for a team composition.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/wenyan/skills/create-team/SKILL.md
+++ b/i18n/wenyan/skills/create-team/SKILL.md
@@ -14,7 +14,7 @@ description: >
   composing agents for a complex review process, or creating a
   coordinated group for recurring collaborative tasks.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/wenyan/skills/test-team-coordination/SKILL.md
+++ b/i18n/wenyan/skills/test-team-coordination/SKILL.md
@@ -13,7 +13,7 @@ description: >
   patterns on equivalent workloads, or establishing baseline performance
   for a team composition.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/zh-CN/skills/create-team/SKILL.md
+++ b/i18n/zh-CN/skills/create-team/SKILL.md
@@ -11,7 +11,7 @@ source_commit: b4dd42cd # stale — source updated for teams infrastructure fix
 translator: claude-opus-4-6
 translation_date: 2026-03-16
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/zh-CN/skills/test-team-coordination/SKILL.md
+++ b/i18n/zh-CN/skills/test-team-coordination/SKILL.md
@@ -10,7 +10,7 @@ source_commit: befb7ac1 # stale — source updated for teams infrastructure fix
 translator: claude-opus-4-6
 translation_date: 2026-03-16
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob
+allowed-tools: Read Write Edit Bash Grep Glob Agent SendMessage TaskCreate
 metadata:
   author: Philipp Thoss
   version: "1.0"


### PR DESCRIPTION
Extracts the one non-gated sub-item from #278 (flagged in its 2026-07-17 comment; adversarially verified this sweep): the 20 i18n snapshot copies of `create-team` and `test-team-coordination` (10 locales x 2 skills) still carried the pre-#354 6-tool `allowed-tools` grant, so installed locale skills lacked the orchestration tools (`Agent SendMessage TaskCreate`) their procedures invoke.

## Why this does not violate the #278 deferral

- `allowed-tools` is a keep-in-English config field per the i18n translation rules — this is config correctness, not a translation refresh.
- No prose changes, no `source_commit` bumps: freshness/staleness accounting is untouched (the de copies' inline `# stale` annotations on `source_commit` remain, correctly).
- The bulk ~2,327-file refresh stays deferred; scope-drift comment posted on #278 separately.

## Verification

- Uniform single-line replacement across exactly 20 files (+20/−20, asserted unique per file)
- All 20 now match the English source line verbatim
- Line counts unchanged (500-line i18n cap unaffected)

References #278 (does **not** close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)