### PR TITLE
skills(#382): one-time pitfall-eviction pass on the >=9 tail — 24 skills to the 6 cap

### DIFF
--- a/skills/assess-github-repo-security/SKILL.md
+++ b/skills/assess-github-repo-security/SKILL.md
@@ -15,7 +15,7 @@ license: MIT
 allowed-tools: Read Bash Grep
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: git
   complexity: intermediate
   language: multi
@@ -348,17 +348,6 @@ absence of the control).
   needs `security_events`; rulesets and Actions permissions need admin. A
   403 is "not assessed", not a GAP — recording it as a gap fabricates a
   finding.
-- **A green check that is not REQUIRED is advisory only**: A CI job that
-  runs and passes gates nothing unless its context is in the ruleset's
-  `required_status_checks`. Do not report a running check as a protective
-  control.
-- **Alerts != fixes**: Dependabot **alerts** (`vulnerability-alerts`, 204)
-  only detect; **security updates** (`automated-security-fixes`) open the
-  fix PRs. Enabling one does not enable the other — assess both.
-- **Treating paid-feature absence as a gap on a public repo**: Secret
-  scanning, push protection, CodeQL, and dependency review are free on
-  public repos; GHAS / Secret Protection / Code Security are private/org
-  products. Their absence on a public repo is N/A, not a gap.
 - **Misreading the auto-commit-bot bypass**: The default `GITHUB_TOKEN` /
   `github-actions[bot]` can never be a ruleset bypass actor. If a repo
   auto-commits to a branch that has `required_status_checks` or a
@@ -368,10 +357,6 @@ absence of the control).
   is the repo default; per-job `permissions:` in the workflow YAML can
   raise or drop it for same-repo events. The API cannot show the effective
   per-workflow grant — note that limitation.
-- **Probing SECURITY.md at only one path**: GitHub auto-detects the policy
-  at the repo root, `docs/`, OR `.github/`. Checking only one path and
-  recording a 404 as a GAP fabricates a finding — a repo with SECURITY.md
-  at root is fully compliant. Only record a GAP if all three 404.
 - **Inferring CodeQL from `security_and_analysis`**: that object carries
   `secret_scanning*`, `dependabot_security_updates`, and `advanced_security`
   — but **no** code-scanning field. CodeQL default-setup state comes only

--- a/skills/build-feature-store/SKILL.md
+++ b/skills/build-feature-store/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: mlops
   complexity: advanced
   language: multi
@@ -219,7 +219,7 @@ def validate_point_in_time_correctness(training_df, entity_df):
 
 **Expected:** Historical features retrieved successfully, entity_df timestamps preserved, no NaN values for materialized features, point-in-time correctness guaranteed (no future data leakage), feature service groups features logically.
 
-**On failure:** Check entity_df has required columns (entity names + event_timestamp), verify feature view names match registry, ensure offline store has data for requested time range, check for timezone mismatches (use UTC), verify entity IDs exist in source data, inspect logs for SQL query errors, validate feature view TTL covers requested time range.
+**On failure:** Check entity_df has required columns (entity names + event_timestamp), verify feature view names match registry, ensure offline store has data for requested time range, check for timezone mismatches (mixed timezones do NOT raise an error — they silently produce incorrect point-in-time joins; use UTC everywhere), verify entity IDs exist in source data, inspect logs for SQL query errors, validate feature view TTL covers requested time range.
 
 ### Step 6: Serve Features for Real-Time Inference
 
@@ -253,7 +253,7 @@ fs = FeatureStore(repo_path=".")
 
 **Expected:** Online features retrieved in <10ms for single entity, batch retrieval scales efficiently, on-demand transformations execute correctly, request-time features merged with batch features, API responds quickly (<50ms end-to-end).
 
-**On failure:** Check online store populated (run materialize if empty), verify Redis/DynamoDB connectivity and latency, ensure entity keys exist in online store, check for cold start issues (warm up cache), verify on-demand transformation logic, monitor online store memory/CPU usage, check network latency between service and online store.
+**On failure:** Check online store populated (run materialize if empty), verify Redis/DynamoDB connectivity and latency, ensure entity keys exist in online store (missing keys return None values, NOT an error — handle them gracefully in serving code), check for cold start issues (warm up cache), verify on-demand transformation logic, monitor online store memory/CPU usage, check network latency between service and online store.
 
 ## Validation
 
@@ -274,13 +274,9 @@ fs = FeatureStore(repo_path=".")
 - **Feature leakage**: Using future data in historical features - always validate point-in-time correctness, use created_timestamp column
 - **Inconsistent transformations**: Different logic for training vs serving - use Feast on-demand views for consistency
 - **Stale features**: Online store not materialized regularly - set up scheduled materialization jobs (cron/Airflow)
-- **Missing entity keys**: Entities in training set not in online store - ensure comprehensive materialization, handle missing keys gracefully
-- **Type mismatches**: Schema types don't match source data - validate dtypes before apply, use explicit Field definitions
 - **Slow online retrieval**: Network latency or overloaded online store - co-locate feature store with inference service, use connection pooling
 - **Large feature views**: Materializing millions of entities is slow - partition by date, use incremental materialization, optimize offline queries
 - **No feature versioning**: Breaking changes affect production models - version feature views, maintain backward compatibility
-- **Timezone confusion**: Mixing timezones causes incorrect joins - always use UTC for timestamps
-- **Ignoring TTL**: Serving expired features - set appropriate TTL values, monitor feature freshness
 
 ## Related Skills
 

--- a/skills/circuit-breaker-pattern/SKILL.md
+++ b/skills/circuit-breaker-pattern/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.1"
+  version: "1.2"
   domain: general
   complexity: intermediate
   language: multi
@@ -440,10 +440,7 @@ Pre-call checks are advisory, not authoritative. A tool that passes pre-call che
 
 ## Common Pitfalls
 
-- **Retrying instead of circuit-breaking**: Calling a broken tool repeatedly wastes the failure budget and context window. Three consecutive failures is a pattern, not bad luck. Open the circuit.
-- **Cooking in the expeditor**: The orchestration layer should decide *what* to attempt, not *how* to fix broken tools. If the expeditor is crafting workaround commands for Bash failures, it has crossed the separation boundary.
 - **Silent scope reduction**: Dropping sub-tasks without documenting them produces results that look complete but are not. Always report what was skipped.
-- **Treating stale data as fresh**: Cached or previously fetched results may not reflect current state. Label uncertainty rather than ignoring it.
 - **Opening circuits too eagerly**: A single transient failure should not open the circuit. Use a threshold (default: 3) to filter noise from signal.
 - **Never probing after opening**: A permanently open circuit means the agent never discovers that a tool has recovered. Half-open probes are essential for recovery.
 - **Ignoring the failure budget**: Without a budget, an agent can accumulate dozens of failures across different tools while still "making progress" on paper. The budget forces an honest checkpoint.

--- a/skills/configure-api-gateway/SKILL.md
+++ b/skills/configure-api-gateway/SKILL.md
@@ -40,7 +40,7 @@ Deploy and configure an API gateway for centralized API traffic management and p
 - **Optional**: Authentication provider (OAuth2, OIDC, API keys)
 - **Optional**: Rate limiting requirements (requests per minute/hour)
 - **Optional**: Custom middleware or plugin configurations
-- **Optional**: TLS certificates for HTTPS endpoints
+- **Optional**: TLS certificates for HTTPS endpoints — the gateway terminates TLS for every route behind it, so provision via cert-manager and verify auto-renewal is actually running; an expiry takes down all routes at once, not one
 
 ## Procedure
 

--- a/skills/configure-api-gateway/SKILL.md
+++ b/skills/configure-api-gateway/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: devops
   complexity: intermediate
   language: multi
@@ -45,6 +45,8 @@ Deploy and configure an API gateway for centralized API traffic management and p
 ## Procedure
 
 > See [Extended Examples](references/EXAMPLES.md) for complete configuration files and templates.
+>
+> Roll out incrementally in step order — do not enable all plugins/middleware in one sync; verify each step's **Expected** block before layering the next (routing → authentication → rate limiting → transformations → advanced features).
 
 ### Step 1: Install API Gateway
 
@@ -95,7 +97,7 @@ kubectl wait --for=condition=ready pod -l app=kong -n kong --timeout=300s
 kubectl get svc -n kong kong-proxy  # Get load balancer IP
 ```
 
-**Expected:** Gateway pods running with 2 replicas. Load balancer service has external IP assigned. Admin API accessible (Kong: port 8001, Traefik: dashboard port 8080). Health checks passing.
+**Expected:** Gateway pods running with 2 replicas. Load balancer service has external IP assigned. Admin API accessible (Kong: port 8001, Traefik: dashboard port 8080). Health checks passing. CPU/memory requests and limits set on the gateway pods — a gateway that hits its CPU limit under load is throttled, and that surfaces as rising latency, not as errors or restarts.
 
 **On failure:**
 - Check pod logs: `kubectl logs -n kong -l app=kong`
@@ -358,8 +360,8 @@ See [EXAMPLES.md](references/EXAMPLES.md#step-6-implement-api-versioning-and-dep
 **Expected:** Different versions route to appropriate backend services. Deprecation headers present on v1 responses. Rate limits stricter for deprecated versions. Default path routes to latest version. Metrics segmented by API version.
 
 **On failure:**
-- Verify path precedence/priority configuration (higher priority = evaluated first)
-- Check for overlapping path patterns
+- Verify path precedence/priority configuration (higher priority = evaluated first; more specific paths need higher priority)
+- Check for overlapping path patterns (overlaps do not error — they silently cause unpredictable routing; verify the actual route hit with `curl -v`)
 - Test each version route independently
 - Review routing logs for path matching
 - Ensure backend services for each version are running
@@ -383,23 +385,15 @@ See [EXAMPLES.md](references/EXAMPLES.md#step-6-implement-api-versioning-and-dep
 
 - **Database Dependency (Kong)**: Kong with database requires PostgreSQL/Cassandra. DB-less mode available but limits some features (runtime config changes). Use DB mode for production with multiple gateway instances.
 
-- **Path Matching Order**: Routes/IngressRoutes evaluated in specific order. More specific paths should have higher priority. Overlapping paths cause unpredictable routing. Test with `curl -v` to verify actual route hit.
-
 - **Authentication Bypass**: Ensure authentication plugins applied to all routes. Easy to add route without auth. Use default plugins at service level, then override per-route as needed.
 
 - **Rate Limit Scope**: Rate limiting `policy: local` counts per gateway pod. For consistent limits across replicas, use centralized policy (Redis) or sticky sessions.
 
 - **CORS Configuration**: API gateway should handle CORS, not individual services. Add CORS plugin/middleware early to avoid browser preflight failures.
 
-- **SSL/TLS Termination**: Gateway typically terminates SSL. Ensure certificates valid and auto-renewal configured. Use cert-manager for Kubernetes certificate management.
-
 - **Upstream Health Checks**: Configure active health checks to detect backend failures quickly. Passive checks rely on real traffic and may be slower to detect issues.
 
 - **Plugin/Middleware Execution Order**: Order matters. Authentication before rate limiting (avoid wasted rate limit slots for invalid requests). Transformation before logging (log transformed values).
-
-- **Resource Limits**: Gateway pods can consume significant CPU under load. Set appropriate resource requests/limits. Monitor CPU throttling in production.
-
-- **Migration Strategy**: Don't enable all plugins at once. Roll out incrementally: routing → authentication → rate limiting → transformations → advanced features.
 
 ## Related Skills
 

--- a/skills/create-2d-composition/SKILL.md
+++ b/skills/create-2d-composition/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: visualization
   complexity: intermediate
   language: Python
@@ -209,7 +209,7 @@ def wrap_text(text, max_width=20):
 ```
 
 **Expected:** Flowchart with connected boxes and arrows
-**On failure:** Adjust layout calculations, verify arrow marker definitions
+**On failure:** Adjust layout calculations, verify arrow marker definitions. SVG `<text>` does NOT auto-wrap and overflowing text is NOT clipped or flagged as an error — it silently spills outside the shape boundary, so wrap it yourself with `wrap_text` before positioning
 
 ### 4. Composite Raster Images
 
@@ -397,15 +397,11 @@ def svg_to_pdf(svg_path, pdf_path):
 ## Common Pitfalls
 
 1. **Unit confusion**: SVG units (px, mm, cm) vs screen pixels vs print DPI
-2. **Text overflow**: Text exceeding shape boundaries, implement wrapping
-3. **Font availability**: System fonts may differ, embed or use web-safe fonts
-4. **Coordinate calculations**: Off-by-one errors in grid layouts
-5. **Color format**: SVG uses hex strings (`#rrggbb`), not tuples
-6. **SVG validity**: Check XML structure, close all tags
-7. **File paths**: Handle special characters, spaces in filenames
-8. **Memory usage**: Large batch operations may require chunking
-9. **Aspect ratio**: Maintain proportions when resizing images
-10. **Transparency**: PNG supports alpha, JPEG does not
+2. **Font availability**: System fonts may differ, embed or use web-safe fonts
+3. **Color format**: SVG uses hex strings (`#rrggbb`), not tuples
+4. **Memory usage**: Large batch operations may require chunking
+5. **Aspect ratio**: Maintain proportions when resizing images
+6. **Transparency**: PNG supports alpha, JPEG does not
 
 ## Related Skills
 

--- a/skills/create-3d-scene/SKILL.md
+++ b/skills/create-3d-scene/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: blender
   complexity: intermediate
   language: Python
@@ -169,7 +169,7 @@ def apply_materials(cube, sphere):
 ```
 
 **Expected:** Materials visible in shader editor with proper node connections
-**On failure:** Check node types exist, verify link syntax, ensure color values in [0,1] range
+**On failure:** Check node types exist, verify link syntax, ensure color values in [0,1] range. A 3-component RGB tuple is NOT accepted for `Base Color` — `default_value` requires explicit alpha, hence `base_color + (1.0,)`
 
 ### 4. Set Up Lighting
 
@@ -241,7 +241,7 @@ def setup_camera():
 ```
 
 **Expected:** Camera positioned with correct focal length and DOF settings
-**On failure:** Use simpler rotation method if track_to fails, verify lens units
+**On failure:** Use simpler rotation method if track_to fails, verify lens units. `camera_add` does NOT make the new camera the scene's render camera — without `bpy.context.scene.camera = camera` a background render aborts with no camera
 
 ### 6. Configure World Environment
 
@@ -364,14 +364,10 @@ def organize_collections():
 
 1. **Object naming conflicts**: Use unique names, check for existing objects before creating
 2. **Incorrect color format**: RGB values must be tuples (r, g, b, a) in [0,1] range
-3. **Missing alpha channel**: When setting colors, include alpha: `(r, g, b, 1.0)`
-4. **Node connection errors**: Verify node types have expected inputs/outputs before linking
-5. **Camera not active**: Must set `bpy.context.scene.camera = camera_object`
-6. **Relative vs absolute paths**: Use absolute paths or Path() for cross-platform compatibility
-7. **Units confusion**: Blender uses meters by default, camera lens in millimeters
-8. **Rotation formats**: Use `math.radians()` for degree-to-radian conversion
-9. **Render engine differences**: EEVEE and Cycles have different features and parameters
-10. **Memory leaks**: Clear orphaned data blocks to prevent memory buildup in batch operations
+3. **Units confusion**: Blender uses meters by default, camera lens in millimeters
+4. **Rotation formats**: Use `math.radians()` for degree-to-radian conversion
+5. **Render engine differences**: EEVEE and Cycles have different features and parameters
+6. **Memory leaks**: Clear orphaned data blocks to prevent memory buildup in batch operations
 
 ## Related Skills
 

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.3"
+  version: "1.4"
   domain: general
   complexity: intermediate
   language: multi
@@ -376,10 +376,8 @@ npm run translation:status
 
 ## Common Pitfalls
 
-- **Vague procedures**: "Configure the system appropriately" is useless to an agent. Provide exact commands, file paths, and configuration values.
 - **Missing On failure**: Every step that can fail needs recovery guidance. Agents can't improvise — they need the fallback spelled out.
 - **Overly broad scope**: A skill that tries to cover "Set up entire development environment" should be 3-5 focused skills instead. One skill = one procedure.
-- **Untestable validation**: "Code quality is good" can't be verified. "Linter passes with 0 warnings" can.
 - **Stale cross-references**: When renaming or removing skills, grep for the old name in all Related Skills sections.
 - **Description too long**: The description field is what agents read to decide activation. Keep it under 1024 characters and front-load the key information.
 - **Authoring at 500-line limit for single language**: An English skill at 490 lines will exceed 500 when translated to German (~10-20% expansion) or CJK languages. Target ~400 lines for the English source and use progressive disclosure (`references/EXAMPLES.md`) for the rest.

--- a/skills/deploy-ml-model-serving/SKILL.md
+++ b/skills/deploy-ml-model-serving/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: mlops
   complexity: advanced
   language: multi
@@ -197,7 +197,7 @@ curl -X POST http://$EXTERNAL_IP/predict \
 
 **Expected:** BentoML service builds successfully, container runs and serves predictions, Kubernetes deployment creates 3 replicas, load balancer exposes external endpoint, health checks pass.
 
-**On failure:** Verify BentoML installation (`bentoml --version`), check model exists in BentoML store (`bentoml models list`), ensure Docker daemon running, verify Kubernetes cluster access (`kubectl cluster-info`), check resource limits not exceeded, inspect pod logs (`kubectl logs <pod-name>`), verify service selector matches pod labels.
+**On failure:** Verify BentoML installation (`bentoml --version`), check model exists in BentoML store (`bentoml models list`), ensure Docker daemon running, verify Kubernetes cluster access (`kubectl cluster-info`), check resource limits not exceeded, inspect pod logs (`kubectl logs <pod-name>`), verify service selector matches pod labels, confirm liveness/readiness probes are defined — without a readiness probe Kubernetes does not wait for model loading and routes traffic to pods that are not ready — and confirm pod anti-affinity is configured — multiple replicas alone do not guarantee availability, since without anti-affinity all replicas can be scheduled onto the same node.
 
 ### Step 3: Implement Seldon Core for Advanced Features
 
@@ -404,11 +404,7 @@ logger = logging.getLogger(__name__)
 - **Memory leaks**: Long-running servers accumulate memory - monitor memory usage, implement periodic restarts, profile code
 - **Dependency conflicts**: Model dependencies incompatible with serving framework - use exact pinned versions, test in Docker before deployment
 - **Resource limits too low**: Pods OOMKilled or CPU throttled - profile resource usage, set appropriate limits based on load testing
-- **Missing health checks**: Kubernetes routes traffic to unhealthy pods - implement proper liveness/readiness probes
-- **No rollback strategy**: Bad deployment without easy rollback - use canary deployments, keep previous version available
 - **Ignoring latency**: Focusing only on accuracy, not inference speed - benchmark latency, optimize model/code, use batching
-- **Single replica**: No high availability, downtime during deployments - use min 2 replicas, configure anti-affinity
-- **No monitoring**: Issues not detected until customers complain - implement comprehensive metrics from day one
 - **GPU not utilized**: GPU available but not used - set CUDA visible devices, verify GPU allocation in Kubernetes
 
 ## Related Skills

--- a/skills/enforce-policy-as-code/SKILL.md
+++ b/skills/enforce-policy-as-code/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: devops
   complexity: intermediate
   language: multi
@@ -125,7 +125,7 @@ spec:
           kind: Namespace
 ```
 
-**Expected:** Policy engine pods running with multiple replicas. CRDs installed (ConstraintTemplate, Constraint for Gatekeeper; ClusterPolicy, Policy for Kyverno). Validating/mutating webhooks active. Audit controller running.
+**Expected:** Policy engine pods running with multiple replicas. CRDs installed (ConstraintTemplate, Constraint for Gatekeeper; ClusterPolicy, Policy for Kyverno). Validating/mutating webhooks active. Audit controller running. Excluded namespaces are exempt from both the `webhook` and the `audit` process — they do NOT report violations because they are never evaluated, not because they are compliant, so over-excluding hides risk rather than surfacing it.
 
 **On failure:**
 - Check pod logs: `kubectl logs -n gatekeeper-system -l app=gatekeeper --tail=50`
@@ -180,7 +180,7 @@ kubectl describe clusterpolicy require-labels
 **Expected:** ConstraintTemplates/ClusterPolicies created successfully. Constraints show status "True" for enforcement. No errors in policy definitions. Webhook begins evaluating new resources against policies.
 
 **On failure:**
-- Validate Rego syntax (Gatekeeper): Use `opa test` locally or check constraint status
+- Validate Rego syntax (Gatekeeper): Use `opa test` locally (or `gator` for offline testing) or check constraint status
 - Check policy YAML syntax: `kubectl apply --dry-run=client -f policy.yaml`
 - Review constraint status: `kubectl get constraint -o yaml | grep -A 10 status`
 - Test with simple policy first, then add complexity
@@ -285,7 +285,7 @@ kubectl apply -f kyverno-mutations.yaml
 - Verify mutation policy syntax: especially JSON paths and conditions
 - Review logs: `kubectl logs -n kyverno deploy/kyverno-admission-controller`
 - Test mutations don't conflict (multiple mutations on same field)
-- Ensure mutation applied before validation (order matters)
+- Ensure mutation applied before validation (order matters — validations evaluate the mutated resource, not the original)
 
 ### Step 5: Enable Audit Mode and Reporting
 
@@ -402,15 +402,7 @@ if git diff --cached --name-only | grep -E 'manifests/.*\.yaml$'; then
 
 - **Missing Resource Specifications**: Policies must specify API groups, versions, and kinds correctly. Use `kubectl api-resources` to find exact values. Wildcards (`*`) convenient but can cause performance issues.
 
-- **Mutation Order**: Mutations applied before validations. Ensure mutations don't conflict and that validations account for mutated values. Test mutation+validation together.
-
-- **Namespace Exclusions**: Excluding system namespaces necessary, but be careful not to over-exclude. Review exclusions regularly as policies mature.
-
-- **Rego Complexity (Gatekeeper)**: Complex Rego policies difficult to debug. Start simple, test with `opa test` locally, add logging with `trace()`, use gator for offline testing.
-
 - **Performance Impact**: Policy evaluation adds latency to admission. Keep policies efficient, use appropriate matching criteria, monitor webhook latency metrics.
-
-- **Policy Conflicts**: Multiple policies modifying same field cause issues. Coordinate policies across teams, use policy libraries for common patterns, test combinations.
 
 - **Background Scanning**: Background audit scans entire cluster. Can be resource-intensive in large clusters. Adjust audit interval based on cluster size and policy count.
 

--- a/skills/expand-awareness/SKILL.md
+++ b/skills/expand-awareness/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 allowed-tools: Read Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: synoptic
   complexity: intermediate
   language: natural
@@ -68,7 +68,7 @@ Map all domains relevant to the current problem. This resembles what a polymath 
 
 **Expected:** A list of 3-7 domains, each with its perspective on the problem. The list feels complete — not exhaustive (every possible domain) but sufficient (every domain that materially affects the problem). Each domain is named specifically enough that you could hand it to a specialist and they would know their scope.
 
-**On failure:** If only one domain emerges, the problem may genuinely be single-domain — use `observe` instead. If only two domains emerge, consider whether there is a connecting domain between them (there usually is — it is the space where the two interact). If dozens of domains emerge, group related ones into clusters and treat each cluster as a single domain for expansion purposes. The goal is simultaneous perception, not an exhaustive taxonomy.
+**On failure:** If only one domain emerges, the problem may genuinely be single-domain — use `observe` instead. If only two domains emerge, consider whether there is a connecting domain between them (there usually is — it is the space where the two interact). If dozens of domains emerge, group related ones into clusters and treat each cluster as a single domain for expansion purposes. The goal is simultaneous perception, not an exhaustive taxonomy. If this step is skipped entirely, expansion has nothing to hold and produces vague spaciousness rather than panoramic perception — the open awareness of this skill is *not* contentless; without an inventory, "expand" has no direction.
 
 ### Step 2: Soften Focus — Release Single-Domain Concentration
 
@@ -86,7 +86,7 @@ Transition from focused attention on one domain to a diffuse readiness to percei
 
 **Expected:** A cognitive state where no single domain dominates attention. The mind is open and receptive rather than focused and directed. This state is unfamiliar and slightly uncomfortable — that discomfort is the signal that narrowness has been released. There is a temptation to fill the openness immediately; resist it.
 
-**On failure:** If focus will not soften — if one domain keeps demanding attention — it may have an unresolved urgency. Address it briefly (note the urgent item, commit to return to it) and then attempt softening again. If the analytical mind protests that this is "unproductive," note the protest as itself a form of narrowness: the habit of always needing a single target is precisely the habit this step works to release.
+**On failure:** If focus will not soften — if one domain keeps demanding attention — it may have an unresolved urgency. Address it briefly (note the urgent item, commit to return to it) and then attempt softening again. If the analytical mind protests that this is "unproductive," note the protest as itself a form of narrowness: the habit of always needing a single target is precisely the habit this step works to release. If what resists is *noise* rather than narrowness — residual context, distracting threads — run `meditate` first: expanding from a noisy baseline amplifies the noise, it does not dilute it, and this step clears narrowness only.
 
 ### Step 3: Expand — Hold All Domains Simultaneously
 
@@ -103,7 +103,7 @@ This is the Global Workspace moment: information that was compartmentalized in s
    - **Resonances**: where does a pattern in one domain echo unexpectedly in another?
    - **Gaps**: where is there empty space between domains that nothing addresses?
    - **Surprises**: what is visible from the panoramic view that was invisible from any single domain?
-5. Do not pursue any single connection. Let them register without analysis. The panoramic view is the product, not any individual insight within it
+5. Do not pursue any single connection — the urge to immediately analyze one collapses the panoramic view into focused attention on that one connection. Let them register without analysis. The panoramic view is the product, not any individual insight within it; analysis has its turn later, in `integrate-gestalt`
 6. If using tools, this is the moment to read files from multiple domains in quick succession — not to analyze them individually, but to let them coexist in context
 
 **Expected:** A felt sense of holding multiple perspectives simultaneously. Connections, tensions, and resonances emerge without being forced. The experience is more like seeing a pattern in a mosaic than like reading a list of items. The between-domain space — where no single domain has authority — becomes visible. This is where the novel insights live: not within any domain but in the relationships between them.
@@ -161,11 +161,8 @@ The panoramic view is temporary by nature. Before allowing attention to narrow b
 
 - **Sequential scanning instead of simultaneous perception**: Rapidly cycling through domains one by one is analysis, not panoramic awareness. The distinction is between seeing a landscape and reading a list of its features. If you find yourself thinking "first A, then B, then C," you are scanning, not expanding
 - **Confusing expansion with diffusion**: Expanded awareness is alert and receptive — you can feel each domain distinctly even while holding all of them. Diffuse attention is scattered and unfocused — everything blurs together. If everything feels blurry, attention has diffused rather than expanded. Re-anchor briefly on one domain and then expand again from that grounded position
-- **Analyzing during expansion**: The urge to immediately pursue a connection collapses the panoramic view into focused attention on that one connection. Note it and continue holding the wide view. Analysis has its turn later, in `integrate-gestalt`
-- **Skipping the inventory**: Expanding without knowing what to expand into produces vague spaciousness rather than panoramic perception. The inventory provides the content that awareness expands to hold. Without it, "expand" has no direction
 - **Rushing through softening**: The transition from focused to open attention takes time. Skipping Step 2 means attempting expansion from a still-focused state, which produces sequential scanning disguised as simultaneous perception
 - **Forcing connections**: Not all domains connect. Fabricating connections between genuinely independent domains pollutes the perception. Let connections emerge or not. The absence of connection is data, not failure
-- **Expanding without prior clearing**: Expanding from a noisy baseline amplifies the noise. Run `meditate` first when context noise is present
 - **Treating expansion as a one-time event**: Panoramic awareness is a practice that deepens with repetition. The first expansion session reveals surface connections; subsequent sessions on the same problem reveal structural patterns. Return to this skill as the problem evolves
 - **Conflating expansion with expertise**: Holding multiple domains in awareness does not make you expert in all of them. Expansion reveals *where* to look, not *what to conclude*. Deep single-domain work remains necessary after expansion identifies the critical intersections
 

--- a/skills/navigate-dach-bureaucracy/SKILL.md
+++ b/skills/navigate-dach-bureaucracy/SKILL.md
@@ -265,7 +265,7 @@ Ensure social security contributions and entitlements are properly coordinated b
 Complete remaining mandatory and practical registrations for daily life.
 
 1. **Bank account**:
-   - Open the account within the first week -- salary payment, rent direct debit, and insurance premium payment all depend on it
+   - Open the account within the first week -- salary payment, rent direct debit, and insurance premium payment all depend on it. In Switzerland this is close to mandatory: LSV+ direct debit cannot be set up on a foreign IBAN at all, and most employers will not pay CHF salary abroad because they refuse the SWIFT fees (cross-border commuters are the standing exception)
    - Germany: most traditional banks require Meldebestaetigung; online banks (N26, Vivid, etc.) may not
    - Austria: similar requirements; Erste Bank, Raiffeisen, and others require Meldezettel
    - Switzerland: PostFinance is accessible; traditional banks may require residence permit
@@ -306,7 +306,7 @@ Complete remaining mandatory and practical registrations for daily life.
 
 **Expected:** All additional registrations completed or initiated, with confirmation documents filed and follow-up dates noted for any pending items.
 
-**On failure:** Most additional registrations are not time-critical (except broadcasting fee registration, which can result in backdated charges, and the bank account, which should be opened within the first week -- see sub-step 1). Prioritize bank account and mobile phone as they are needed for daily life -- do not defer the account: without a local one, salary payment, rent direct debit, and insurance premium payment are all problematic (in Switzerland a foreign account will not work for CHF salary or LSV+ direct debit at all), so open it within the first week. Other items can be completed within the first 1-3 months.
+**On failure:** Most additional registrations are not time-critical (except broadcasting fee registration, which can result in backdated charges, and the bank account, which should be opened within the first week -- see sub-step 1). Prioritize bank account and mobile phone as they are needed for daily life. Other items can be completed within the first 1-3 months.
 
 ## Validation
 

--- a/skills/navigate-dach-bureaucracy/SKILL.md
+++ b/skills/navigate-dach-bureaucracy/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 allowed-tools: Read Grep Glob WebFetch WebSearch
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: relocation
   complexity: advanced
   language: natural
@@ -99,7 +99,7 @@ Complete the residence registration, which is the foundational step that unlocks
 
 1. **Germany (Anmeldung at Buergeramt)**:
    - Book an appointment online at the city's Buergeramt website (Berlin: service.berlin.de; Munich: muenchen.de/rathaus; others: check city website)
-   - If no appointments available, check for walk-in hours (Buergeramt ohne Termin) or try smaller satellite offices
+   - If no appointments available, verify the published walk-in hours (Buergeramt ohne Termin) before going, or try smaller satellite offices -- many Buergeraemter are appointment-only and will turn away anyone arriving without a booked Termin
    - Prepare documents:
      - Valid passport or national ID card (original)
      - Wohnungsgeberbestaetigung (landlord confirmation form -- the landlord must complete and sign this)
@@ -122,7 +122,7 @@ Complete the residence registration, which is the foundational step that unlocks
    - At the office:
      - Submit the form; processing is usually immediate
      - You receive a stamped Meldebestaetigung
-   - Deadline: within 3 days of moving in (Bezug der Unterkunft)
+   - Deadline: within 3 days of moving in (Bezug der Unterkunft) -- extremely tight; submit the Meldezettel the day you move in if possible
    - For EU citizens: apply for Anmeldebescheinigung within 4 months at the MA 35 (Vienna) or BH (other regions)
 
 3. **Switzerland (Anmeldung at Einwohnerkontrolle)**:
@@ -265,6 +265,7 @@ Ensure social security contributions and entitlements are properly coordinated b
 Complete remaining mandatory and practical registrations for daily life.
 
 1. **Bank account**:
+   - Open the account within the first week -- salary payment, rent direct debit, and insurance premium payment all depend on it
    - Germany: most traditional banks require Meldebestaetigung; online banks (N26, Vivid, etc.) may not
    - Austria: similar requirements; Erste Bank, Raiffeisen, and others require Meldezettel
    - Switzerland: PostFinance is accessible; traditional banks may require residence permit
@@ -305,7 +306,7 @@ Complete remaining mandatory and practical registrations for daily life.
 
 **Expected:** All additional registrations completed or initiated, with confirmation documents filed and follow-up dates noted for any pending items.
 
-**On failure:** Most additional registrations are not time-critical (except broadcasting fee registration, which can result in backdated charges). Prioritize bank account and mobile phone as they are needed for daily life. Other items can be completed within the first 1-3 months.
+**On failure:** Most additional registrations are not time-critical (except broadcasting fee registration, which can result in backdated charges, and the bank account, which should be opened within the first week -- see sub-step 1). Prioritize bank account and mobile phone as they are needed for daily life -- do not defer the account: without a local one, salary payment, rent direct debit, and insurance premium payment are all problematic (in Switzerland a foreign account will not work for CHF salary or LSV+ direct debit at all), so open it within the first week. Other items can be completed within the first 1-3 months.
 
 ## Validation
 
@@ -320,14 +321,10 @@ Complete remaining mandatory and practical registrations for daily life.
 
 ## Common Pitfalls
 
-- **Showing up without an appointment in Germany**: Many German Buergeraemter are appointment-only; always check online first and book ahead
-- **Missing the 3-day deadline in Austria**: The Meldezettel deadline is extremely tight; submit it the day you move in if possible
 - **Choosing health insurance under time pressure**: In Germany, the choice of Krankenkasse matters (supplementary benefits vary); in Switzerland, premiums vary widely between insurers for identical basic coverage; take time to compare
 - **Ignoring the Quellensteuer/ordentliche Besteuerung distinction in Switzerland**: Getting this wrong affects how you file taxes and may result in underpayment or overpayment
-- **Not carrying documents in the first weeks**: Keep originals of passport, Meldebestaetigung, employment contract, and insurance confirmation with you during the first month; you will need them repeatedly
 - **Assuming the employer handles everything**: Employers typically handle payroll registration, social security, and sometimes health insurance, but residence registration, bank accounts, broadcasting fees, and most other steps are your responsibility
 - **Forgetting church tax opt-out in Germany**: Many newcomers are unaware that declaring a religion during Anmeldung triggers automatic Kirchensteuer; this can be 8-9% of your income tax
-- **Delaying bank account opening**: Without a local bank account, salary payment, rent direct debit, and insurance premium payment are all problematic; open an account within the first week
 - **Not saving confirmation numbers and reference IDs**: Every office interaction generates a reference number (Aktenzeichen, Geschaeftszahl, Dossiernummer); record these immediately as they are needed for follow-up inquiries
 - **Applying Swiss health insurance rules in Germany or vice versa**: The three DACH countries have fundamentally different health insurance systems; do not assume transferability
 

--- a/skills/optimize-cloud-costs/SKILL.md
+++ b/skills/optimize-cloud-costs/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: devops
   complexity: intermediate
   language: multi
@@ -333,7 +333,7 @@ kubectl get deployment api-server -n production -o json | \
 - Review VPA admission controller logs: `kubectl logs -n kube-system -l app=vpa-admission-controller`
 - Verify webhook is registered: `kubectl get mutatingwebhookconfigurations vpa-webhook-config`
 - Don't use VPA and HPA on same metric (CPU/memory) - causes conflicts
-- Start with "Off" mode to review recommendations before enabling automatic updates
+- Start with "Off" mode to review recommendations before enabling automatic updates — do not apply VPA recommendations immediately; sudden changes can cause OOMKills or CPU throttling
 
 ### Step 5: Leverage Spot/Preemptible Instances
 
@@ -423,7 +423,7 @@ kubectl describe resourcequota production-quota -n production
 
 **On failure:**
 - Verify ResourceQuota and LimitRange applied correctly: `kubectl get resourcequota,limitrange -A`
-- Check for pods failing due to quota: `kubectl get events -n production | grep quota`
+- Check for pods failing due to quota: `kubectl get events -n production | grep quota` — quotas set too low block legitimate growth, so review usage monthly and communicate limits to teams before enforcing them
 - Review Kubecost alert configuration: `kubectl logs -n kubecost -l app=cost-analyzer | grep alert`
 - Ensure Prometheus has Kubecost metrics: `curl http://prometheus:9090/api/v1/query?query=kubecost_monthly_cost`
 - Test alert routing: verify email/Slack webhook configuration
@@ -445,10 +445,6 @@ kubectl describe resourcequota production-quota -n production
 
 ## Common Pitfalls
 
-- **Aggressive Right-Sizing**: Don't immediately apply VPA recommendations. Start with "Off" mode, review suggestions for a week, then gradually apply. Sudden changes can cause OOMKills or CPU throttling.
-
-- **HPA + VPA Conflict**: Never use HPA and VPA on same metric (CPU/memory). Use HPA for horizontal scaling, VPA for per-pod resource tuning, or HPA on custom metrics + VPA on resources.
-
 - **Spot Without Fault Tolerance**: Only run fault-tolerant, stateless workloads on spot. Never databases, stateful services, or single-replica critical services. Always use PodDisruptionBudgets.
 
 - **Insufficient Monitoring Period**: Cost optimization decisions need historical data. Wait at least 7 days before making changes, 30 days for VPA recommendations, 90 days for trend analysis.
@@ -458,10 +454,6 @@ kubectl describe resourcequota production-quota -n production
 - **Network Egress Costs**: Compute costs visible in Kubecost, but egress (data transfer) can be significant. Monitor cross-AZ traffic, use topology-aware routing, consider data transfer costs in architecture.
 
 - **Storage Overlooked**: PersistentVolume costs often forgotten. Audit unused PVCs, right-size volumes, use volume expansion instead of over-provisioning, implement PV cleanup policies.
-
-- **Quota Too Restrictive**: Setting quotas too low blocks legitimate growth. Review quota usage monthly, adjust based on actual needs, communicate limits to teams before enforcement.
-
-- **False Savings from Wrong Metrics**: Using CPU/memory as sole optimization metric misses I/O, network, storage costs. Consider total cost of ownership, not just compute.
 
 - **Chargeback Before Trust**: Implementing chargeback before teams understand and trust cost data causes friction. Start with showback (informational), build culture of cost awareness, then move to chargeback.
 

--- a/skills/orchestrate-ml-pipeline/SKILL.md
+++ b/skills/orchestrate-ml-pipeline/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: mlops
   complexity: advanced
   language: multi
@@ -135,7 +135,7 @@ import pandas as pd
 
 **Expected:** DAG appears in Airflow UI, scheduled runs execute on time, task failures trigger retries and alerts, XCom passes data between tasks, MLflow integration logs experiments.
 
-**On failure:** Check DAG file syntax (`python dags/ml_training_dag.py`), verify imports available in Airflow environment, ensure XCom not exceeding size limits (use file paths for large data), check email configuration for alerts, verify scheduler running, inspect task logs in Airflow UI.
+**On failure:** Check DAG file syntax (`python dags/ml_training_dag.py`), verify imports available in Airflow environment, ensure XCom not exceeding size limits (use file paths or external storage (S3) for large data), check email configuration for alerts, verify scheduler running, inspect task logs in Airflow UI.
 
 ### Step 4: Implement Advanced Features
 
@@ -242,14 +242,10 @@ on:
 
 ## Common Pitfalls
 
-- **Circular dependencies**: Task A depends on B, B depends on A - carefully design DAG structure, use Airflow/Prefect validators
 - **Memory leaks**: Long-running tasks accumulate memory - set task timeouts, monitor resource usage, restart workers periodically
-- **XCom size limits**: Passing large data via XCom - use file paths or external storage (S3) instead of direct serialization
 - **Timezone confusion**: Schedule runs at wrong times - always use UTC, explicitly set timezone in schedule
 - **Missing retries**: Tasks fail permanently on transient errors - configure retries with exponential backoff
-- **Tight coupling**: Tasks directly depend on implementation details - use clear interfaces, pass parameters explicitly
 - **No idempotency**: Re-running tasks causes duplicates or errors - design tasks to be idempotent (safe to retry)
-- **Poor error handling**: Failures don't provide useful context - add detailed logging, capture exceptions properly
 - **Resource contention**: Parallel tasks overwhelm resources - limit concurrency, set resource quotas
 - **Version conflicts**: Different tasks need incompatible dependencies - use Docker containers for task isolation
 

--- a/skills/prepare-print-model/SKILL.md
+++ b/skills/prepare-print-model/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob WebFetch
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: 3d-printing
   complexity: intermediate
   language: multi
@@ -149,8 +149,9 @@ Select orientation to optimize strength, surface finish, and support usage:
 **Orientation decision matrix**:
 
 **For strength**:
-- Orient so layer lines run perpendicular to primary load direction
-- Example: Bracket under tension → print vertically so layers stack along load axis
+- The layer interface is the weak plane, not the material: a part pulled across its stacked layers does **not** fail by breaking the extruded bead, it delaminates at the bond between layers. This anisotropy — not the filament's rated tensile strength — is what sets the orientation, and it is what lets you reason about load cases no table below covers (torsion, impact, fatigue, hoop stress): ask which surface the load tries to pull apart, and keep layer interfaces off it.
+- Orient so the layer stacking direction (build Z) runs perpendicular to the primary load, keeping the load in-plane where continuous extruded beads carry it
+- Example: Bracket under tension → lay it flat so the tension axis stays in the X/Y plane; printing it upright stacks layer interfaces across the load axis and invites delamination
 
 **For surface finish**:
 - Orient largest/most visible surface flat on bed (minimal stair-stepping)
@@ -163,9 +164,9 @@ Select orientation to optimize strength, surface finish, and support usage:
 **Load direction analysis**:
 ```text
 If part experiences:
-- Tensile load along axis → print with layers perpendicular to axis
-- Compressive load → layers can be parallel (less critical)
-- Bending moment → layers perpendicular to neutral axis
+- Tensile load along axis → stack layers perpendicular to that axis (load stays in-plane)
+- Compressive load → stacking direction less critical (layer bonds are pressed together, not pulled apart)
+- Bending moment → stack layers perpendicular to the neutral axis (outer fibre is in tension)
 - Shear → avoid layer interfaces parallel to shear direction
 ```
 
@@ -287,6 +288,8 @@ Inspect sliced G-code for issues:
 - **First layer not squishing**: Adjust Z-offset down by 0.05mm
 - **Sparse top layers**: Increase top solid layers to 5+
 
+A clean slice is not a validation: the slicer does **not** warn about thin-wall gaps or odd infill decisions — it silently emits them — so never skip this preview.
+
 **Expected:** Preview shows continuous perimeters, proper infill, clean travels, and no obvious defects.
 
 **On failure:** Adjust slicer settings and re-slice. Common fixes:
@@ -344,15 +347,11 @@ head -n 50 model.gcode | grep "^M104\|^M140"  # Verify temperatures
 ## Common Pitfalls
 
 1. **Skipping mesh repair**: Non-manifold meshes can slice but fail to print correctly with gaps or malformed layers
-2. **Ignoring wall thickness**: Thin walls (< minimum) will have gaps, drastically reducing strength
-3. **Wrong orientation for strength**: Printing tensile parts with layers parallel to load direction creates weak delamination plane
-4. **Insufficient supports**: Underestimating overhang angle leads to sagging, stringing, or complete failure
-5. **First layer neglect**: 90% of print failures occur in first layer—Z-offset and bed adhesion are critical
-6. **Temperature from Internet**: Every printer/material combination is unique; always calibrate temperature with tower tests
-7. **Excessive detail for layer height**: Fine features smaller than 2× layer height won't resolve properly
-8. **Not previewing slice**: Slicers can make unexpected decisions (thin wall gaps, weird infill); always preview before printing
-9. **Material hygroscopy**: Wet filament (especially Nylon, TPU, PETG) causes poor layer adhesion, stringing, and brittleness
-10. **Overconfidence in supports**: Heavy parts with large overhangs can still sag even with supports—test on smaller models first
+2. **First layer neglect**: 90% of print failures occur in first layer—Z-offset and bed adhesion are critical
+3. **Temperature from Internet**: Every printer/material combination is unique; always calibrate temperature with tower tests
+4. **Excessive detail for layer height**: Fine features smaller than 2× layer height won't resolve properly
+5. **Material hygroscopy**: Wet filament (especially Nylon, TPU, PETG) causes poor layer adhesion, stringing, and brittleness
+6. **Overconfidence in supports**: Heavy parts with large overhangs can still sag even with supports—test on smaller models first
 
 ## Related Skills
 

--- a/skills/prepare-print-model/SKILL.md
+++ b/skills/prepare-print-model/SKILL.md
@@ -166,7 +166,7 @@ Select orientation to optimize strength, surface finish, and support usage:
 If part experiences:
 - Tensile load along axis → stack layers perpendicular to that axis (load stays in-plane)
 - Compressive load → stacking direction less critical (layer bonds are pressed together, not pulled apart)
-- Bending moment → stack layers perpendicular to the neutral axis (outer fibre is in tension)
+- Bending moment → lay the beam flat so its long axis is in X/Y (the outer fibre is in tension along that axis, and standing it on end puts every layer interface across that tension)
 - Shear → avoid layer interfaces parallel to shear direction
 ```
 

--- a/skills/prune-agent-memory/SKILL.md
+++ b/skills/prune-agent-memory/SKILL.md
@@ -15,7 +15,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.2"
+  version: "1.3"
   domain: general
   complexity: intermediate
   language: multi
@@ -237,7 +237,7 @@ Place SUPERSEDED records as their own files in the memory directory (e.g., `supe
 
 ### Step 6: Apply Preemptive Filters
 
-Define "what NOT to save" rules to prevent future memory pollution. Review existing memories for patterns that should have been filtered at write time.
+Define "what NOT to save" rules to prevent future memory pollution — pruning alone does not stop recurrence; without filters, future sessions recreate the same ephemeral entries just deleted. Review existing memories for patterns that should have been filtered at write time.
 
 Patterns that should **never** become persistent memories:
 
@@ -372,15 +372,11 @@ Memory drift occurs when stored facts become silently wrong — not because they
 
 ## Common Pitfalls
 
-- **Deleting failed strategies without inoculation**: Deleting a memory about an abandoned approach when the conditions that produced it still exist. The system regenerates the same conclusion from the same inputs along the same reasoning path. The deletion was a placebo. Use Step 5 inoculation when triggers persist.
 - **Pruning without verification**: Deleting entries because they "look old" without checking whether they are still accurate and useful. Age alone is not a deletion criterion — some of the most valuable memories are old architectural decisions that remain true.
 - **Self-verifying fidelity**: An agent reading its own compressed memory and concluding "yes, this seems right" is not a fidelity check. Fidelity requires external anchors: project files, git history, registry counts, actual tool output. Without anchors, you are checking consistency, not accuracy.
-- **Aggressive pruning without audit trail**: Deleting entries without recording what was deleted. When a future session needs a fact that was pruned, the audit trail explains what happened and may contain enough context to reconstruct the memory.
 - **Pruning decisions as memories**: Do not write "I decided to prune X because Y" as a regular memory entry. That goes in the pruning log only. Memory entries about memory management are meta-pollution.
-- **Ignoring the preemptive filters**: Pruning existing entries but not establishing rules to prevent the same patterns from recurring. Without filters, the next 10 sessions will recreate the same ephemeral entries you just deleted.
 - **Treating all types equally**: Decision memories and feedback memories should almost never be pruned — they represent user intent and rationale. Project and reference memories are the primary pruning targets because they track state that changes.
 - **Confusing compression with corruption**: A memory that summarizes a complex topic in one line is compressed, not corrupted. Only flag it as a fidelity failure if the compression lost the actionable insight, not merely the detail.
-- **Over-pinning**: Marking too many entries as protected defeats the purpose of pruning. If >30% of entries are protected, the criteria are too loose. Protect irreplaceable context, not merely important facts.
 - **Re-synthesis loops**: Merging fragments during re-synthesis can create new entries that themselves need pruning next cycle. Keep merges minimal — combine only entries that clearly cover the same topic. Do not synthesize new insights during a pruning pass.
 
 ## Related Skills

--- a/skills/register-ml-model/SKILL.md
+++ b/skills/register-ml-model/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: mlops
   complexity: intermediate
   language: multi
@@ -115,7 +115,7 @@ class ModelStageManager:
 
 **Expected:** Model version stage updates in registry, old versions archived automatically, transition timestamps recorded in tags, rollback restores previous production version.
 
-**On failure:** Check version exists and is in expected stage, verify archive_existing_versions flag behavior (may not archive if only one version), ensure database supports concurrent transactions for stage updates, check for stage transition locks (only one transition per version at a time), verify approval workflow integration.
+**On failure:** Check version exists and is in expected stage, verify archive_existing_versions flag behavior (may not archive if only one version), ensure database supports concurrent transactions for stage updates, check for stage transition locks (only one transition per version at a time), verify approval workflow integration. Note that MLflow does **not** gate promotion on model quality — `transition_model_version_stage()` succeeds for any version regardless of its metrics, so mandatory pre-Production validation must be enforced by your own promotion script or CI/CD, never assumed from the registry.
 
 ### Step 4: Implement Model Aliasing and References
 
@@ -210,10 +210,7 @@ def main():
 - **Stage conflicts**: Multiple versions in same stage cause confusion - use `archive_existing_versions=True` to auto-archive
 - **Missing run linkage**: Registering models without run_id loses lineage - always register from MLflow runs, not raw files
 - **Alias confusion**: Using stages as deployment targets instead of aliases - stages are for workflow, aliases for deployment references
-- **Validation skipped**: Promoting to Production without checks - implement mandatory validation in CI/CD pipeline
 - **No rollback plan**: Production issues without rollback capability - maintain previous Production version in Archived stage
-- **Tag overload**: Too many unstructured tags - standardize tag schema and naming conventions
-- **Manual processes**: Human-driven promotions are error-prone and slow - automate with CI/CD and approval workflows
 - **Lost artifacts**: Model registered but artifacts deleted from storage - ensure artifact retention policies align with model lifecycle
 
 ## Related Skills

--- a/skills/render-blender-output/SKILL.md
+++ b/skills/render-blender-output/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: blender
   complexity: intermediate
   language: Python
@@ -328,7 +328,7 @@ def render_frame(frame_number):
 ```
 
 **Expected:** Render executes, output files written to specified location
-**On failure:** Check scene setup, verify camera exists, ensure output directory writable
+**On failure:** Check scene setup, verify `scene.camera` points at an active camera — a camera object merely existing in the scene does NOT make it the render camera — ensure output directory writable
 
 ### 7. Batch Render Multiple Cameras
 
@@ -419,16 +419,12 @@ def optimize_performance():
 
 ## Common Pitfalls
 
-1. **Missing camera**: Scene must have active camera set for rendering
-2. **Output path not set**: Always specify `scene.render.filepath` before rendering
-3. **Insufficient samples**: Low sample counts cause noise in Cycles renders
-4. **Wrong color space**: Check color management settings for correct display
-5. **File format incompatibility**: Not all formats support all color depths
-6. **Memory overflow**: Large resolutions or complex scenes may exceed RAM
-7. **GPU out of memory**: Reduce tile size or switch to CPU for large scenes
-8. **Background mode output**: In background mode, must use --render-output flag or set filepath
-9. **Frame number formatting**: Use #### for automatic frame padding
-10. **Compositing disabled**: Enable `scene.use_nodes` to use compositing
+1. **Insufficient samples**: Low sample counts cause noise in Cycles renders
+2. **Wrong color space**: Check color management settings for correct display
+3. **Memory overflow**: Large resolutions or complex scenes may exceed RAM
+4. **GPU out of memory**: Reduce tile size or switch to CPU for large scenes
+5. **Background mode output**: In background mode, must use --render-output flag or set filepath
+6. **Compositing disabled**: Enable `scene.use_nodes` to use compositing
 
 ## Related Skills
 

--- a/skills/render-publication-graphic/SKILL.md
+++ b/skills/render-publication-graphic/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: visualization
   complexity: intermediate
   language: multi
@@ -476,13 +476,9 @@ embed_metadata('figure1.png', 'figure1_with_metadata.png', metadata)
 1. **Insufficient resolution**: 72 DPI web graphics cannot be printed at quality
 2. **Wrong color space**: RGB graphics may print differently than displayed
 3. **Font substitution**: Non-embedded fonts replaced with defaults
-4. **Small text**: Fonts below 8pt may be illegible when printed
-5. **Thin lines**: Lines below 0.5pt may not print clearly
-6. **File size**: High DPI graphics can be very large, compress appropriately
-7. **Compression artifacts**: JPEG compression unsuitable for line art or text
-8. **Missing bleed**: Print graphics need 3-5mm bleed beyond trim
-9. **Transparency issues**: Some formats don't preserve transparency correctly
-10. **Aspect ratio**: Distortion from incorrect dimension calculations
+4. **Compression artifacts**: JPEG compression unsuitable for line art or text
+5. **Transparency issues**: Some formats don't preserve transparency correctly
+6. **Aspect ratio**: Distortion from incorrect dimension calculations
 
 ## Related Skills
 

--- a/skills/script-blender-automation/SKILL.md
+++ b/skills/script-blender-automation/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: blender
   complexity: advanced
   language: Python
@@ -281,7 +281,7 @@ if __name__ == "__main__":
 ```
 
 **Expected:** Operator appears in search, executes with proper undo support
-**On failure:** Check bl_idname format (lowercase with underscores), verify property types
+**On failure:** Check bl_idname format (lowercase `category.name` — a dotted category prefix is required, underscores between words), verify property types
 
 ### 5. Modal Operator for Interactive Tools
 
@@ -382,8 +382,8 @@ if __name__ == "__main__":
     register()
 ```
 
-**Expected:** Add-on installs via Preferences, operators appear in menus
-**On failure:** Check bl_info format, verify Blender version requirement, ensure all classes listed
+**Expected:** Add-on installs via Preferences, which copies it into Blender's `scripts/addons` directory — a script left anywhere else is not an installed add-on; operators appear in menus
+**On failure:** Check bl_info format, verify Blender version requirement, ensure all classes listed, import add-on submodules relatively (`from .operators import ...`) so they do not resolve into circular imports
 
 ### 7. Data-Driven Procedural Generation
 
@@ -454,16 +454,12 @@ def create_from_json(filepath):
 
 ## Common Pitfalls
 
-1. **Circular imports in add-ons**: Use relative imports, structure modules carefully
-2. **Operator naming**: bl_idname must be lowercase with single underscore (category.name)
-3. **Property types**: Use correct bpy.props types (FloatProperty, IntProperty, etc.)
-4. **Context access**: Not all operators work in all contexts (viewport vs render)
-5. **BMesh cleanup**: Always call `bm.free()` after `bm.to_mesh()` to prevent memory leaks
-6. **Animation keyframe timing**: Frame numbers start at 1, not 0
-7. **Driver expression errors**: Validate expressions, use safe namespace
-8. **Modal operator blocking**: Don't block in modal(), use non-blocking operations
-9. **Add-on installation paths**: Place in Blender's scripts/addons directory
-10. **Version compatibility**: API changes between Blender versions, document requirements
+1. **Context access**: Not all operators work in all contexts (viewport vs render)
+2. **BMesh cleanup**: Always call `bm.free()` after `bm.to_mesh()` to prevent memory leaks
+3. **Animation keyframe timing**: Frame numbers start at 1, not 0
+4. **Driver expression errors**: Validate expressions, use safe namespace
+5. **Modal operator blocking**: Don't block in modal(), use non-blocking operations
+6. **Version compatibility**: API changes between Blender versions, document requirements
 
 ## Related Skills
 

--- a/skills/script-blender-automation/SKILL.md
+++ b/skills/script-blender-automation/SKILL.md
@@ -383,7 +383,7 @@ if __name__ == "__main__":
 ```
 
 **Expected:** Add-on installs via Preferences, which copies it into Blender's `scripts/addons` directory — a script left anywhere else is not an installed add-on; operators appear in menus
-**On failure:** Check bl_info format, verify Blender version requirement, ensure all classes listed, import add-on submodules relatively (`from .operators import ...`) so they do not resolve into circular imports
+**On failure:** Check bl_info format, verify Blender version requirement, ensure all classes listed, import add-on submodules relatively (`from .operators import ...`) so they resolve against the add-on package rather than a same-named top-level module, and keep the dependency direction one-way (`__init__` imports operators, never the reverse) to avoid circular imports
 
 ### 7. Data-Driven Procedural Generation
 

--- a/skills/select-print-material/SKILL.md
+++ b/skills/select-print-material/SKILL.md
@@ -170,7 +170,7 @@ Assess printing difficulty vs. performance for candidates:
 - Moderate warping (PETG needs 70°C+ bed)
 - Some stringing (tune retraction)
 - TPU requires direct drive extruder, slow speeds
-- TPU is hygroscopic despite its low print and bed temperatures — a dry box is required, not optional; wet TPU does not fail loudly, it just prints stringy with weak, tear-prone layer bonds
+- TPU is hygroscopic despite its low print and bed temperatures — a dry box is required, not optional; wet TPU can fail quietly — you may get no audible popping at all, only stringing and weak, tear-prone layer bonds — so an absence of symptoms is not evidence of dryness
 - Good strength-to-ease ratio
 - **Tradeoff**: PETG strings easily, TPU challenging for overhangs
 
@@ -225,7 +225,7 @@ Verify material compatibility with special use cases:
 **UV Resistance**:
 - **Excellent**: ASA (designed for outdoor), Nylon
 - **Good**: PETG, TPU
-- **Poor**: PLA (yellows and degrades), ABS (yellows) — outdoor sunlight embrittles both within months, not years; treat "it survived a summer" as no evidence of durability
+- **Poor**: PLA (yellows and degrades), ABS (yellows) — outdoor sunlight embrittles both within months, not years, so a single summer outdoors is not enough to qualify a part for multi-year service
 
 **Expected:** Special requirements verified against material capabilities.
 

--- a/skills/select-print-material/SKILL.md
+++ b/skills/select-print-material/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob WebFetch
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: 3d-printing
   complexity: intermediate
   language: multi
@@ -109,7 +109,7 @@ Fatigue resistance:       Nylon > PETG > ABS > PLA
 UV resistance:            ASA > PETG > ABS > PLA (poor)
 Chemical resistance:      Nylon > PETG > ABS/ASA > PLA
 Outdoor durability:       ASA > Nylon > PETG > PLA (degrades)
-Moisture resistance:      ABS/ASA > PETG > PLA > Nylon (hygroscopic)
+Moisture resistance:      ABS/ASA > PETG > PLA > TPU/Nylon (both hygroscopic)
 ```
 
 **Expected:** 2-5 candidate materials remain after filtering.
@@ -129,7 +129,7 @@ Consult material property table for detailed comparison:
 | **PETG** | 220-250°C | 70-85°C | 50-60 MPa | 15-20% | 75-80°C | Good | Medium | Medium |
 | **ABS** | 230-260°C | 95-110°C | 40-50 MPa | 20-40% | 95-105°C | Fair | Hard | Low |
 | **ASA** | 240-260°C | 95-110°C | 45-55 MPa | 15-30% | 95-105°C | Excellent | Hard | Low |
-| **TPU** | 210-230°C | 40-60°C | 30-50 MPa | 400-600% | 60-80°C | Good | Medium | Low |
+| **TPU** | 210-230°C | 40-60°C | 30-50 MPa | 400-600% | 60-80°C | Good | Medium | High |
 | **Nylon** | 240-270°C | 70-90°C | 70-80 MPa | 50-150% | 75-90°C | Excellent | Hard | Very High |
 
 **Notes**:
@@ -170,6 +170,7 @@ Assess printing difficulty vs. performance for candidates:
 - Moderate warping (PETG needs 70°C+ bed)
 - Some stringing (tune retraction)
 - TPU requires direct drive extruder, slow speeds
+- TPU is hygroscopic despite its low print and bed temperatures — a dry box is required, not optional; wet TPU does not fail loudly, it just prints stringy with weak, tear-prone layer bonds
 - Good strength-to-ease ratio
 - **Tradeoff**: PETG strings easily, TPU challenging for overhangs
 
@@ -224,7 +225,7 @@ Verify material compatibility with special use cases:
 **UV Resistance**:
 - **Excellent**: ASA (designed for outdoor), Nylon
 - **Good**: PETG, TPU
-- **Poor**: PLA (yellows and degrades), ABS (yellows)
+- **Poor**: PLA (yellows and degrades), ABS (yellows) — outdoor sunlight embrittles both within months, not years; treat "it survived a summer" as no evidence of durability
 
 **Expected:** Special requirements verified against material capabilities.
 
@@ -301,16 +302,12 @@ notes: "Post-cure 15min at 60°C for full strength. Brittle without cure."
 
 ## Common Pitfalls
 
-1. **Choosing PLA for everything**: PLA is easy but unsuitable for temperature >50°C, outdoor use, or long-term durability
-2. **Ignoring hygroscopy**: Nylon and TPU absorb moisture from air, causing bubbling, poor adhesion, and brittleness—must use dry box
-3. **ABS without enclosure**: ABS warps severely without heated chamber; ASA slightly better but still needs enclosure
-4. **Assuming food safety**: FDM parts are porous and trap bacteria; true food safety requires sealing or using SLA smooth resin
-5. **Over-designing for strength**: Using expensive Nylon when PETG sufficient; overkill wastes money and adds printing difficulty
-6. **Underestimating temperature**: Parts near motors, heated beds, or in cars reach 60°C+ where PLA softens
-7. **UV exposure neglect**: PLA and ABS yellow and degrade in sunlight within months; use ASA or coat with UV-resistant finish
-8. **Wet filament printing**: Moisture causes steam bubbles in extruder, weak layer adhesion, stringing—always dry hygroscopic materials
-9. **Ignoring fumes**: ABS and ASA emit styrene fumes; requires active ventilation (not just open window)
-10. **Resin handling**: Uncured resin is skin sensitizer and toxic; always wear gloves and work in ventilated area
+1. **ABS without enclosure**: ABS warps severely without heated chamber; ASA slightly better but still needs enclosure
+2. **Assuming food safety**: FDM parts are porous and trap bacteria; true food safety requires sealing or using SLA smooth resin
+3. **Underestimating temperature**: Parts near motors, heated beds, or in cars reach 60°C+ where PLA softens
+4. **Wet filament printing**: Moisture causes steam bubbles in extruder, weak layer adhesion, stringing, and brittle finished parts—always dry hygroscopic materials
+5. **Ignoring fumes**: ABS and ASA emit styrene fumes; requires active ventilation (not just open window)
+6. **Resin handling**: Uncured resin is skin sensitizer and toxic; always wear gloves and work in ventilated area
 
 ## Related Skills
 

--- a/skills/setup-local-kubernetes/SKILL.md
+++ b/skills/setup-local-kubernetes/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: devops
   complexity: basic
   language: multi
@@ -35,7 +35,7 @@ Create a local Kubernetes development environment for fast iteration and testing
 ## Inputs
 
 - **Required**: Docker Desktop or Docker Engine installed
-- **Required**: At least 4GB RAM available for cluster
+- **Required**: At least 4GB RAM and 2 CPU cores available for cluster
 - **Required**: Choice of local cluster tool (kind, k3d, or minikube)
 - **Optional**: Application source code to deploy
 - **Optional**: Kubernetes version preference
@@ -170,7 +170,7 @@ kubectl delete deployment,service hello
 **Expected:** Multi-node cluster running with control plane and worker nodes. Ingress controller installed and ready. Local registry accessible at localhost:5000. kubectl context set to new cluster. Test deployment successful.
 
 **On failure:**
-- Check Docker has sufficient resources (4GB+ memory recommended)
+- Check Docker has sufficient resources (4GB+ memory, 2+ CPU cores recommended)
 - Verify no port conflicts: `lsof -i :80,443,5000,6550`
 - For kind: ensure Docker desktop Kubernetes is disabled (conflicts)
 - For k3d: check Docker network connectivity
@@ -267,7 +267,7 @@ curl http://my-app.local
 **On failure:**
 - Verify Docker daemon accessible: `docker ps`
 - Check if local registry reachable: `curl http://localhost:5000/v2/_catalog`
-- For file sync issues, ensure paths in config match actual structure
+- For file sync issues, ensure paths in skaffold.yaml/Tiltfile match actual structure and the Dockerfile WORKDIR
 - Review Skaffold/Tilt logs for build errors
 - Ensure Dockerfile has proper base image and builds successfully: `docker build .`
 - Check resource limits not causing OOMKills: `kubectl describe pod -l app=my-app`
@@ -333,7 +333,7 @@ kubectl wait --for=condition=ready pod -l app=postgres --timeout=60s
 kubectl exec -it postgres-0 -- psql -U devuser -d devdb -c "SELECT version();"
 ```
 
-**Expected:** Storage class configured for dynamic provisioning. Database pods running and ready. Services accessible via port-forward or from other pods. Data persists across pod restarts. Resource usage appropriate for development (small limits).
+**Expected:** Storage class configured for dynamic provisioning. Database pods running and ready. Services accessible via port-forward or from other pods. Data persists across pod restarts. Resource usage appropriate for development (small limits — do not copy production resource specs to local).
 
 **On failure:**
 - Check if storage provisioner installed: `kubectl get storageclass`
@@ -443,21 +443,13 @@ docker system prune -f
 
 ## Common Pitfalls
 
-- **Insufficient Resources**: Local clusters need 4GB+ RAM, 2+ CPU cores. Check Docker Desktop settings. Reduce replicas and resource requests for development.
-
-- **Port Conflicts**: Ports 80, 443, 5000 commonly used. Check with `lsof -i :<port>` before cluster creation. Adjust port mappings if needed.
-
 - **Slow Rebuilds**: Without proper caching, Docker rebuilds are slow. Use multi-stage builds, .dockerignore, and BuildKit. Enable Skaffold/Tilt caching.
 
 - **Context Confusion**: Multiple kubectl contexts cause confusion. Use `kubectl config current-context` and `kubectx` tool to switch clearly.
 
-- **File Sync Not Working**: Path mismatches between host and container break sync. Verify paths in skaffold.yaml/Tiltfile match Dockerfile WORKDIR.
-
 - **Ingress Not Resolving**: Forgot to add entry to /etc/hosts. Or ingress controller not ready. Wait for controller pods before testing.
 
 - **Database Data Loss**: Default storage ephemeral. Use PersistentVolumes for data that should survive restarts. Be explicit about storage class.
-
-- **Resource Limits Too High**: Don't copy production resource specs to local. Reduce limits significantly for local development to fit in Docker Desktop.
 
 - **Network Isolation**: Local cluster can't always reach host services. Use `host.docker.internal` (Docker Desktop) or ngrok for reverse proxying.
 

--- a/skills/setup-service-mesh/SKILL.md
+++ b/skills/setup-service-mesh/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: devops
   complexity: advanced
   language: multi
@@ -80,7 +80,7 @@ spec:
 **Expected:** Control plane pods running in istio-system (Istio) or linkerd (Linkerd) namespace. `istioctl version` or `linkerd version` shows matching client and server versions.
 
 **On failure:**
-- Check cluster has sufficient resources (at least 4 CPU cores, 8GB RAM for production)
+- Check cluster has sufficient resources (at least 4 CPU cores, 8GB RAM for production; sidecar proxies add another 100-200MB memory per pod on top of control-plane needs)
 - Verify Kubernetes version compatibility (check mesh documentation)
 - Review logs: `kubectl logs -n istio-system -l app=istiod` or `kubectl logs -n linkerd -l linkerd.io/control-plane-component=controller`
 - Check for conflicting CRDs: `kubectl get crd | grep istio` or `kubectl get crd | grep linkerd`
@@ -169,7 +169,7 @@ istioctl authn tls-check $(kubectl get pod -n default -l app=test-app -o jsonpat
 **On failure:**
 - Check certificate issuance: `kubectl get certificates -A` (cert-manager)
 - Verify CA is healthy: `kubectl logs -n istio-system -l app=istiod | grep -i cert`
-- Test with PERMISSIVE mode first, then transition to STRICT
+- Test with PERMISSIVE mode first — do NOT enable STRICT immediately in production; verify all services are meshed, then transition to STRICT
 - Check for services without sidecars: `kubectl get pods --all-namespaces -o json | jq '.items[] | select(.spec.containers | length == 1) | .metadata.name'`
 
 ### Step 4: Implement Traffic Management Rules
@@ -219,6 +219,7 @@ for i in {1..100}; do curl -s http://api.example.com/api/v2 | grep version; done
 
 **On failure:**
 - Verify destination hosts resolve: `kubectl get svc -n production`
+- For external traffic, a VirtualService alone does NOT expose the service — a Gateway resource (ingress) is required alongside it
 - Check subset labels match pod labels: `kubectl get pods -n production --show-labels`
 - Review pilot logs: `kubectl logs -n istio-system -l app=istiod`
 - Test without circuit breaker first, then add incrementally
@@ -330,8 +331,6 @@ istioctl analyze --all-namespaces
 
 ## Common Pitfalls
 
-- **Resource Exhaustion**: Service mesh adds 100-200MB memory per pod for sidecars. Ensure cluster has sufficient capacity. Set appropriate resource limits in injection config.
-
 - **Configuration Conflicts**: Multiple VirtualServices for same host cause undefined behavior. Use single VirtualService per host with multiple match conditions instead.
 
 - **Certificate Expiration**: mTLS certificates auto-rotate but CA root must be managed. Monitor certificate expiry with: `kubectl get certificate -A` and set up alerts.
@@ -342,13 +341,7 @@ istioctl analyze --all-namespaces
 
 - **Port Naming Requirement**: Istio requires named ports following protocol-name pattern (e.g., http-web, tcp-db). Unnamed ports default to TCP passthrough.
 
-- **Gradual Rollout Required**: Don't enable STRICT mTLS immediately in production. Use PERMISSIVE mode during migration, verify all services meshed, then switch to STRICT.
-
 - **Observability Overhead**: 100% tracing sampling causes performance issues. Use 1-10% for production: `sampling: 1.0` in mesh config.
-
-- **Gateway vs VirtualService Confusion**: Gateway configures ingress (load balancer), VirtualService configures routing. Both required for external traffic.
-
-- **Version Compatibility**: Ensure mesh version compatible with Kubernetes version. Istio supports n-1 minor versions, Linkerd typically supports last 3 Kubernetes versions.
 
 ## Related Skills
 

--- a/skills/troubleshoot-print-issues/SKILL.md
+++ b/skills/troubleshoot-print-issues/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob WebFetch
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: 3d-printing
   complexity: intermediate
   language: multi
@@ -142,7 +142,7 @@ Root cause: Material choice (ABS) incompatible with open printer in drafty room
 
 **Expected:** Root cause identified with supporting evidence (measured temperatures, belt tension, visual inspection).
 
-**On failure:** If root cause unclear, use elimination method: fix most likely cause, re-test, repeat until resolved.
+**On failure:** If root cause unclear, use elimination method: fix most likely cause, re-test, repeat until resolved. Change one parameter per test—if you stack changes you will not know which one fixed the print, or which one made it worse.
 
 ### 4. Apply First-Level Fixes
 
@@ -177,9 +177,9 @@ Implement immediate solutions for common issues:
 - Add brim: 8-10mm for small footprint parts
 - Add raft: For very difficult materials (TPU, Nylon)
 
-**Expected:** First layer adheres completely with no lifting.
+**Expected:** First layer adheres completely with no lifting. Z-offset is the usual culprit in both directions—too high and the lines never fuse, too low and the nozzle scrapes the bed and starves the flow.
 
-**On failure:** Check bed flatness with feeler gauge or mesh leveling; warped bed requires glass/PEI sheet or mesh compensation.
+**On failure:** Check bed flatness with feeler gauge or mesh leveling; warped bed requires glass/PEI sheet or mesh compensation. A bed that was level last month is not still level—beds warp, springs compress, and adjustments slip, so re-level weekly instead of trusting a past leveling.
 
 ### Stringing
 
@@ -379,16 +379,12 @@ notes: "Check belt tension monthly, pulley tends to slip"
 
 ## Common Pitfalls
 
-1. **Changing multiple variables**: Adjust one parameter at a time; otherwise you won't know what fixed it (or made it worse)
-2. **Ignoring wet filament**: Hygroscopic materials (Nylon, TPU, PETG) absorb moisture causing bubbling, stringing, poor adhesion—always suspect wet filament first
-3. **Skipping mechanical checks**: Loose belts and worn components cause issues no amount of slicer tuning can fix
-4. **Temperature from internet**: Every printer/material combination is unique—always run your own temperature tower
-5. **Over-tightening belts**: Too tight = premature bearing wear; aim for guitar string tension, not steel cable
-6. **Blaming slicer**: Slicer bugs are rare; 95% of issues are mechanical, thermal, or material-related
-7. **Not cleaning nozzle**: Partial clogs cause intermittent under-extrusion that looks like flow/e-step issues
-8. **Assuming bed is level**: Beds warp over time, springs compress, and adjustments slip—re-level weekly for reliable results
-9. **Wrong Z-offset**: Most first layer failures are Z-offset too high (not enough squish) or too low (nozzle scraping bed)
-10. **Environmental neglect**: ABS/ASA in 15°C garage with drafts will never print well—material requires stable warm environment
+1. **Ignoring wet filament**: Hygroscopic materials (Nylon, TPU, PETG) absorb moisture causing bubbling, stringing, poor adhesion—always suspect wet filament first
+2. **Skipping mechanical checks**: Loose belts and worn components cause issues no amount of slicer tuning can fix
+3. **Temperature from internet**: Every printer/material combination is unique—always run your own temperature tower
+4. **Over-tightening belts**: Too tight = premature bearing wear; aim for guitar string tension, not steel cable
+5. **Blaming slicer**: Slicer bugs are rare; 95% of issues are mechanical, thermal, or material-related
+6. **Not cleaning nozzle**: Partial clogs cause intermittent under-extrusion that looks like flow/e-step issues
 
 ## Related Skills
 

--- a/skills/version-ml-data/SKILL.md
+++ b/skills/version-ml-data/SKILL.md
@@ -210,7 +210,7 @@ dvc repro
 
 **Expected:** DVC pipeline executes in correct dependency order, only changed stages rerun, outputs cached efficiently, metrics tracked automatically, Git commits include `dvc.yaml` and `dvc.lock`.
 
-**On failure:** Check script paths exist and are executable, verify dependencies specified correctly, ensure params.yaml keys match script usage, check for circular dependencies in pipeline, verify output paths writable, inspect script error messages in stderr, check Python environment has required packages. If unchanged stages rerun, run `dvc status` to see what DVC considers changed — cached stages do NOT rerun unless a dep, param, cmd, or output differs, so barring `dvc repro -f`, a rerun always means something changed.
+**On failure:** Check script paths exist and are executable, verify dependencies specified correctly, ensure params.yaml keys match script usage, check for circular dependencies in pipeline, verify output paths writable, inspect script error messages in stderr, check Python environment has required packages. If unchanged stages rerun, run `dvc status` to see what DVC considers changed — cached stages do NOT rerun unless a dep, param, cmd, or output differs, so barring `dvc repro -f` or a stage marked `always_changed: true` (which includes any stage declaring no deps and no outs), a rerun always means something changed.
 
 ### Step 5: Share and Reproduce Data Versions
 

--- a/skills/version-ml-data/SKILL.md
+++ b/skills/version-ml-data/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.0"
+  version: "1.1"
   domain: mlops
   complexity: intermediate
   language: multi
@@ -210,7 +210,7 @@ dvc repro
 
 **Expected:** DVC pipeline executes in correct dependency order, only changed stages rerun, outputs cached efficiently, metrics tracked automatically, Git commits include `dvc.yaml` and `dvc.lock`.
 
-**On failure:** Check script paths exist and are executable, verify dependencies specified correctly, ensure params.yaml keys match script usage, check for circular dependencies in pipeline, verify output paths writable, inspect script error messages in stderr, check Python environment has required packages.
+**On failure:** Check script paths exist and are executable, verify dependencies specified correctly, ensure params.yaml keys match script usage, check for circular dependencies in pipeline, verify output paths writable, inspect script error messages in stderr, check Python environment has required packages. If unchanged stages rerun, run `dvc status` to see what DVC considers changed — cached stages do NOT rerun unless a dep, param, cmd, or output differs, so barring `dvc repro -f`, a rerun always means something changed.
 
 ### Step 5: Share and Reproduce Data Versions
 
@@ -311,15 +311,11 @@ on:
 ## Common Pitfalls
 
 - **Committing large files to Git**: Forgot to run `dvc add` first - always use DVC for large files (>10MB), check `.gitignore`
-- **Missing remote configuration**: `dvc push` fails because no remote - configure remote before sharing, test with `dvc remote list`
 - **Lost data versions**: Deleted `.dvc/cache` without pushing - always `dvc push` before cleaning cache
-- **Inconsistent environments**: Different Python/package versions - use virtual environments, pin dependencies in `requirements.txt`
 - **Broken pipelines**: Changed script without updating `dvc.yaml` - keep pipeline definitions in sync with code
-- **Slow pipeline**: Rerunning unchanged stages - DVC caches by default, check `dvc status` to diagnose
 - **Merge conflicts**: `.dvc` files conflict during merges - resolve like code conflicts, use `dvc checkout` after resolution
 - **Large pull times**: Pulling all data for small experiments - use `dvc pull <specific.dvc>` for selective pulls
 - **Credential leaks**: Committing `.dvc/config.local` - keep credentials in `config.local` (git-ignored), not `config`
-- **No data lineage**: Not tracking preprocessing steps - use DVC pipelines to track all transformations
 
 ## Related Skills
 


### PR DESCRIPTION
## Summary

The one-time eviction pass on the `>=9`-pitfall tail. All 24 skills go to exactly **6** pitfalls, one commit per skill so each diff is individually reviewable (issue AC 4).

Six skills carry a second, follow-up commit. Their first commit captured the file mid-run, before the verify tier's repair round had finished writing — a background `git status` poll loop of mine was contending for `.git/index.lock` and silently starving the commit loop (it kept exiting 0 while the commits failed). The follow-up commits carry the remainder. Net content is identical to a clean run; only the commit boundaries differ.

71 evictions total. **37** were covered by a Procedure step that already taught the content; **34** required folding the bullet's counterintuitive kernel into that step *first*, per the rule at `evolve-skill:132`. Both list formats in the tail were preserved rather than normalized — 16 dash-bullet skills and 8 numbered skills, with numbered survivors renumbered contiguously 1–6. (An earlier revision of this body said 9 and 10; those came from the generating run's own `listFormat` self-reports, which covered only 19 of 24 skills and were wrong. Counted from disk.)

## Why the scope is 24 and not 16

The issue was filed against a 16-skill tail measured with a dash-only counter, which reads 0 for skills that format pitfalls as numbered lists. The corrected count adds the 8-skill blender/3d-printing family. The counter is now committed as `scripts/audit-skill-sections.js` (PR #402) and handles both formats, so this class of undercount cannot recur silently.

## Verification

Every skill went through an adversarial verify agent instructed to hunt specifically for a **lost negation** — the documented failure mode, after PRs #381 and #387 each lost an inoculating negation and needed review-driven fold-backs.

**21 passed, 3 failed, all 3 repaired.** The failures are the interesting part, because they are exactly what the tier exists to catch:

1. **`navigate-dach-bureaucracy` — a fabricated claim.** The fold asserted "a foreign account does not substitute", which appeared in neither the evicted bullet nor anywhere else in the file. An invented fact is worse than a dropped one: it reads as authoritative and nothing downstream contradicts it. The repair replaced it with a specific, checkable claim — in Switzerland a foreign account will not work for CHF salary or LSV+ direct debit.
2. **`select-print-material` — lost TPU kernel.** The eviction dropped the fact that TPU is hygroscopic despite its low print temperatures, and the editing agent's rationale for skipping the fold was inverted by the evidence. Restored in negation form: "a dry box is required, not optional; wet TPU does not fail loudly, it just prints stringy with weak, tear-prone layer bonds".
3. **`prepare-print-model` — lost orientation kernel.** Evicted with `folded: false` although the named covering step taught only part of it. Restored as a concrete worked example in Step 4.

Three further advisory findings from the verify tier were folded in on top:

- **`version-ml-data` — a factual error introduced by an otherwise good fold.** It claimed "a rerun always means something changed", which `dvc repro -f` falsifies. Tightened to keep the negation while naming the exception.
- **`optimize-cloud-costs`** — the evicted quota bullet's operational mitigation (review monthly, communicate before enforcing) survived nowhere; appended to the Step 7 On-failure block.
- **`setup-local-kubernetes`** — the 2-CPU-core prerequisite had landed only in reactive failure-path text; promoted to Inputs where it belongs as a pre-flight requirement.

Corpus checks: all 24 at exactly 6 pitfalls, all six required sections present, all under 500 lines, no CRLF introduced.

## Model provenance — please read before approving

This pass spans two models. A Fable 5 workflow hit the usage-credit ceiling mid-run and it resumed on Opus 4.8, so **no skill here carries Fable verification** — the interruption killed all 24 first-run verify agents.

- **Fable-authored eviction decisions (8):** `assess-github-repo-security`, `deploy-ml-model-serving`, `optimize-cloud-costs`, `orchestrate-ml-pipeline`, `prune-agent-memory`, `setup-local-kubernetes`, `setup-service-mesh`, `version-ml-data`.
- **Fable-authored folds, Opus-authored evictions (4):** `build-feature-store`, `configure-api-gateway`, `enforce-policy-as-code`, `navigate-dach-bureaucracy`. Fable's fold edits were preserved verbatim; only the "which four to remove" decision is Opus's.
- **Fully Opus (12):** the remainder.
- **All 24 verifications:** Opus.

Tracked in **#400** with a per-skill checklist and the recheck procedure, filed at the maintainer's request. Eviction is judgment work, so the provenance is worth keeping rather than assuming parity.

## Known follow-up

The 10 i18n mirrors of each touched skill will report a stale `source_commit` once this lands. `validate:translations` is warn-only, so this does not block. Refreshing ~240 translated files belongs to the existing bulk-refresh issue **#278**, not here.

Closes #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jDb5BjxdjNi7xL34YfgiM

