### PR TITLE
evolve(create-skill): add a pitfall on unverified tool-behavior claims

### DIFF
--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -379,9 +379,9 @@ npm run translation:status
 - **Missing On failure**: Every step that can fail needs recovery guidance. Agents can't improvise — they need the fallback spelled out.
 - **Overly broad scope**: A skill that tries to cover "Set up entire development environment" should be 3-5 focused skills instead. One skill = one procedure.
 - **Stale cross-references**: When renaming or removing skills, grep for the old name in all Related Skills sections.
-- **Asserting tool behaviour you have not checked**: The claim you feel surest about is the one to verify. "The default is X", "this fails with Y", "the tag falls back to latest" — such statements read as authoritative and nothing downstream contradicts them, so a wrong one survives review and misleads every run that follows. Check the primary docs while writing, and prefer a failure you have observed over one you believe exists.
 - **Authoring at 500-line limit for single language**: An English skill at 490 lines will exceed 500 when translated to German (~10-20% expansion) or CJK languages. Target ~400 lines for the English source and use progressive disclosure (`references/EXAMPLES.md`) for the rest.
 - **Avoid `git mv` on NTFS-mounted paths (WSL)**: On `/mnt/` paths, `git mv` for directories can create broken permissions (`d?????????`). Use `mkdir -p` + copy files + `git rm` the old path instead. See the [environment guide](../../guides/setting-up-your-environment.md) troubleshooting section.
+- **Asserting tool behavior you have not checked**: The claim you feel surest about is the one to verify — "the default is X" reads as authoritative, so a wrong one survives review by default. Cite the doc you checked, and prefer a failure you observed over one you believe exists.
 
 ## Examples
 

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.4"
+  version: "1.5"
   domain: general
   complexity: intermediate
   language: multi
@@ -379,7 +379,7 @@ npm run translation:status
 - **Missing On failure**: Every step that can fail needs recovery guidance. Agents can't improvise — they need the fallback spelled out.
 - **Overly broad scope**: A skill that tries to cover "Set up entire development environment" should be 3-5 focused skills instead. One skill = one procedure.
 - **Stale cross-references**: When renaming or removing skills, grep for the old name in all Related Skills sections.
-- **Description too long**: The description field is what agents read to decide activation. Keep it under 1024 characters and front-load the key information.
+- **Asserting tool behaviour you have not checked**: The claim you feel surest about is the one to verify. "The default is X", "this fails with Y", "the tag falls back to latest" — such statements read as authoritative and nothing downstream contradicts them, so a wrong one survives review and misleads every run that follows. Check the primary docs while writing, and prefer a failure you have observed over one you believe exists.
 - **Authoring at 500-line limit for single language**: An English skill at 490 lines will exceed 500 when translated to German (~10-20% expansion) or CJK languages. Target ~400 lines for the English source and use progressive disclosure (`references/EXAMPLES.md`) for the rest.
 - **Avoid `git mv` on NTFS-mounted paths (WSL)**: On `/mnt/` paths, `git mv` for directories can create broken permissions (`d?????????`). Use `mkdir -p` + copy files + `git rm` the old path instead. See the [environment guide](../../guides/setting-up-your-environment.md) troubleshooting section.
 


### PR DESCRIPTION
## Why

The sharpest lesson from today's sweep, encoded so it survives the session.

Three Helm pitfalls I authored in #402 were factually wrong. None was written carelessly — each was written **confidently**, and that was the mechanism:

- "hook Jobs accumulate and a re-install fails on the name collision" — Helm's default `before-hook-creation` policy deletes the prior hook, so no collision occurs
- "an empty tag makes each install pull whatever `latest` points to" — with the skill's own `| default .Chart.AppVersion` template it resolves to AppVersion, and a bare trailing colon is `InvalidImageName`, not `latest`
- "values deep-merge, they do not replace" — true for maps, false for lists, and contradicted by the skill's own `values-dev.yaml`

The adversarial reviewer caught all three, but only because it checked upstream docs instead of accepting the prose. Nothing downstream contradicts a confidently-wrong claim, so it survives review by default and misleads every run that follows.

The generalizable rule: **confidence is the signal to verify, not to skip verifying** — and an observed failure mode beats a believed one.

## The eviction

`create-skill` was at the 6-pitfall cap, so per the rule at `evolve-skill:132` this evicts rather than appends. Removed **Description too long**, the lowest-rediscovery-cost entry in the set — every claim it made is already taught three times:

| Where | What it already says |
|---|---|
| Frontmatter template `:74-77` | "Must be clear enough for an agent to decide whether to activate this skill from the description alone. Max 1024 characters. Start with a verb." |
| Step 2 Expected `:99` | repeats the 1024 limit and activation triggers |
| Validation checklist `:365` | `description` is under 1024 characters |

Its one distinct phrase — "front-load the key information" — is what "Start with a verb" already instructs. **No fold was needed**, because no kernel was unique to it.

### Considered and rejected as eviction candidates

- **Stale cross-references** looks redundant with Step 9's On-failure block, but is not. Step 9 teaches the *outbound* direction (verify my references resolve); the pitfall teaches the *inbound* one (renaming a skill breaks references held by other skills). Evicting it would have required a fold first.
- **Missing On failure** is taught at `:186`, but its "agents can't improvise" clause is the motivating *why*, stated nowhere else.

## Verification

`node scripts/audit-skill-sections.js create-skill` → 6 pitfalls, all six sections, 411 lines. Corpus gate, `validate:i18n-parity` (3576 files), and `check-content-style --added` all clean. LF only.

Version `1.4 → 1.5` — additive under the criterion clarified in #388: a caller following 1.4 still gets a correct result.

## Translations

Flagged for re-sync (10 locales): de, zh-CN, ja, es, caveman{,-lite,-ultra}, wenyan{,-lite,-ultra}. Changed section: Common Pitfalls.

Per **#405**, `source_commit` is deliberately **not** bumped — the locale copies were not re-translated, and bumping would mark stale content as fresh and suppress the very freshness signal that should surface it.

## Related

Sibling of **#408**, which records the adjacent observation (a repaired fold carries higher residual risk than an untouched one) and is deliberately *not* yet encoded — one data point, where the fold-first rule earned its place only after two independent recurrences. This pitfall has three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jDb5BjxdjNi7xL34YfgiM