### PR TITLE
fix: #374 web-scraping shell-blind probe + #375 pitfall growth reconciliation

### DIFF
--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -215,6 +215,8 @@ Each item must be objectively verifiable. "Code is clean" is bad. "`devtools::ch
 
 Draw from real experience. The best pitfalls are ones that waste significant time and are non-obvious.
 
+The 3-6 cap holds for the life of the skill: when a later evolution wants a seventh pitfall, [evolve-skill](../evolve-skill/SKILL.md) evicts the pitfall with the lowest rediscovery cost instead of appending past the cap.
+
 **Expected:** 3-6 pitfalls, each with a bold name, a description of what goes wrong, and how to avoid it.
 
 **On failure:** If pitfalls feel generic ("be careful with X"), make them specific: name the symptom, the cause, and the fix. Draw from actual failure scenarios encountered during development or testing.

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.2"
+  version: "1.3"
   domain: general
   complexity: intermediate
   language: multi

--- a/skills/evolve-skill/SKILL.md
+++ b/skills/evolve-skill/SKILL.md
@@ -129,7 +129,7 @@ Follow these editing rules:
 - Preserve all existing sections — add content, don't remove sections
 - Keep step numbering sequential after insertions
 - Every new or modified step must have both Expected and On failure
-- New pitfalls go at the end of the Common Pitfalls section
+- New pitfalls go at the end of the Common Pitfalls section — but above 6 pitfalls, do not append. Drop (or move to `references/EXAMPLES.md`) the pitfall with the lowest rediscovery cost: the one a competent agent would most likely avoid unaided, e.g. one whose content the skill's own Procedure already teaches. Pitfalls are ranked by what they save, not by age. Skills already over the cap are grandfathered — apply the eviction rule the next time the skill is evolved, not as a bulk retro-edit
 - New related skills go at the end of the Related Skills section
 
 #### For Variants

--- a/skills/evolve-skill/SKILL.md
+++ b/skills/evolve-skill/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.2"
+  version: "1.3"
   domain: general
   complexity: intermediate
   language: multi
@@ -129,7 +129,7 @@ Follow these editing rules:
 - Preserve all existing sections — add content, don't remove sections
 - Keep step numbering sequential after insertions
 - Every new or modified step must have both Expected and On failure
-- New pitfalls go at the end of the Common Pitfalls section — but above 6 pitfalls, do not append. Drop (or move to `references/EXAMPLES.md`) the pitfall with the lowest rediscovery cost: the one a competent agent would most likely avoid unaided, e.g. one whose content the skill's own Procedure already teaches. Pitfalls are ranked by what they save, not by age. Skills already over the cap are grandfathered — apply the eviction rule the next time the skill is evolved, not as a bulk retro-edit
+- New pitfalls go at the end of the Common Pitfalls section — but if appending would push the count above 6, do not append: evict the pitfall with the lowest rediscovery cost instead, the one a competent agent would most likely avoid unaided. An eviction must name the Procedure step or section that already teaches the evicted content — if none does, first fold the pitfall's counterintuitive fact into the step that should carry it, then evict. Pitfalls are ranked by what they save, not by age. Skills already over the cap are grandfathered: evict when a later evolution adds a pitfall, not as a bulk retro-edit
 - New related skills go at the end of the Related Skills section
 
 #### For Variants

--- a/skills/headless-web-scraping/SKILL.md
+++ b/skills/headless-web-scraping/SKILL.md
@@ -52,23 +52,35 @@ Determine which scrapling fetcher matches the target site's defenses.
 # 2. StealthyFetcher — Cloudflare/Turnstile, TLS fingerprint checks
 # 3. DynamicFetcher  — JS-rendered SPAs, click/scroll interactions
 
-# Quick probe: try Fetcher first, escalate on failure
+# Quick probe: try Fetcher first, escalate on failure.
+# The probe cannot judge sufficiency without knowing what success looks like.
+# Supply a marker you expect on the *rendered* page: a heading, a field label,
+# a known row value. Do NOT test `status == 200 and get_all_text()` — a JS app
+# shell returns 200 with non-empty text (nav, footer, boilerplate), so that
+# check passes on exactly the page where the fetcher failed.
 from scrapling import Fetcher
+
+EXPECTED_MARKER = "Quarterly Revenue"  # required, target-specific
 
 fetcher = Fetcher()
 response = fetcher.get("https://example.com/target-page")
+text = response.get_all_text() if response.status == 200 else ""
 
-if response.status == 200 and response.get_all_text():
+if EXPECTED_MARKER in text:
     print("Fetcher tier sufficient")
 else:
-    print("Escalate to StealthyFetcher or DynamicFetcher")
+    print(f"Escalate - status {response.status}, {len(text)} chars, marker absent")
 ```
+
+Where no marker is knowable (e.g. a discovery crawl), fetch one representative page
+with both `Fetcher` and `DynamicFetcher` and compare text lengths — an app shell is
+a small fraction of the rendered page.
 
 | Signal | Recommended Tier |
 |---|---|
 | Static HTML, no protection | `Fetcher` |
 | 403/503, Cloudflare challenge page | `StealthyFetcher` |
-| Page loads but content area is empty | `DynamicFetcher` |
+| Page loads but content area is empty or only chrome/nav copy | `DynamicFetcher` |
 | Need to click buttons or scroll | `DynamicFetcher` |
 | altcha CAPTCHA present | None (cannot be automated) |
 
@@ -278,7 +290,7 @@ def scrape_urls(urls, selector, delay=1.0):
 - **Starting with DynamicFetcher**: Always try `Fetcher` first, then escalate -- `DynamicFetcher` is 10-50x slower due to full browser startup
 - **Constructor kwargs instead of `configure()`**: scrapling v0.4.x deprecated passing options to the constructor; always use the `configure()` method
 - **Ignoring altcha CAPTCHA**: No fetcher tier can solve altcha proof-of-work challenges -- detect them early and fall back to manual instructions
-- **No rate limiting**: Even if the site does not return 429, aggressive scraping can get your IP banned or cause service degradation
+- **Treating HTTP 200 as evidence of content**: A JavaScript app shell returns 200 with non-empty boilerplate text (nav, footer) for any path, including wrong ones -- verify a target-specific expected marker, or compare raw vs rendered text length, before trusting the cheap tier
 - **Assuming stable selectors**: Website CSS classes change frequently -- validate selectors against current page source before each scraping campaign
 
 ## Related Skills

--- a/skills/headless-web-scraping/SKILL.md
+++ b/skills/headless-web-scraping/SKILL.md
@@ -36,6 +36,7 @@ architecture and CSS-based data extraction.
 
 - **Required**: Target URL or list of URLs to scrape
 - **Required**: Data to extract (CSS selectors, field names, or description of target elements)
+- **Optional**: Expected content marker for the tier-sufficiency probe — a string known to appear on the *rendered* target page (heading, field label, known row value); without one, fall back to the raw-vs-rendered length comparison in Step 1
 - **Optional**: Fetcher tier override (default: auto-select based on site behavior)
 - **Optional**: Output format (default: JSON; alternatives: CSV, Python dict)
 - **Optional**: Rate limit delay in seconds (default: 1)

--- a/skills/headless-web-scraping/SKILL.md
+++ b/skills/headless-web-scraping/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Bash Read Write Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: web-scraping
   complexity: intermediate
   language: Python

--- a/skills/headless-web-scraping/SKILL.md
+++ b/skills/headless-web-scraping/SKILL.md
@@ -56,7 +56,10 @@ Determine which scrapling fetcher matches the target site's defenses.
 # Quick probe: try Fetcher first, escalate on failure.
 # The probe cannot judge sufficiency without knowing what success looks like.
 # Supply a marker you expect on the *rendered* page: a heading, a field label,
-# a known row value. Do NOT test `status == 200 and get_all_text()` — a JS app
+# a known row value. Prefer language- and render-invariant strings (a stable
+# identifier, numeric value, or attribute value) over localized display text,
+# which false-negatives on locale/AB variants and wastes an escalation.
+# Do NOT test `status == 200 and get_all_text()` — a JS app
 # shell returns 200 with non-empty text (nav, footer, boilerplate), so that
 # check passes on exactly the page where the fetcher failed.
 from scrapling import Fetcher
@@ -75,7 +78,11 @@ else:
 
 Where no marker is knowable (e.g. a discovery crawl), fetch one representative page
 with both `Fetcher` and `DynamicFetcher` and compare text lengths — an app shell is
-a small fraction of the rendered page.
+a small fraction of the rendered page. Expect the rendered fetch to be several times
+larger; under ~2x is inconclusive — calibrate on a second page. This fallback is a
+whole-page proxy: a small JS-hydrated island on a large static page shows raw ≈
+rendered while your target is exactly the missing island, so prefer a marker
+whenever one is knowable.
 
 | Signal | Recommended Tier |
 |---|---|
@@ -265,7 +272,7 @@ def scrape_urls(urls, selector, delay=1.0):
 3. Identify your scraper with a descriptive User-Agent when possible
 4. Do not scrape personal data without legal basis
 5. Cache responses locally to avoid redundant requests
-6. Stop immediately if you receive a 429 (Too Many Requests)
+6. Stop immediately if you receive a 429 (Too Many Requests) — and do not read the absence of 429s as safety: aggressive scraping can trigger IP bans without a single 429 first
 
 **Expected:** Scraping runs at a controlled rate. `robots.txt` is checked before bulk operations. No 429 responses are triggered.
 

--- a/skills/review-skill-format/SKILL.md
+++ b/skills/review-skill-format/SKILL.md
@@ -131,11 +131,15 @@ done
 
 # Validation section may use either heading
 grep -qE "## Validation( Checklist)?" skills/<skill-name>/SKILL.md && echo "Validation: OK" || echo "Validation: MISSING"
+
+# Report pitfall count (create-skill cap: 3-6; evolve-skill evicts instead of appending past 6)
+pitfall_count=$(sed -n '/^## Common Pitfalls/,/^## [^#]/p' skills/<skill-name>/SKILL.md | grep -c '^- ')
+echo "Common Pitfalls: $pitfall_count bullets (cap 3-6)"
 ```
 
-**Expected:** All six sections present. Procedure section contains at least one `### Step` sub-heading.
+**Expected:** All six sections present. Procedure section contains at least one `### Step` sub-heading. Pitfall count is reported; 3-6 is within cap.
 
-**On failure:** Report each missing section as BLOCKING. A skill without all six sections is non-compliant with the agentskills.io standard. Provide the section template from the `create-skill` meta-skill.
+**On failure:** Report each missing section as BLOCKING. A skill without all six sections is non-compliant with the agentskills.io standard. Provide the section template from the `create-skill` meta-skill. A pitfall count above 6 is SUGGEST, not BLOCKING (existing over-cap skills are grandfathered): recommend evicting the lowest-rediscovery-cost pitfall per `evolve-skill`.
 
 ### Step 5: Check Procedure Step Format
 

--- a/skills/review-skill-format/SKILL.md
+++ b/skills/review-skill-format/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.2"
+  version: "1.3"
   domain: review
   complexity: intermediate
   language: multi
@@ -132,14 +132,15 @@ done
 # Validation section may use either heading
 grep -qE "## Validation( Checklist)?" skills/<skill-name>/SKILL.md && echo "Validation: OK" || echo "Validation: MISSING"
 
-# Report pitfall count (create-skill cap: 3-6; evolve-skill evicts instead of appending past 6)
-pitfall_count=$(sed -n '/^## Common Pitfalls/,/^## [^#]/p' skills/<skill-name>/SKILL.md | grep -c '^- ')
-echo "Common Pitfalls: $pitfall_count bullets (cap 3-6)"
+# Report pitfall count (create-skill cap: 3-6; evolve-skill evicts instead of appending past 6).
+# Counts dash and numbered items; `|| true` guards grep's exit-1-on-zero under `set -e`.
+pitfall_count=$(sed -n '/^## Common Pitfalls/,/^## [^#]/p' skills/<skill-name>/SKILL.md | grep -cE '^(- |[0-9]+\. )' || true)
+echo "Common Pitfalls: $pitfall_count items (cap 3-6)"
 ```
 
 **Expected:** All six sections present. Procedure section contains at least one `### Step` sub-heading. Pitfall count is reported; 3-6 is within cap.
 
-**On failure:** Report each missing section as BLOCKING. A skill without all six sections is non-compliant with the agentskills.io standard. Provide the section template from the `create-skill` meta-skill. A pitfall count above 6 is SUGGEST, not BLOCKING (existing over-cap skills are grandfathered): recommend evicting the lowest-rediscovery-cost pitfall per `evolve-skill`.
+**On failure:** Report each missing section as BLOCKING. A skill without all six sections is non-compliant with the agentskills.io standard. Provide the section template from the `create-skill` meta-skill. A pitfall count above 6 is SUGGEST, not BLOCKING — the count check is advisory by design: it cannot distinguish a grandfathered over-cap skill from fresh over-cap authoring, so enforcement of the 3-6 cap for new skills lives in `create-skill` at authoring time; recommend evicting the lowest-rediscovery-cost pitfall per `evolve-skill`. A count of 0 with the section present means a non-list format (e.g. a table) — count manually.
 
 ### Step 5: Check Procedure Step Format
 
@@ -207,6 +208,7 @@ grep -A1 "id: <skill-name>" skills/_registry.yml | grep -q "path: <skill-name>/S
 - [ ] `name` field matches directory name
 - [ ] `description` is under 1024 characters
 - [ ] All six required sections present (When to Use, Inputs, Procedure, Validation, Common Pitfalls, Related Skills)
+- [ ] Pitfall count reported (3-6 within cap; above-cap or 0-with-section-present noted as SUGGEST)
 - [ ] Every procedure step has **Expected:** and **On failure:** blocks
 - [ ] Line count is 500 or fewer
 - [ ] Skill is listed in `_registry.yml` with correct domain, path, and metadata


### PR DESCRIPTION
## Summary

Two skill-spec bugs from the 2026-07-20 adversarial review batch.

**#374 — headless-web-scraping.** The sufficiency probe (`status == 200 and get_all_text()`) passes on a JavaScript app shell — 200 plus non-empty nav/footer boilerplate — i.e. on exactly the page where the cheap fetcher tier failed. The probe now requires a target-specific `EXPECTED_MARKER` with the shell rationale inline; a rendered-vs-raw length comparison is documented as the no-marker fallback; the escalation tell reads "empty or only chrome/nav copy"; a Common Pitfalls bullet records that a 200 is not evidence of content.

**#375 — pitfall growth rules.** `evolve-skill` appended without bound while `create-skill` caps at 3-6; 95/371 skills already exceed the cap. `evolve-skill` now carries an eviction rule (above 6, drop the pitfall with the lowest rediscovery cost — ranked by what they save, not by age), `create-skill` states the cap holds for the life of the skill, and `review-skill-format` reports the pitfall count (above-cap = SUGGEST, grandfathered).

## Acceptance criteria mapping

#374: probe no longer treats 200+text as sufficiency ✔ / replacement requires marker with rationale ✔ / no-marker fallback documented ✔ / escalation tell widened ✔ / pitfalls bullet added ✔

#375: eviction rule ✔ / ranking criterion stated (rediscovery cost) ✔ / cap and growth rule reconciled from both sides ✔ / review-skill-format reports count ✔ / grandfathering decision recorded in commit + rule text ✔

## Self-consistency note

Adding the #374 bullet would have pushed headless-web-scraping to 7 pitfalls — breaching the cap #375 fixes. Applied the new eviction rule to it: evicted **No rate limiting**, whose content is fully taught by Step 5's ethical-scraping checklist in the same skill (rediscovery cost ~zero). Count stays at 6.

## Validation

- [x] `check-content-style.js --added origin/main`: 0 blocking errors
- [x] `validate:line-endings`: OK
- [x] All four files well under the 500-line cap
- [x] Pitfall counter self-test: headless-web-scraping 6, version-ml-data 10 (matches issue measurement)

Closes #374, closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAw93zGpmEc9tN5LszcUHE