### PR TITLE
fix: close three self-contained issues (#398 apa-specialist drift, #401 locale JSON gate, #410 evolve-skill counts)

### DIFF
--- a/.github/workflows/validate-locales-json.yml
+++ b/.github/workflows/validate-locales-json.yml
@@ -1,0 +1,31 @@
+name: Validate Locale JSON
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'viz/public/locales/**'
+      - 'scripts/validate-locales-json.js'
+      - '.github/workflows/validate-locales-json.yml'
+  pull_request:
+    paths:
+      - 'viz/public/locales/**'
+      - 'scripts/validate-locales-json.js'
+      - '.github/workflows/validate-locales-json.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  locales-json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Validate viz UI locale JSON
+        run: node scripts/validate-locales-json.js

--- a/agents/apa-specialist.md
+++ b/agents/apa-specialist.md
@@ -4,15 +4,17 @@ description: APA 7th edition compliance specialist for academic manuscripts, cov
 tools: [Read, Write, Edit, Bash, Grep, Glob]
 intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "1.1.0"
 author: Philipp Thoss
 created: 2026-02-19
-updated: 2026-02-19
+updated: 2026-07-24
 tags: [apa, academic-writing, citations, formatting, quarto]
 priority: normal
 max_context_tokens: 200000
 skills:
   - format-apa-report
+  - format-citations
+  - validate-references
 ---
 
 # APA Specialist Agent
@@ -59,6 +61,10 @@ This agent can execute the following structured procedures from the [skills libr
 
 ### Reporting
 - `format-apa-report` -- Format Quarto or R Markdown reports following APA 7th edition style, covering apaquarto/papaja setup, title pages, abstracts, citations, tables, figures, and reference formatting
+
+### Citations
+- `format-citations` -- Format citations across academic styles (APA 7, Chicago, Vancouver, IEEE) using CSL processors and R tooling; convert between styles and generate in-text citations and reference lists (complements format-apa-report for the citation layer)
+- `validate-references` -- Check BibTeX entries for completeness, DOI resolution, and broken links; verify required fields per entry type, resolve DOIs via the CrossRef API, and flag duplicates and missing fields — the auditing counterpart to this agent's citation checks
 
 ## Usage Scenarios
 
@@ -207,5 +213,5 @@ The agent scans the entire document for statistical symbols and checks each agai
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-19
+**Version**: 1.1.0
+**Last Updated**: 2026-07-24

--- a/agents/apa-specialist.md
+++ b/agents/apa-specialist.md
@@ -57,14 +57,14 @@ This agent audits existing manuscripts for APA compliance and produces new APA-f
 
 ## Available Skills
 
-This agent can execute the following structured procedures from the [skills library](../skills/):
+This agent can execute the following structured procedures from the [skills library](../skills/). Core skills (loaded automatically when spawned as subagent) are marked with **[core]**.
 
 ### Reporting
-- `format-apa-report` -- Format Quarto or R Markdown reports following APA 7th edition style, covering apaquarto/papaja setup, title pages, abstracts, citations, tables, figures, and reference formatting
+- `format-apa-report` -- Format Quarto or R Markdown reports following APA 7th edition style, covering apaquarto/papaja setup, title pages, abstracts, citations, tables, figures, and reference formatting **[core]**
 
 ### Citations
-- `format-citations` -- Format citations across academic styles (APA 7, Chicago, Vancouver, IEEE) using CSL processors and R tooling; convert between styles and generate in-text citations and reference lists (complements format-apa-report for the citation layer)
-- `validate-references` -- Check BibTeX entries for completeness, DOI resolution, and broken links; verify required fields per entry type, resolve DOIs via the CrossRef API, and flag duplicates and missing fields — the auditing counterpart to this agent's citation checks
+- `format-citations` -- Format citations across academic styles (APA 7, Chicago, Vancouver, IEEE) using CSL processors and R tooling; convert between styles and generate in-text citations and reference lists (complements format-apa-report for the citation layer) **[core]**
+- `validate-references` -- Check BibTeX entries for completeness, DOI resolution, and broken links; verify required fields per entry type, resolve DOIs via the CrossRef API, and flag duplicates and missing fields — the auditing counterpart to this agent's citation checks **[core]**
 
 ## Usage Scenarios
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "validate:content-style": "node scripts/check-content-style.js --all",
     "validate:line-endings": "node scripts/check-line-endings.js",
     "validate:skill-sections": "node scripts/audit-skill-sections.js --missing",
+    "validate:locales-json": "node scripts/validate-locales-json.js",
     "translation:status": "node scripts/generate-translation-status.js",
     "translate:scaffold": "bash scripts/translate-content.sh",
     "test": "npm run validate:integrity && npm run check-readmes",

--- a/scripts/validate-locales-json.js
+++ b/scripts/validate-locales-json.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * validate-locales-json.js — fail if any viz UI locale file is not valid JSON.
+ *
+ * The force-graph frontend loads `viz/public/locales/<locale>.json` at runtime and
+ * looks up UI strings by key. A file that fails to parse leaves the loader with no
+ * table, so the UI silently renders raw i18n keys (e.g. `nav.search`) instead of
+ * translated labels — a failure that is invisible in CI until a human opens the page.
+ * This gate parses every locale file and fails closed so a malformed file is caught
+ * at PR time. Mirrors the CI gate (.github/workflows/validate-locales-json.yml).
+ *
+ *   node scripts/validate-locales-json.js   # exit 0 = all valid, exit 1 = problem
+ *
+ * Fail-closed: an empty or missing locales directory is itself a failure — an absent
+ * corpus must never read as a pass.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const localesDir = resolve(scriptDir, '..', 'viz', 'public', 'locales');
+
+/** @type {string[]} */
+const failures = [];
+
+let files;
+try {
+  files = readdirSync(localesDir).filter((f) => f.endsWith('.json')).sort();
+} catch (err) {
+  console.error(`::error::cannot read locales directory ${localesDir}: ${err.message}`);
+  process.exit(1);
+}
+
+if (files.length === 0) {
+  console.error(`::error::no *.json locale files found in ${localesDir} (fail-closed)`);
+  process.exit(1);
+}
+
+for (const file of files) {
+  const path = join(localesDir, file);
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (err) {
+    failures.push(`${file}: unreadable — ${err.message}`);
+    console.error(`::error file=viz/public/locales/${file}::unreadable — ${err.message}`);
+    continue;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    failures.push(`${file}: invalid JSON — ${err.message}`);
+    console.error(`::error file=viz/public/locales/${file}::invalid JSON — ${err.message}`);
+    continue;
+  }
+  // A locale table must be a plain non-empty object of key -> value. An array,
+  // null, or empty object would parse but still leave the UI without strings.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    failures.push(`${file}: parsed but is not a JSON object`);
+    console.error(`::error file=viz/public/locales/${file}::parsed but is not a JSON object`);
+    continue;
+  }
+  if (Object.keys(parsed).length === 0) {
+    failures.push(`${file}: parsed to an empty object (no UI strings)`);
+    console.error(`::error file=viz/public/locales/${file}::parsed to an empty object (no UI strings)`);
+    continue;
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\nvalidate-locales-json: ${failures.length} of ${files.length} locale file(s) failed:`);
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log(`validate-locales-json: OK — ${files.length} locale file(s) valid (${files.join(', ')})`);

--- a/skills/evolve-skill/SKILL.md
+++ b/skills/evolve-skill/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.4"
+  version: "1.5"
   domain: general
   complexity: intermediate
   language: multi
@@ -333,7 +333,7 @@ git diff
 - **Accidental content deletion**: When restructuring steps, it's easy to drop an On failure block or a table row. Always review `git diff` before committing.
 - **Stale cross-references**: When creating a variant, both the original and the variant need to reference each other. One-directional references leave the graph incomplete.
 - **Registry count drift**: After creating a variant, the `total_skills` count must be incremented. Forgetting this causes validation failures in other skills that check the registry.
-- **Stale translations after evolution**: With 1,288 translation files in the repo, every skill evolution triggers staleness in up to 4 locale files. Always check for existing translations with `ls i18n/*/skills/<skill-name>/SKILL.md` and update `source_commit` in each translated file's frontmatter, or flag them for re-translation in the commit message. Skipping this causes `npm run validate:translations` to report stale warnings.
+- **Stale translations after evolution**: The repo mirrors content across 10 locale trees (`i18n/<locale>/skills/<skill-name>/SKILL.md`), so a single skill evolution can stale up to 10 locale copies. Always check for existing translations with `ls i18n/*/skills/<skill-name>/SKILL.md` and either update `source_commit` in each translated file's frontmatter *after re-translating*, or flag them for re-translation in the commit message. Bumping `source_commit` without re-translating marks stale content as fresh and suppresses the freshness check — never do that. Skipping the check entirely causes `npm run validate:translations` to report stale warnings.
 - **Scope creep during refinement**: A refinement that doubles the skill's length should probably be a variant instead. If you're adding more than 3 new procedure steps, reconsider the scope decision from Step 3.
 - **Avoid `git mv` on NTFS-mounted paths (WSL)**: On `/mnt/` paths, `git mv` for directories can create broken permissions (`d?????????`). Use `mkdir -p` + copy files + `git rm` the old path instead. See the [environment guide](../../guides/setting-up-your-environment.md) troubleshooting section.
 


### PR DESCRIPTION
Closes #398, closes #401, closes #410.

Three independent, self-contained fixes surfaced by the 2026-07-24 issue-triage sweep — each converts an OPEN-TODO into a closed issue. One commit per issue.

## #398 — apa-specialist skill drift
`agents/apa-specialist.md` listed only `format-apa-report` in its frontmatter and `## Available Skills` body, while `agents/_registry.yml` already listed three (`format-apa-report`, `format-citations`, `validate-references`). Added the two citation skills to the frontmatter (3 total, under the 5-skill cap; both are APA-identity skills) and a `### Citations` body subsection. Descriptions are copied from each skill's own frontmatter, not paraphrased from memory. Bumped 1.0.0 → 1.1.0. De-orphans the citations coverage flagged in #403.

## #410 — stale counts in evolve-skill translation pitfall
The "Stale translations after evolution" pitfall claimed "1,288 translation files" and staleness in "up to 4 locale files". The repo mirrors content across **10** locale trees (~3,620 files). Dropped the brittle absolute file-count (it rots on every content addition and adds no instructional value) and corrected 4 → 10. Also folded in the guidance that bumping `source_commit` without re-translating hides staleness. Bumped 1.4 → 1.5.

## #401 — no JSON-validity gate on viz UI locale files
A `viz/public/locales/<locale>.json` that fails to parse leaves the force-graph loader with no string table, so the page silently renders raw i18n keys — invisible in CI until a human opens it. Added:
- `scripts/validate-locales-json.js` — parses every locale file; **fails closed** on a missing/empty dir or a non-object/empty table
- `npm run validate:locales-json`
- `.github/workflows/validate-locales-json.yml` — runs on any change to the locale files, the script, or the workflow

**Verified against its own output:** the gate passes on the 5 current locale files and fails (exit 1 + GitHub file annotation) on a seeded malformed canary.

## Local gate results (all green)
- `validate:integrity` — PASSED
- `validate:skill-sections` — 0 issues
- `check-content-style --added origin/main` — 0 blocking errors
- `check-readmes` — up to date (registry-derived READMEs unaffected)
- new locale-JSON gate — pass on real files, fail on canary
- no CRLF in new files; `.gitattributes` already rules `.js`/`.yml`

Note: the 10 i18n mirrors of `evolve-skill` and `apa-specialist` remain flagged-stale (pre-existing drift, #278/#405); `source_commit` intentionally **not** bumped, since bumping without re-translating is exactly the anti-pattern #405 warns against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)