### PR TITLE
ci: gate npm run test:cli on push/PR (#326 item 8)

### DIFF
--- a/.github/workflows/ci-node-cli.yml
+++ b/.github/workflows/ci-node-cli.yml
@@ -1,0 +1,43 @@
+name: CI Node CLI
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cli/**'
+      # CLI tests are registry-derived (#307): registry changes must re-run them.
+      - 'skills/_registry.yml'
+      - 'agents/_registry.yml'
+      - 'teams/_registry.yml'
+      - 'guides/_registry.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ci-node-cli.yml'
+  pull_request:
+    paths:
+      - 'cli/**'
+      - 'skills/_registry.yml'
+      - 'agents/_registry.yml'
+      - 'teams/_registry.yml'
+      - 'guides/_registry.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ci-node-cli.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      # Before this gate, test:cli ran in CI only as the prepublishOnly hook at
+      # release time — a CLI regression merged on main surfaced weeks later at
+      # the next npm publish, misattributed (#326 item 8).
+      - run: npm run test:cli

--- a/.github/workflows/ci-node-cli.yml
+++ b/.github/workflows/ci-node-cli.yml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  cli-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Extracts item 8 from #326 (adversarially verified this sweep, including a fresh-clone simulation: 78/78 in a clean checkout).

## Why

`test:cli` runs in CI only as the `prepublishOnly` hook — a CLI regression merged on main surfaces weeks later at the next `npm publish`, misattributed to the release. This closes that window with a plain push/PR gate.

## Scope

- Triggers: `cli/**`, the four content registries (CLI tests are registry-derived since #307), `package.json`/`package-lock.json`, and the workflow file itself.
- Not covered here (stays in #326): the rust-cli branch residuals, the v1.x `audit` bug (#365, needs a freeze-exception decision), and the Node/Rust parity items.
- Note: GitHub Actions CI is not the workflows/ content pillar — the #288 Phase-2 gate does not apply.

## Verification

- `npm run test:cli` green locally on this branch: **78/78 pass** (~66s)
- Workflow mirrors repo conventions: checkout@v7, setup-node@v7 + node 24 + npm cache, `permissions: contents: read`

References #326 (does **not** close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)