### PR TITLE
ci: warn-only A9 invocation-phrase allowed-tools check — closes #356

### DIFF
--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -222,30 +222,39 @@ fi
 # A skill whose procedure invokes an orchestration tool by name ("via the
 # `Agent` tool", "coordinate ... with `SendMessage`") should declare that tool
 # in its frontmatter allowed-tools — the #354 drift class. The heuristic is
-# deliberately narrow: an invocation verb, optional "the", then a backticked
-# KNOWN orchestration tool name. Measured 2026-07-19 over all 368 skills:
-# 3 files / 11 lines matched, 0 false positives, 0 violations; both historical
-# #354 cases would have been flagged. The verb anchor excludes bare mentions
-# (deprecation notes, tool lists); un-backticked phrasing evades the pattern —
-# accepted false-negative class, which is why this stays warn-only (see #356).
+# deliberately narrow: an invocation verb (lower- or sentence-case), optional
+# "the", then a backticked KNOWN orchestration tool name. Measured 2026-07-19
+# over all 368 skills: 3 files / 12 lines matched, 0 false positives,
+# 0 violations; both historical #354 cases would have been flagged. The verb
+# anchor excludes bare mentions (deprecation notes, tool lists). Known
+# false-negative classes, accepted because this is warn-only (see #356):
+# un-backticked tool names ("with the Agent tool"), markdown emphasis breaking
+# adjacency ("**via** `Agent`"), and verbs outside the list.
+# allowed-tools is parsed from the frontmatter block only (first ---...---),
+# in both inline (space-separated) and YAML block-list form.
 echo "--- A9: Invocation-phrase allowed-tools coverage (warn-only) ---"
 a9_tools='Agent|SendMessage|TaskCreate|TaskUpdate|TaskGet|TaskList|TeamCreate|TeamDelete|Workflow'
-a9_verbs='via|using|with|through|call|calls|calling|invoke|invokes|invoked|spawn|spawns|spawned|spawning'
+a9_verbs='via|Via|use|Use|uses|used|using|Using|with|With|through|Through|call|calls|calling|Call|invoke|invokes|invoked|Invoke|spawn|spawns|spawned|spawning|Spawn'
 # The backtick lives in a single-quoted variable: GNU grep interprets an
 # ESCAPED backtick (\`) as a buffer-start anchor, not a literal — a pattern
 # built with \` matches under ugrep but silently never matches under GNU grep.
 a9_bt='`'
 a9_pattern="(${a9_verbs}) (the )?${a9_bt}(${a9_tools})${a9_bt}"
 a9_warned=0
-a9_hits=$(grep -rlE "$a9_pattern" skills/*/SKILL.md || true)
+a9_hits=$(grep -lE "$a9_pattern" skills/*/SKILL.md || true)
 while IFS= read -r f; do
   [ -z "$f" ] && continue
   [ "$f" = "skills/_template/SKILL.md" ] && continue
   invoked=$(grep -oE "$a9_pattern" "$f" | grep -oE "${a9_bt}(${a9_tools})${a9_bt}" | tr -d "$a9_bt" | sort -u || true)
-  allowed=$(grep -m1 '^allowed-tools:' "$f" | tr -d '\r' || true)
+  # Frontmatter region only (skips body code-fence examples); supports both
+  # `allowed-tools: A B C` and the YAML block-list form.
+  a9_fm=$(sed -n '2,/^---[[:space:]]*$/p' "$f" | tr -d '\r')
+  a9_inline=$(printf '%s\n' "$a9_fm" | grep -m1 '^allowed-tools:' | sed 's/^allowed-tools:[[:space:]]*//' || true)
+  a9_block=$(printf '%s\n' "$a9_fm" | awk '/^allowed-tools:[[:space:]]*$/{f=1;next} f&&/^[[:space:]]*-[[:space:]]/{sub(/^[[:space:]]*-[[:space:]]*/,"");print;next} f{exit}' || true)
+  allowed=$(printf '%s %s' "$a9_inline" "$a9_block" | tr '\n' ' ')
   while IFS= read -r tool; do
     [ -z "$tool" ] && continue
-    case " ${allowed#allowed-tools:} " in
+    case " $allowed " in
       *" $tool "*) : ;;
       *) echo "WARN: $f invokes \`$tool\` in its procedure but allowed-tools lacks it (#356)"
          warn_count=$((warn_count + 1)); a9_warned=$((a9_warned + 1)) ;;

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -218,6 +218,42 @@ else
   [ "$a8_fail" -eq 0 ] && echo "OK: all $a8_count auto-generated files (readmes + per-locale translation_status) are in the auto-commit file_pattern"
 fi
 
+# A9: Invocation-phrase allowed-tools coverage (#356, warn-only)
+# A skill whose procedure invokes an orchestration tool by name ("via the
+# `Agent` tool", "coordinate ... with `SendMessage`") should declare that tool
+# in its frontmatter allowed-tools — the #354 drift class. The heuristic is
+# deliberately narrow: an invocation verb, optional "the", then a backticked
+# KNOWN orchestration tool name. Measured 2026-07-19 over all 368 skills:
+# 3 files / 11 lines matched, 0 false positives, 0 violations; both historical
+# #354 cases would have been flagged. The verb anchor excludes bare mentions
+# (deprecation notes, tool lists); un-backticked phrasing evades the pattern —
+# accepted false-negative class, which is why this stays warn-only (see #356).
+echo "--- A9: Invocation-phrase allowed-tools coverage (warn-only) ---"
+a9_tools='Agent|SendMessage|TaskCreate|TaskUpdate|TaskGet|TaskList|TeamCreate|TeamDelete|Workflow'
+a9_verbs='via|using|with|through|call|calls|calling|invoke|invokes|invoked|spawn|spawns|spawned|spawning'
+# The backtick lives in a single-quoted variable: GNU grep interprets an
+# ESCAPED backtick (\`) as a buffer-start anchor, not a literal — a pattern
+# built with \` matches under ugrep but silently never matches under GNU grep.
+a9_bt='`'
+a9_pattern="(${a9_verbs}) (the )?${a9_bt}(${a9_tools})${a9_bt}"
+a9_warned=0
+a9_hits=$(grep -rlE "$a9_pattern" skills/*/SKILL.md || true)
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ "$f" = "skills/_template/SKILL.md" ] && continue
+  invoked=$(grep -oE "$a9_pattern" "$f" | grep -oE "${a9_bt}(${a9_tools})${a9_bt}" | tr -d "$a9_bt" | sort -u || true)
+  allowed=$(grep -m1 '^allowed-tools:' "$f" | tr -d '\r' || true)
+  while IFS= read -r tool; do
+    [ -z "$tool" ] && continue
+    case " ${allowed#allowed-tools:} " in
+      *" $tool "*) : ;;
+      *) echo "WARN: $f invokes \`$tool\` in its procedure but allowed-tools lacks it (#356)"
+         warn_count=$((warn_count + 1)); a9_warned=$((a9_warned + 1)) ;;
+    esac
+  done <<< "$invoked"
+done <<< "$a9_hits"
+[ "$a9_warned" -eq 0 ] && echo "OK: no invocation-phrase/allowed-tools drift (anchored pattern, warn-only)"
+
 echo ""
 echo "=== Category B: Structural Integrity ==="
 


### PR DESCRIPTION
Implements #356's acceptance criteria: prototype the narrow invocation-phrase heuristic, measure FP/FN, and add it as a warn-only integrity check.

## Measurement (2026-07-19, all 368 skills)

- **Pattern**: invocation verb (`via|using|with|through|call*|invoke*|spawn*`) + optional `the` + backticked known orchestration tool name (`Agent|SendMessage|TaskCreate|TaskUpdate|TaskGet|TaskList|TeamCreate|TeamDelete|Workflow`).
- **Hits**: 3 files / 11 lines — `create-team`, `test-team-coordination`, `unleash-the-agents`. All invoked tools are declared in the respective `allowed-tools` → **0 violations, 0 false positives** on the current corpus.
- **Anchoring works**: `memex`'s "via the MCP tool" (not a known tool name) and `test-team-coordination`'s parenthetical TeamCreate deprecation note (no invocation verb) are correctly excluded.
- **FN check**: both historical #354 cases (`create-team`/`test-team-coordination` pre-PR #358) would have been flagged — verified by negative test (removing `TaskCreate` from `create-team` produces the WARN). Un-backticked phrasing (e.g. `unleash-the-agents` line 118 "with the Agent tool") evades the line-level pattern — accepted FN class; the same file is still caught via its backticked lines. This FN class is why the check is warn-only rather than blocking.

This clears the issue's own "FP acceptably low" bar, so the check ships as **A9 (warn-only)** in `scripts/validate-integrity.sh`. (The issue suggested the "A8" slot — taken by #357 in the meantime.)

## Implementation notes

- Shortlist-first: one repo-wide `grep -rlE`, then per-hit-file extraction — negligible runtime cost.
- Portability gotcha caught in testing: an escaped backtick (`` \` ``) is a **buffer-start anchor** in GNU grep (CI) but a literal in ugrep (this WSL's interactive default) — the pattern matched locally and would have silently never matched in CI. The backtick now lives in a single-quoted variable, verified against `/usr/bin/grep`.
- Warn semantics follow the established `warn_count` pattern (B5/B7-B9); `failed` untouched.

## Verification

- Positive: full A-section run green, `OK: no invocation-phrase/allowed-tools drift`
- Negative 1: `TaskCreate` dropped from `create-team` → WARN
- Negative 2: invocation line added to a skill with no `allowed-tools` frontmatter → WARN

Closes #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)