### PR TITLE
viz: UX quick wins — locale notice, hit targets + hint, graph-wired search, header band fix (#391 #392 #393 #395)

### DIFF
--- a/viz/css/style.css
+++ b/viz/css/style.css
@@ -496,6 +496,17 @@ body::after {
   transition: border-color var(--transition-speed);
 }
 
+.filter-empty-state {
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.filter-empty-state.hidden {
+  display: none;
+}
+
 .filter-search::placeholder {
   color: var(--text-muted);
   opacity: 0.6;

--- a/viz/css/style.css
+++ b/viz/css/style.css
@@ -1042,6 +1042,46 @@ body::after {
   display: block;
 }
 
+/* ── Locale Filter Notice ───────────────────────── */
+.locale-notice {
+  position: fixed;
+  top: calc(var(--header-height) + var(--safe-area-top) + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  background: var(--bg-panel);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--text-accent);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--text-primary);
+  z-index: 90;
+  max-width: calc(100vw - 32px);
+}
+
+.locale-notice[hidden] {
+  display: none;
+}
+
+.locale-notice button {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-accent);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 3px 8px;
+  cursor: pointer;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.locale-notice button:hover {
+  border-color: var(--text-accent);
+}
+
 /* ── Hamburger Menu ─────────────────────────────── */
 .hamburger-toggle {
   display: none;

--- a/viz/css/style.css
+++ b/viz/css/style.css
@@ -295,6 +295,10 @@ body::after {
   transition: transform var(--transition-speed);
 }
 
+.panel-toggle-label {
+  display: none; /* shown on phone widths for discoverability */
+}
+
 .panel-toggle.collapsed {
   left: 0;
 }
@@ -1281,6 +1285,35 @@ body::after {
   }
 }
 
+/* ── Laptop band: header controls scroll instead of overflowing ── */
+/* Between the phone drawer (<=768px) and full-width desktop, the
+   inline control row can exceed the viewport; let it scroll so Reset
+   and the mode buttons never become unreachable. */
+@media (min-width: 769px) and (max-width: 1250px) {
+  .header-drawer {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: thin;
+    margin-left: 12px;
+  }
+
+  .header-drawer .header-controls {
+    width: max-content;
+    flex-wrap: nowrap;
+  }
+
+  .header-drawer::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  .header-drawer::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 2px;
+  }
+}
+
 /* ── Responsive ──────────────────────────────────────────────── */
 @media (max-width: 768px) {
   /* Disable CRT scanline overlay on mobile for performance */
@@ -1358,11 +1391,27 @@ body::after {
     left: 0;
     min-width: 44px;
     min-height: 44px;
-    font-size: 16px;
+    font-size: 13px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 12px;
+    border-color: var(--text-accent);
+    color: var(--text-accent);
+  }
+
+  .panel-toggle .panel-toggle-label {
+    display: inline;
+    font-family: var(--font-mono);
+    letter-spacing: 0.5px;
   }
 
   .panel-toggle:not(.collapsed) {
     left: 260px;
+  }
+
+  .panel-toggle:not(.collapsed) .panel-toggle-label {
+    display: none; /* label only while closed — open state shows the panel itself */
   }
 
   .detail-panel {

--- a/viz/css/style.css
+++ b/viz/css/style.css
@@ -1073,7 +1073,9 @@ body::after {
   border-radius: 4px;
   font-size: 12px;
   color: var(--text-primary);
-  z-index: 90;
+  /* Below the filter panel (50) and its toggle (60): the notice is
+     informational and must never occlude a primary control. */
+  z-index: 45;
   max-width: calc(100vw - 32px);
 }
 
@@ -1466,6 +1468,18 @@ body::after {
 
   .header-stats {
     display: none;
+  }
+
+  /* Clear the panel toggle entirely: it occupies the header+8px band at the
+     left edge, and the notice would otherwise span the full width across it. */
+  .locale-notice {
+    top: calc(var(--header-height) + var(--safe-area-top) + 60px);
+    left: 8px;
+    right: 8px;
+    transform: none;
+    max-width: none;
+    flex-wrap: wrap;
+    justify-content: center;
   }
 
   .hamburger-toggle {

--- a/viz/css/style.css
+++ b/viz/css/style.css
@@ -1082,6 +1082,78 @@ body::after {
   border-color: var(--text-accent);
 }
 
+/* ── First-Visit Hint + Legend ──────────────────── */
+.first-visit-hint {
+  position: fixed;
+  bottom: calc(24px + var(--safe-area-bottom));
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--bg-panel);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--bg-panel-border);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--text-primary);
+  z-index: 60;
+  max-width: min(420px, calc(100vw - 32px));
+  text-align: center;
+}
+
+.first-visit-hint[hidden] {
+  display: none;
+}
+
+.hint-legend {
+  display: flex;
+  gap: 16px;
+  color: var(--text-muted);
+}
+
+.hint-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hint-shape {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: var(--text-accent);
+}
+
+.hint-shape-circle {
+  border-radius: 50%;
+}
+
+.hint-shape-oct {
+  clip-path: polygon(30% 0%, 70% 0%, 100% 30%, 100% 70%, 70% 100%, 30% 100%, 0% 70%, 0% 30%);
+}
+
+.hint-shape-pent {
+  clip-path: polygon(50% 0%, 100% 38%, 81% 100%, 19% 100%, 0% 38%);
+}
+
+.first-visit-hint button {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-accent);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 4px 12px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.first-visit-hint button:hover {
+  border-color: var(--text-accent);
+}
+
 /* ── Hamburger Menu ─────────────────────────────── */
 .hamburger-toggle {
   display: none;

--- a/viz/index.html
+++ b/viz/index.html
@@ -190,6 +190,17 @@
   <!-- ── Graph Canvas ──────────────────────────────────────────── -->
   <div id="graph-container" role="application" data-i18n-aria="a11y.graphContainer" aria-label="Interactive skill network visualization" tabindex="0"></div>
 
+  <!-- ── First-Visit Hint + Legend ─────────────────────────────── -->
+  <div id="first-visit-hint" class="first-visit-hint" role="note" hidden>
+    <div class="hint-text" data-i18n="hint.text">Click any node to explore it — drag to pan, scroll to zoom.</div>
+    <div class="hint-legend">
+      <span class="hint-legend-item"><span class="hint-shape hint-shape-circle" aria-hidden="true"></span><span data-i18n="hint.legendSkill">Skill</span></span>
+      <span class="hint-legend-item"><span class="hint-shape hint-shape-oct" aria-hidden="true"></span><span data-i18n="hint.legendAgent">Agent</span></span>
+      <span class="hint-legend-item"><span class="hint-shape hint-shape-pent" aria-hidden="true"></span><span data-i18n="hint.legendTeam">Team</span></span>
+    </div>
+    <button id="hint-dismiss" type="button" data-i18n="hint.dismiss">Got it</button>
+  </div>
+
   <!-- ── Detail Panel (Right) ──────────────────────────────────── -->
   <aside id="detail-panel" class="detail-panel">
     <div class="panel-top-bar">

--- a/viz/index.html
+++ b/viz/index.html
@@ -90,6 +90,7 @@
   <!-- ── Panel Toggle (Left edge) ──────────────────────────────── -->
   <button id="panel-toggle" class="panel-toggle" data-i18n-aria="filter.togglePanel" aria-label="Toggle filter panel" aria-expanded="true" aria-controls="filter-panel">
     <span class="panel-toggle-icon" aria-hidden="true">&#x25C0;</span>
+    <span class="panel-toggle-label" data-i18n="filter.filtersLabel">Filters</span>
   </button>
 
   <!-- ── Filter Panel (Left) ───────────────────────────────────── -->

--- a/viz/index.html
+++ b/viz/index.html
@@ -81,6 +81,12 @@
     </div>
   </header>
 
+  <!-- ── Locale Filter Notice ──────────────────────────────────── -->
+  <div id="locale-notice" class="locale-notice" role="status" hidden>
+    <span id="locale-notice-text"></span>
+    <button id="locale-notice-toggle" type="button"></button>
+  </div>
+
   <!-- ── Panel Toggle (Left edge) ──────────────────────────────── -->
   <button id="panel-toggle" class="panel-toggle" data-i18n-aria="filter.togglePanel" aria-label="Toggle filter panel" aria-expanded="true" aria-controls="filter-panel">
     <span class="panel-toggle-icon" aria-hidden="true">&#x25C0;</span>

--- a/viz/js/app.js
+++ b/viz/js/app.js
@@ -5,7 +5,7 @@
 // put id:"lazy_load", label:"Lazy-load mode modules on demand", input:"mode_bindings", output:"active_module"
 // put id:"render_mode", label:"Render active mode with current filters", node_type:"output", input:"active_module"
 
-import { initGraph, destroyGraph, focusNode, resetView, zoomIn, zoomOut, setSkillVisibility, getGraph, refreshGraph, preloadIcons, switchIconPalette, setVisibleAgents, setVisibleTeams, getVisibleAgentIds } from './graph.js';
+import { initGraph, destroyGraph, focusNode, resetView, zoomIn, zoomOut, setSkillVisibility, getGraph, refreshGraph, preloadIcons, switchIconPalette, setVisibleAgents, setVisibleTeams, getVisibleAgentIds, zoomToFitCore } from './graph.js';
 import { setIconMode, getIconMode, setHdMode, getHdMode } from './icons.js';
 import { initPanel, openPanel, closePanel, refreshPanelTheme } from './panel.js';
 import { initFilters, getVisibleSkillIds, getVisibleAgentIds as getFilteredAgentIds, getVisibleTeamIds as getFilteredTeamIds, refreshSwatches, setLocaleFilter, getLocaleFilterInfo, getShowUntranslated, setShowUntranslated } from './filters.js';
@@ -118,8 +118,10 @@ function isWebGLAvailable() {
 function modeCallbacks() {
   return {
     onClick(node) {
-      if (node) openPanel(node);
-      else closePanel();
+      if (node) {
+        dismissHint(); // user has discovered click-to-detail
+        openPanel(node);
+      } else closePanel();
     },
     onHover(node) {
       showTooltip(node);
@@ -323,10 +325,9 @@ async function switchMode(newModeName) {
         hiveMod.setHiveSpread(savedSpread);
       }
     } else if (newModeName === '2d') {
-      // Auto zoom-to-fit after layout settles
+      // Auto zoom-to-fit after layout settles (core component only)
       setTimeout(() => {
-        const g = getGraph();
-        if (g) g.zoomToFit(800, 40);
+        if (getGraph()) zoomToFitCore(800, 40);
       }, LAYOUT_SETTLE_MS);
     }
   } catch (err) {
@@ -465,6 +466,7 @@ async function main() {
   const container = document.getElementById('graph-container');
   initGraph(container, data, modeCallbacks());
   hideLoading();
+  initHint();
 
   // ── Preload icons ──
   preloadIcons(data.nodes, getCurrentThemeName());
@@ -656,10 +658,9 @@ async function main() {
     switchMode('campfire');
   }
 
-  // ── Auto zoom-to-fit after layout settles ──
+  // ── Auto zoom-to-fit after layout settles (core component only) ──
   setTimeout(() => {
-    const g = getGraph();
-    if (g) g.zoomToFit(800, 40);
+    if (getGraph()) zoomToFitCore(800, 40);
   }, LAYOUT_SETTLE_MS);
 }
 
@@ -714,6 +715,24 @@ document.addEventListener('touchmove', e => {
 document.addEventListener('touchend', () => {
   if (tooltip) tooltip.style.display = 'none';
 }, { passive: true });
+
+// ── First-visit hint + legend ───────────────────────────────────────
+const HINT_DISMISSED_KEY = 'skillnet-hint-dismissed';
+
+function dismissHint(persist = true) {
+  const hint = document.getElementById('first-visit-hint');
+  if (hint && !hint.hidden) {
+    hint.hidden = true;
+    if (persist) localStorage.setItem(HINT_DISMISSED_KEY, 'true');
+  }
+}
+
+function initHint() {
+  const hint = document.getElementById('first-visit-hint');
+  if (!hint || localStorage.getItem(HINT_DISMISSED_KEY) === 'true') return;
+  hint.hidden = false;
+  document.getElementById('hint-dismiss')?.addEventListener('click', () => dismissHint());
+}
 
 // ── Locale-filter notice ("N of M shown" banner + toggle) ───────────
 function updateLocaleNotice() {

--- a/viz/js/app.js
+++ b/viz/js/app.js
@@ -8,7 +8,8 @@
 import { initGraph, destroyGraph, focusNode, resetView, zoomIn, zoomOut, setSkillVisibility, getGraph, refreshGraph, preloadIcons, switchIconPalette, setVisibleAgents, setVisibleTeams, getVisibleAgentIds } from './graph.js';
 import { setIconMode, getIconMode, setHdMode, getHdMode } from './icons.js';
 import { initPanel, openPanel, closePanel, refreshPanelTheme } from './panel.js';
-import { initFilters, getVisibleSkillIds, getVisibleAgentIds as getFilteredAgentIds, getVisibleTeamIds as getFilteredTeamIds, refreshSwatches, setLocaleFilter } from './filters.js';
+import { initFilters, getVisibleSkillIds, getVisibleAgentIds as getFilteredAgentIds, getVisibleTeamIds as getFilteredTeamIds, refreshSwatches, setLocaleFilter, getLocaleFilterInfo, getShowUntranslated, setShowUntranslated } from './filters.js';
+import { CACHE_BUST } from './build-info.js';
 import { setTheme, getThemeNames, getCurrentThemeName } from './colors.js';
 import { logEvent, isEnabled as isEventLogEnabled, downloadLog } from './eventlog.js';
 import { t, initI18n, loadLocale, detectLocale, getSupportedLocales, getLocale, applyLocaleToDOM, onLocaleChange } from './i18n.js';
@@ -363,7 +364,7 @@ async function main() {
   showLoading(t('loading.data'));
   let data;
   try {
-    const res = await fetch(DATA_URL);
+    const res = await fetch(`${DATA_URL}?v=${CACHE_BUST}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     data = await res.json();
   } catch (err) {
@@ -456,6 +457,7 @@ async function main() {
       const visSkills = getVisibleSkillIds();
       activeMode.setSkillVisibility(visSkills);
       updateFilteredStats(visSkills);
+      updateLocaleNotice();
     },
   });
 
@@ -488,6 +490,7 @@ async function main() {
   }
 
   // Apply initial locale filter if non-English locale was restored
+  bindLocaleNotice();
   const initialLocale = getLocale();
   if (initialLocale !== 'en') {
     setLocaleFilter(initialLocale);
@@ -711,6 +714,41 @@ document.addEventListener('touchmove', e => {
 document.addEventListener('touchend', () => {
   if (tooltip) tooltip.style.display = 'none';
 }, { passive: true });
+
+// ── Locale-filter notice ("N of M shown" banner + toggle) ───────────
+function updateLocaleNotice() {
+  const notice = document.getElementById('locale-notice');
+  if (!notice) return;
+  const { locale, total, hiddenCount, showUntranslated } = getLocaleFilterInfo();
+
+  if (locale === 'en' || hiddenCount === 0) {
+    notice.hidden = true;
+    return;
+  }
+
+  const textEl = document.getElementById('locale-notice-text');
+  const toggleBtn = document.getElementById('locale-notice-toggle');
+  if (textEl) {
+    textEl.textContent = showUntranslated
+      ? t('localeNotice.showingAll', { total, hidden: hiddenCount })
+      : t('localeNotice.showing', { shown: total - hiddenCount, total, hidden: hiddenCount });
+  }
+  if (toggleBtn) {
+    toggleBtn.textContent = showUntranslated ? t('localeNotice.hideUntranslated') : t('localeNotice.showUntranslated');
+  }
+  notice.title = t('localeNotice.info');
+  notice.hidden = false;
+}
+
+function bindLocaleNotice() {
+  const toggleBtn = document.getElementById('locale-notice-toggle');
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
+      setShowUntranslated(!getShowUntranslated());
+    });
+  }
+  onLocaleChange(() => updateLocaleNotice());
+}
 
 function updateFilteredStats(visibleSkillIds) {
   if (!allData) return;

--- a/viz/js/build-info.js
+++ b/viz/js/build-info.js
@@ -1,0 +1,5 @@
+// build-info.js - Build metadata shared across modules
+// __BUILD_TIME__ is injected by vite (see vite.config.js define);
+// the typeof guard keeps non-vite contexts (tests, direct loads) working.
+
+export const CACHE_BUST = typeof __BUILD_TIME__ !== 'undefined' ? __BUILD_TIME__ : Date.now();

--- a/viz/js/filters.js
+++ b/viz/js/filters.js
@@ -36,6 +36,7 @@ let selectedLanguages = new Set();
 let onLocaleFilterChange = null;
 let nodeLocalesMap = {};    // nodeId -> Set<string> (locale codes)
 let activeLocale = 'en';   // current locale from the header dropdown
+let showUntranslated = localStorage.getItem('skillnet-show-untranslated') === 'true';
 
 /**
  * @param {HTMLElement} el - Filter panel element
@@ -269,8 +270,9 @@ function updateSkillsCount() {
   const el = filterEl.querySelector('#skills-section-count');
   if (!el) return;
 
+  // Same basis as the graph and header stats: checkboxes ∩ tag ∩ language ∩ locale ∩ search
   const total = Object.keys(skillStates).length;
-  const visible = Object.values(skillStates).filter(Boolean).length;
+  const visible = getVisibleSkillIds().length;
   el.textContent = visible < total ? `${visible}/${total}` : String(total);
 }
 
@@ -300,7 +302,7 @@ function renderAgents(agents) {
       <input type="checkbox" data-agent="${agent.id}" ${agentStates[agent.id] ? 'checked' : ''}>
       <span class="filter-swatch agent-oct" data-agent-id="${agentId}" style="background: ${color}"></span>
       <span class="filter-name">${agent.title || agent.id}</span>
-      <span class="filter-count">${agent.priority || ''}</span>
+      <span class="filter-count">${agent.priority ? t('priority.' + agent.priority) : ''}</span>
     `;
     list.appendChild(item);
 
@@ -453,6 +455,7 @@ function nodePassesTagFilter(nodeId) {
 
 function fireTagFilterChange() {
   logEvent('filters', { event: 'tagFilterChange', selectedTags: [...selectedTags], tagCount: selectedTags.size });
+  updateSkillsCount();
   if (onTagChange) onTagChange();
 }
 
@@ -581,6 +584,7 @@ function restoreLanguageSelection() {
 
 function fireLanguageFilterChange() {
   logEvent('filters', { event: 'languageFilterChange', selectedLanguages: [...selectedLanguages], count: selectedLanguages.size });
+  updateSkillsCount();
   if (onLanguageChange) onLanguageChange();
 }
 
@@ -602,12 +606,39 @@ function buildLocaleIndex(allNodes) {
 export function setLocaleFilter(localeCode) {
   activeLocale = localeCode;
   logEvent('filters', { event: 'localeFilterChange', locale: localeCode });
+  updateSkillsCount();
   if (onLocaleFilterChange) onLocaleFilterChange();
 }
 
 function nodePassesLocaleFilter(nodeId) {
-  if (activeLocale === 'en') return true;
+  if (activeLocale === 'en' || showUntranslated) return true;
   return nodeLocalesMap[nodeId]?.has(activeLocale) ?? false;
+}
+
+/** Toggle whether untranslated skills stay visible under a non-English locale. */
+export function setShowUntranslated(value) {
+  showUntranslated = !!value;
+  localStorage.setItem('skillnet-show-untranslated', String(showUntranslated));
+  logEvent('filters', { event: 'showUntranslatedToggle', enabled: showUntranslated });
+  updateSkillsCount();
+  if (onLocaleFilterChange) onLocaleFilterChange();
+}
+
+export function getShowUntranslated() {
+  return showUntranslated;
+}
+
+/**
+ * Locale-filter summary for the header notice.
+ * hiddenCount counts skills lacking the active locale regardless of the
+ * show-untranslated toggle, so the notice can report what the filter affects.
+ */
+export function getLocaleFilterInfo() {
+  const skillIds = Object.keys(skillStates);
+  const total = skillIds.length;
+  if (activeLocale === 'en') return { locale: activeLocale, total, hiddenCount: 0, showUntranslated };
+  const hiddenCount = skillIds.filter(id => !(nodeLocalesMap[id]?.has(activeLocale))).length;
+  return { locale: activeLocale, total, hiddenCount, showUntranslated };
 }
 
 // ── Section collapse / expand ────────────────────────────────────

--- a/viz/js/filters.js
+++ b/viz/js/filters.js
@@ -21,6 +21,11 @@ let onAgentChange = null;
 let onTeamChange = null;
 let onTagChange = null;
 
+// Search state (filters both the sidebar list and the graph)
+let searchQuery = '';
+let nodeSearchText = {};    // nodeId -> lowercase "title domain id" haystack
+let searchDebounceTimer = null;
+
 // Tag filter state
 let nodeTagsMap = {};       // nodeId -> Set<string> (lowercase tags)
 let allTags = [];           // sorted array of { tag, count }
@@ -56,6 +61,13 @@ export function initFilters(el, skillNodes, agents, teams, { onFilterChange, onA
 
   // Build locale index from node data
   buildLocaleIndex([...skillNodes, ...agents, ...teams]);
+
+  // Build search haystacks (same match semantics as the sidebar list:
+  // a skill matches if its name or its domain name contains the query)
+  nodeSearchText = {};
+  for (const node of skillNodes) {
+    nodeSearchText[node.id] = `${node.title || ''} ${node.domain || ''} ${node.id}`.toLowerCase();
+  }
 
   // Build domain -> skills lookup
   skillsByDomain = {};
@@ -125,8 +137,24 @@ function renderSearchBox() {
 
   list.parentNode.insertBefore(input, list);
 
+  // Empty-state message (shown when zero rows match)
+  const existingEmpty = filterEl.querySelector('.filter-empty-state');
+  if (existingEmpty) existingEmpty.remove();
+  const emptyEl = document.createElement('div');
+  emptyEl.className = 'filter-empty-state hidden';
+  list.parentNode.insertBefore(emptyEl, list);
+
   input.addEventListener('input', () => {
-    applySearch(input.value.trim().toLowerCase());
+    const query = input.value.trim().toLowerCase();
+    applySearch(query);
+    // Debounced: propagate the search to the graph + counts
+    clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = setTimeout(() => {
+      if (query === searchQuery) return;
+      searchQuery = query;
+      logEvent('filters', { event: 'searchChange', queryLength: query.length });
+      fireSkillChange();
+    }, 250);
   });
 }
 
@@ -135,6 +163,7 @@ function applySearch(query) {
   if (!list) return;
 
   const groups = list.querySelectorAll('.filter-domain-group');
+  let anyMatch = false;
 
   for (const group of groups) {
     const domain = group.dataset.domain;
@@ -151,6 +180,7 @@ function applySearch(query) {
     // Domain matches if its name matches or any child skill matches
     const domainName = domain.toLowerCase();
     const domainMatches = !query || domainName.includes(query) || visibleCount > 0;
+    if (domainMatches) anyMatch = true;
 
     group.classList.toggle('hidden', !domainMatches);
 
@@ -164,6 +194,17 @@ function applySearch(query) {
     } else if (!query) {
       // Restore collapsed state when clearing search
       group.classList.toggle('expanded', domainExpanded[domain] || false);
+    }
+  }
+
+  // Empty state when nothing matches
+  const emptyEl = filterEl.querySelector('.filter-empty-state');
+  if (emptyEl) {
+    if (query && !anyMatch) {
+      emptyEl.textContent = t('filter.noResults', { query });
+      emptyEl.classList.remove('hidden');
+    } else {
+      emptyEl.classList.add('hidden');
     }
   }
 }
@@ -838,9 +879,14 @@ function fireAgentChange() {
 
 // ── Public getters ───────────────────────────────────────────────
 
+function nodePassesSearch(nodeId) {
+  if (!searchQuery) return true;
+  return nodeSearchText[nodeId]?.includes(searchQuery) ?? false;
+}
+
 export function getVisibleSkillIds() {
   return Object.entries(skillStates)
-    .filter(([id, v]) => v && nodePassesTagFilter(id) && nodePassesLanguageFilter(id) && nodePassesLocaleFilter(id))
+    .filter(([id, v]) => v && nodePassesTagFilter(id) && nodePassesLanguageFilter(id) && nodePassesLocaleFilter(id) && nodePassesSearch(id))
     .map(([k]) => k);
 }
 

--- a/viz/js/filters.js
+++ b/viz/js/filters.js
@@ -62,8 +62,10 @@ export function initFilters(el, skillNodes, agents, teams, { onFilterChange, onA
   // Build locale index from node data
   buildLocaleIndex([...skillNodes, ...agents, ...teams]);
 
-  // Build search haystacks (same match semantics as the sidebar list:
-  // a skill matches if its name or its domain name contains the query)
+  // Build search haystacks. matchesQuery() below is the single match predicate
+  // for BOTH the sidebar list and the graph — keeping two copies is what let
+  // them diverge (graph matched on id, list did not, so an id query could show
+  // a node and "No skills match" at the same time).
   nodeSearchText = {};
   for (const node of skillNodes) {
     nodeSearchText[node.id] = `${node.title || ''} ${node.domain || ''} ${node.id}`.toLowerCase();
@@ -158,6 +160,18 @@ function renderSearchBox() {
   });
 }
 
+/**
+ * The one match predicate shared by the sidebar list and the graph.
+ * A skill matches its title, its domain name, or its id (ids are the canonical
+ * identifier used across the registry, paths, and CLI, so `create-r-package` is
+ * a natural query even though the row renders "Create R Package").
+ */
+function matchesQuery(skillId, query) {
+  if (!query) return true;
+  if (!skillId) return false;
+  return nodeSearchText[skillId]?.includes(query) ?? false;
+}
+
 function applySearch(query) {
   const list = filterEl.querySelector('#skills-filter-list');
   if (!list) return;
@@ -171,8 +185,8 @@ function applySearch(query) {
     let visibleCount = 0;
 
     for (const item of skillItems) {
-      const name = item.querySelector('.filter-skill-name')?.textContent.toLowerCase() || '';
-      const matches = !query || name.includes(query);
+      const skillId = item.querySelector('input')?.dataset.skill;
+      const matches = matchesQuery(skillId, query);
       item.classList.toggle('hidden', !matches);
       if (matches) visibleCount++;
     }
@@ -184,12 +198,10 @@ function applySearch(query) {
 
     group.classList.toggle('hidden', !domainMatches);
 
-    // If searching and there are matches, show all skills in the domain and auto-expand
+    // If searching and there are matches, auto-expand the domain.
+    // A domain-name match needs no special case: the haystack contains the
+    // domain, so every skill in it already matched above.
     if (query && domainMatches) {
-      if (domainName.includes(query)) {
-        // Domain name matches: show all skills
-        for (const item of skillItems) item.classList.remove('hidden');
-      }
       group.classList.add('expanded');
     } else if (!query) {
       // Restore collapsed state when clearing search
@@ -673,6 +685,11 @@ export function getShowUntranslated() {
  * Locale-filter summary for the header notice.
  * hiddenCount counts skills lacking the active locale regardless of the
  * show-untranslated toggle, so the notice can report what the filter affects.
+ *
+ * Deliberately locale-scoped, NOT the post-all-filters count: the notice
+ * explains one filter, so its numbers stay stable while the user works the tag,
+ * language, and search filters. It therefore can read "Showing 200 of 369"
+ * while the header stat reads 150 — the header is the all-filters number.
  */
 export function getLocaleFilterInfo() {
   const skillIds = Object.keys(skillStates);
@@ -888,8 +905,7 @@ function fireAgentChange() {
 // ── Public getters ───────────────────────────────────────────────
 
 function nodePassesSearch(nodeId) {
-  if (!searchQuery) return true;
-  return nodeSearchText[nodeId]?.includes(searchQuery) ?? false;
+  return matchesQuery(nodeId, searchQuery);
 }
 
 export function getVisibleSkillIds() {

--- a/viz/js/filters.js
+++ b/viz/js/filters.js
@@ -763,6 +763,14 @@ function bindPanelToggle() {
   const toggle = document.getElementById('panel-toggle');
   if (!toggle) return;
 
+  // On phone widths the panel starts off-canvas via CSS; sync the toggle
+  // state so the first tap opens (not "closes") and the label is visible.
+  if (window.innerWidth <= 768) {
+    filterEl.classList.add('collapsed');
+    toggle.classList.add('collapsed');
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+
   // ── Backdrop overlay ────────────────────────────
   let backdropEl = null;
 

--- a/viz/js/graph.js
+++ b/viz/js/graph.js
@@ -30,6 +30,48 @@ let cachedFontScale = 0;
 let cachedFontBold = '';
 let cachedFontNormal = '';
 
+// ── Core component (for outlier-free zoomToFit) ──────────────────
+let coreNodeIds = null; // Set of largest-connected-component ids (null = fit all)
+
+function computeCoreComponent() {
+  const neighbor = new Map();
+  for (const link of graphData.links) {
+    const src = resolveNodeId(link.source);
+    const tgt = resolveNodeId(link.target);
+    if (!neighbor.has(src)) neighbor.set(src, []);
+    if (!neighbor.has(tgt)) neighbor.set(tgt, []);
+    neighbor.get(src).push(tgt);
+    neighbor.get(tgt).push(src);
+  }
+  const seen = new Set();
+  let largest = null;
+  for (const node of graphData.nodes) {
+    if (seen.has(node.id)) continue;
+    const component = [];
+    const queue = [node.id];
+    seen.add(node.id);
+    while (queue.length) {
+      const id = queue.pop();
+      component.push(id);
+      for (const nb of neighbor.get(id) || []) {
+        if (!seen.has(nb)) { seen.add(nb); queue.push(nb); }
+      }
+    }
+    if (!largest || component.length > largest.length) largest = component;
+  }
+  // Only clip outliers when a clearly dominant core exists
+  coreNodeIds = largest && largest.length >= graphData.nodes.length * 0.5
+    ? new Set(largest)
+    : null;
+}
+
+/** zoomToFit on the dominant connected component, letting outlier clusters clip. */
+export function zoomToFitCore(ms = 600, padding = 40) {
+  if (!graph) return;
+  if (coreNodeIds) graph.zoomToFit(ms, padding, node => coreNodeIds.has(node.id));
+  else graph.zoomToFit(ms, padding);
+}
+
 // ── Pre-computed adjacency map ───────────────────────────────────
 let adjacencyMap = new Map(); // nodeId -> { skills: Set, agents: Set, teams: Set }
 
@@ -223,6 +265,7 @@ export function initGraph(container, data, { onClick, onHover } = {}) {
   onNodeHover = onHover;
   rebuildNodeIndex();
   buildAdjacencyMap(graphData.links);
+  computeCoreComponent();
   precomputeLinkColors();
 
   graph = ForceGraph()(container)
@@ -310,6 +353,7 @@ export function destroyGraph() {
   selectedNodeId = null;
   hoveredNodeId = null;
   highlightedNodeIds = null;
+  coreNodeIds = null;
   nodeById = new Map();
   adjacencyMap.clear();
   glowCache.clear();
@@ -580,7 +624,10 @@ function drawNode(node, ctx, globalScale) {
   });
 }
 
-function drawHitArea(node, color, ctx) {
+// Minimum screen-space hit radius (CSS px) so clicks land at any zoom level
+const MIN_HIT_RADIUS_PX = 10;
+
+function drawHitArea(node, color, ctx, globalScale) {
   if (!isFinite(node.x) || !isFinite(node.y)) return;
   let r;
   if (node.type === 'team') {
@@ -593,8 +640,9 @@ function drawHitArea(node, color, ctx) {
     const featured = FEATURED_NODES[node.id];
     r = featured ? featured.radius : cfg.radius;
   }
+  const minScreenR = globalScale > 0 ? MIN_HIT_RADIUS_PX / globalScale : 8;
   ctx.beginPath();
-  ctx.arc(node.x, node.y, Math.max(r + 4, 8), 0, 2 * Math.PI);
+  ctx.arc(node.x, node.y, Math.max(r + 4, 8, minScreenR), 0, 2 * Math.PI);
   ctx.fillStyle = color;
   ctx.fill();
 }
@@ -671,7 +719,7 @@ export function focusNode(id) {
 export function resetView() {
   logEvent('graph', { event: 'resetView' });
   clearSelection();
-  if (graph) graph.zoomToFit(600, 40);
+  zoomToFitCore(600, 40);
 }
 
 export function zoomIn() {
@@ -718,11 +766,12 @@ export function setSkillVisibility(visibleSkillIds) {
   graphData = { nodes: filteredNodes, links: filteredLinks };
   rebuildNodeIndex();
   buildAdjacencyMap(graphData.links);
+  computeCoreComponent();
   precomputeLinkColors();
 
   if (graph) {
     graph.graphData(graphData);
-    setTimeout(() => graph.zoomToFit(400, 40), 500);
+    setTimeout(() => zoomToFitCore(400, 40), 500);
   }
 }
 

--- a/viz/js/i18n.js
+++ b/viz/js/i18n.js
@@ -23,7 +23,8 @@ const SUPPORTED_LOCALES = [
 
 const LOCALE_CODES = new Set(SUPPORTED_LOCALES.map(l => l.code));
 
-// Cache-bust parameter — build timestamp in production, epoch in dev
+// Cache-bust parameter — the vite-injected build timestamp (dev server included);
+// the Date.now() fallback in build-info.js only applies outside vite.
 const __cacheBust = CACHE_BUST;
 
 // ── Flatten nested JSON to dot-separated keys ──────────────────────

--- a/viz/js/i18n.js
+++ b/viz/js/i18n.js
@@ -6,6 +6,8 @@
  * Fallback chain: current locale → English → raw key.
  */
 
+import { CACHE_BUST } from './build-info.js';
+
 let currentLocale = 'en';
 let strings = {};       // current locale strings (flat: "header.skills" → "skills")
 let enStrings = {};     // English fallback (always loaded)
@@ -22,7 +24,7 @@ const SUPPORTED_LOCALES = [
 const LOCALE_CODES = new Set(SUPPORTED_LOCALES.map(l => l.code));
 
 // Cache-bust parameter — build timestamp in production, epoch in dev
-const __cacheBust = typeof __BUILD_TIME__ !== 'undefined' ? __BUILD_TIME__ : Date.now();
+const __cacheBust = CACHE_BUST;
 
 // ── Flatten nested JSON to dot-separated keys ──────────────────────
 

--- a/viz/js/panel.js
+++ b/viz/js/panel.js
@@ -250,7 +250,7 @@ function openAgentPanel(node) {
     <h2 class="panel-title" style="color: ${color}; text-shadow: 0 0 12px ${color}">${escHtml(node.title || node.id)}</h2>
     <div class="panel-badges">
       <span class="badge" style="border-color: ${color}; color: ${color}">${t('panel.badgeAgent')}</span>
-      <span class="badge" style="border-color: ${priorityColor}; color: ${priorityColor}">${escHtml(node.priority)}</span>
+      <span class="badge" style="border-color: ${priorityColor}; color: ${priorityColor}">${escHtml(node.priority ? t('priority.' + node.priority) : '')}</span>
     </div>
     <p class="panel-desc">${escHtml(node.description)}</p>
   `;

--- a/viz/public/locales/de.json
+++ b/viz/public/locales/de.json
@@ -20,6 +20,7 @@
     "clear": "Löschen",
     "searchPlaceholder": "Skills suchen\u2026",
     "searchAriaLabel": "Skills suchen",
+    "noResults": "Keine Skills passen zu „{query}“",
     "selected": "{count} ausgewählt",
     "members": "{count} Mitglieder",
     "bulkSkills": "Massenaktionen für Skills",

--- a/viz/public/locales/de.json
+++ b/viz/public/locales/de.json
@@ -37,7 +37,8 @@
     "languages": "Sprachen",
     "bulkLanguages": "Massenaktionen für Sprachen",
     "clearAllLanguages": "Alle Sprachen löschen",
-    "togglePanel": "Filterpanel ein-/ausblenden"
+    "togglePanel": "Filterpanel ein-/ausblenden",
+    "filtersLabel": "Filter"
   },
   "controls": {
     "colorTheme": "Farbschema",

--- a/viz/public/locales/de.json
+++ b/viz/public/locales/de.json
@@ -130,5 +130,17 @@
     "fireGoesOut": "Das Feuer erlischt.",
     "practicesTotal": "{count} Praktiken insgesamt",
     "hearthKeeper": "Herdhüter"
+  },
+  "localeNotice": {
+    "showing": "{shown} von {total} Skills angezeigt — {hidden} noch nicht übersetzt",
+    "showingAll": "Alle {total} Skills angezeigt — {hidden} noch nicht übersetzt",
+    "showUntranslated": "Unübersetzte anzeigen",
+    "hideUntranslated": "Unübersetzte ausblenden",
+    "info": "Skills ohne Übersetzung in der gewählten Sprache werden standardmäßig ausgeblendet."
+  },
+  "priority": {
+    "critical": "kritisch",
+    "high": "hoch",
+    "normal": "normal"
   }
 }

--- a/viz/public/locales/de.json
+++ b/viz/public/locales/de.json
@@ -131,6 +131,13 @@
     "practicesTotal": "{count} Praktiken insgesamt",
     "hearthKeeper": "Herdhüter"
   },
+  "hint": {
+    "text": "Klicken Sie auf einen Knoten, um Details zu sehen — Ziehen zum Verschieben, Scrollen zum Zoomen.",
+    "legendSkill": "Skill",
+    "legendAgent": "Agent",
+    "legendTeam": "Team",
+    "dismiss": "Verstanden"
+  },
   "localeNotice": {
     "showing": "{shown} von {total} Skills angezeigt — {hidden} noch nicht übersetzt",
     "showingAll": "Alle {total} Skills angezeigt — {hidden} noch nicht übersetzt",

--- a/viz/public/locales/en.json
+++ b/viz/public/locales/en.json
@@ -37,7 +37,8 @@
     "languages": "Languages",
     "bulkLanguages": "Bulk actions for Languages",
     "clearAllLanguages": "Clear all languages",
-    "togglePanel": "Toggle filter panel"
+    "togglePanel": "Toggle filter panel",
+    "filtersLabel": "Filters"
   },
   "controls": {
     "colorTheme": "Color Theme",

--- a/viz/public/locales/en.json
+++ b/viz/public/locales/en.json
@@ -150,6 +150,13 @@
     "patternSynoptic": "Synoptic",
     "moreSkills": "+{count} more"
   },
+  "hint": {
+    "text": "Click any node to explore it — drag to pan, scroll to zoom.",
+    "legendSkill": "Skill",
+    "legendAgent": "Agent",
+    "legendTeam": "Team",
+    "dismiss": "Got it"
+  },
   "localeNotice": {
     "showing": "Showing {shown} of {total} skills — {hidden} not yet translated",
     "showingAll": "Showing all {total} skills — {hidden} not yet translated",

--- a/viz/public/locales/en.json
+++ b/viz/public/locales/en.json
@@ -20,6 +20,7 @@
     "clear": "Clear",
     "searchPlaceholder": "Search skills\u2026",
     "searchAriaLabel": "Search skills",
+    "noResults": "No skills match \u201c{query}\u201d",
     "selected": "{count} selected",
     "members": "{count} members",
     "bulkSkills": "Bulk actions for Skills",

--- a/viz/public/locales/en.json
+++ b/viz/public/locales/en.json
@@ -149,5 +149,17 @@
     "patternWaveParallel": "Wave-parallel",
     "patternSynoptic": "Synoptic",
     "moreSkills": "+{count} more"
+  },
+  "localeNotice": {
+    "showing": "Showing {shown} of {total} skills — {hidden} not yet translated",
+    "showingAll": "Showing all {total} skills — {hidden} not yet translated",
+    "showUntranslated": "Show untranslated",
+    "hideUntranslated": "Hide untranslated",
+    "info": "Skills without a translation in the selected language are hidden by default."
+  },
+  "priority": {
+    "critical": "critical",
+    "high": "high",
+    "normal": "normal"
   }
 }

--- a/viz/public/locales/es.json
+++ b/viz/public/locales/es.json
@@ -20,6 +20,7 @@
     "clear": "Limpiar",
     "searchPlaceholder": "Buscar habilidades\u2026",
     "searchAriaLabel": "Buscar habilidades",
+    "noResults": "Ninguna habilidad coincide con «{query}»",
     "selected": "{count} seleccionados",
     "members": "{count} miembros",
     "bulkSkills": "Acciones masivas para Habilidades",

--- a/viz/public/locales/es.json
+++ b/viz/public/locales/es.json
@@ -131,6 +131,13 @@
     "practicesTotal": "{count} prácticas en total",
     "hearthKeeper": "guardián del hogar"
   },
+  "hint": {
+    "text": "Haz clic en cualquier nodo para explorarlo — arrastra para desplazarte, usa la rueda para hacer zoom.",
+    "legendSkill": "Habilidad",
+    "legendAgent": "Agente",
+    "legendTeam": "Equipo",
+    "dismiss": "Entendido"
+  },
   "localeNotice": {
     "showing": "Mostrando {shown} de {total} habilidades — {hidden} sin traducir",
     "showingAll": "Mostrando las {total} habilidades — {hidden} sin traducir",

--- a/viz/public/locales/es.json
+++ b/viz/public/locales/es.json
@@ -130,5 +130,17 @@
     "fireGoesOut": "El fuego se apaga.",
     "practicesTotal": "{count} prácticas en total",
     "hearthKeeper": "guardián del hogar"
+  },
+  "localeNotice": {
+    "showing": "Mostrando {shown} de {total} habilidades — {hidden} sin traducir",
+    "showingAll": "Mostrando las {total} habilidades — {hidden} sin traducir",
+    "showUntranslated": "Mostrar sin traducir",
+    "hideUntranslated": "Ocultar sin traducir",
+    "info": "Las habilidades sin traducción en el idioma seleccionado se ocultan por defecto."
+  },
+  "priority": {
+    "critical": "crítica",
+    "high": "alta",
+    "normal": "normal"
   }
 }

--- a/viz/public/locales/es.json
+++ b/viz/public/locales/es.json
@@ -37,7 +37,8 @@
     "languages": "Idiomas",
     "bulkLanguages": "Acciones masivas para Idiomas",
     "clearAllLanguages": "Limpiar todos los idiomas",
-    "togglePanel": "Mostrar/ocultar panel de filtros"
+    "togglePanel": "Mostrar/ocultar panel de filtros",
+    "filtersLabel": "Filtros"
   },
   "controls": {
     "colorTheme": "Tema de color",

--- a/viz/public/locales/ja.json
+++ b/viz/public/locales/ja.json
@@ -131,6 +131,13 @@
     "practicesTotal": "合計 {count} の実践",
     "hearthKeeper": "炉守り"
   },
+  "hint": {
+    "text": "ノードをクリックすると詳細が表示されます — ドラッグで移動、スクロールでズーム。",
+    "legendSkill": "スキル",
+    "legendAgent": "エージェント",
+    "legendTeam": "チーム",
+    "dismiss": "わかった"
+  },
   "localeNotice": {
     "showing": "{total} 件中 {shown} 件のスキルを表示中 — {hidden} 件は未翻訳",
     "showingAll": "全 {total} 件のスキルを表示中 — {hidden} 件は未翻訳",

--- a/viz/public/locales/ja.json
+++ b/viz/public/locales/ja.json
@@ -130,5 +130,17 @@
     "fireGoesOut": "火が消えた。",
     "practicesTotal": "合計 {count} の実践",
     "hearthKeeper": "炉守り"
+  },
+  "localeNotice": {
+    "showing": "{total} 件中 {shown} 件のスキルを表示中 — {hidden} 件は未翻訳",
+    "showingAll": "全 {total} 件のスキルを表示中 — {hidden} 件は未翻訳",
+    "showUntranslated": "未翻訳を表示",
+    "hideUntranslated": "未翻訳を非表示",
+    "info": "選択した言語に翻訳されていないスキルは、デフォルトで非表示になります。"
+  },
+  "priority": {
+    "critical": "重要",
+    "high": "高",
+    "normal": "通常"
   }
 }

--- a/viz/public/locales/ja.json
+++ b/viz/public/locales/ja.json
@@ -37,7 +37,8 @@
     "languages": "言語",
     "bulkLanguages": "言語の一括操作",
     "clearAllLanguages": "すべての言語をクリア",
-    "togglePanel": "フィルターパネルの切り替え"
+    "togglePanel": "フィルターパネルの切り替え",
+    "filtersLabel": "フィルター"
   },
   "controls": {
     "colorTheme": "カラーテーマ",

--- a/viz/public/locales/ja.json
+++ b/viz/public/locales/ja.json
@@ -20,6 +20,7 @@
     "clear": "クリア",
     "searchPlaceholder": "スキルを検索\u2026",
     "searchAriaLabel": "スキルを検索",
+    "noResults": "「{query}」に一致するスキルはありません",
     "selected": "{count} 件選択中",
     "members": "{count} 人のメンバー",
     "bulkSkills": "スキルの一括操作",

--- a/viz/public/locales/zh-CN.json
+++ b/viz/public/locales/zh-CN.json
@@ -20,6 +20,7 @@
     "clear": "清除",
     "searchPlaceholder": "搜索技能\u2026",
     "searchAriaLabel": "搜索技能",
+    "noResults": "没有技能匹配“{query}”",
     "selected": "已选择 {count} 项",
     "members": "{count} 名成员",
     "bulkSkills": "技能批量操作",

--- a/viz/public/locales/zh-CN.json
+++ b/viz/public/locales/zh-CN.json
@@ -131,6 +131,13 @@
     "practicesTotal": "共 {count} 个实践",
     "hearthKeeper": "连接者"
   },
+  "hint": {
+    "text": "点击任意节点查看详情 — 拖动平移，滚动缩放。",
+    "legendSkill": "技能",
+    "legendAgent": "代理",
+    "legendTeam": "团队",
+    "dismiss": "知道了"
+  },
   "localeNotice": {
     "showing": "显示 {shown} / {total} 个技能 — {hidden} 个尚未翻译",
     "showingAll": "显示全部 {total} 个技能 — {hidden} 个尚未翻译",

--- a/viz/public/locales/zh-CN.json
+++ b/viz/public/locales/zh-CN.json
@@ -37,7 +37,8 @@
     "languages": "语言",
     "bulkLanguages": "语言批量操作",
     "clearAllLanguages": "清除所有语言",
-    "togglePanel": "切换筛选面板"
+    "togglePanel": "切换筛选面板",
+    "filtersLabel": "筛选"
   },
   "controls": {
     "colorTheme": "配色方案",

--- a/viz/public/locales/zh-CN.json
+++ b/viz/public/locales/zh-CN.json
@@ -130,5 +130,17 @@
     "fireGoesOut": "火已熄灭。",
     "practicesTotal": "共 {count} 个实践",
     "hearthKeeper": "连接者"
+  },
+  "localeNotice": {
+    "showing": "显示 {shown} / {total} 个技能 — {hidden} 个尚未翻译",
+    "showingAll": "显示全部 {total} 个技能 — {hidden} 个尚未翻译",
+    "showUntranslated": "显示未翻译",
+    "hideUntranslated": "隐藏未翻译",
+    "info": "所选语言中没有翻译的技能默认隐藏。"
+  },
+  "priority": {
+    "critical": "关键",
+    "high": "高",
+    "normal": "普通"
   }
 }

--- a/viz/vite.config.js
+++ b/viz/vite.config.js
@@ -3,6 +3,10 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   base: '/agent-almanac/',
   publicDir: 'public',
+  define: {
+    // Stable per-build cache-bust token shared by locale + data fetches
+    __BUILD_TIME__: JSON.stringify(String(Date.now())),
+  },
   resolve: {
     dedupe: ['three'],
   },


### PR DESCRIPTION
## Summary

Implements the four self-contained quick wins from the 2026-07-22 adversarially-verified UX review, one commit per issue.

### #391 — locale auto-filter transparency
- **"N of M shown" notice** (localized, `role="status"`) whenever a non-English locale hides untranslated skills, with a **Show/Hide untranslated** toggle (persisted in localStorage). Per product decision: hiding remains the default; the banner + info tooltip make it visible and reversible.
- **Shared count basis**: the sidebar Skills count now uses the same predicate chain as the graph and header stats (checkboxes ∩ tag ∩ language ∩ locale ∩ search); tag/language/locale changes refresh it. No more 365-vs-368-vs-369 self-contradiction.
- **Cache-buster**: `skills.json` fetch now carries `?v=__BUILD_TIME__` — and `__BUILD_TIME__` is now actually defined in `vite.config.js` (it never was; the locale fetches were silently falling back to per-load `Date.now()`, defeating HTTP caching entirely). New shared `js/build-info.js` module.
- **Priority enums** (`critical/high/normal`) pass through `t()` in the agent list and detail panel; keys added to all 5 UI locales.

### #392 — default view reveals its interactivity
- Minimum **20px screen-space hit target** (10px radius) in `nodePointerAreaPaint`, independent of zoom.
- **Dismissible first-visit hint + shape legend** (circle=skill, octagon=agent, pentagon=team), localized, auto-dismissed once the user opens a node panel, persisted.
- **Core-fit zoom**: default/Reset `zoomToFit` fits the dominant connected component (≥50% of nodes) and lets outlier clusters clip; falls back to fit-all when no dominant core exists.

### #393 — search reaches the graph
- Search is now a first-class filter dimension: debounced (250ms) into `getVisibleSkillIds()`, so the graph, header stats, and the `aria-live` sidebar count all react on the shared basis. Match semantics mirror the list (skill name or domain name).
- Localized **empty-state message** when zero rows match (previously the section silently collapsed and the agent list backfilled).

### #395 — header controls reachable everywhere
- New 769–1250px media query: the control row becomes a horizontally scrollable flex item (`min-width: 0` + `overflow-x: auto`, thin scrollbar) — Reset and all six mode buttons stay reachable.
- Phone widths: filter toggle is now a labeled accent pill ("Filters", localized). Also fixes a latent state bug: the panel starts off-canvas via CSS but the toggle started uncollapsed, so the first tap was a no-op; initial state is now synced.

## Verification

- `node --check` clean on all edited modules; all 5 locale JSONs parse.
- `vite build` green locally.
- Counts/behavior verified against AC lists in #391/#392/#393/#395.

Closes #392. Closes #393. Closes #395. Closes #391 (all four ACs; the deploy-staleness sibling remains #363).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jDb5BjxdjNi7xL34YfgiM
