### PR TITLE
feat(agents): extend 8 agents for #403 §2a (de-orphan tensegrity/ocr/citations + team riders)

### DIFF
--- a/agents/_registry.yml
+++ b/agents/_registry.yml
@@ -157,12 +157,13 @@ agents:
     description: Expert peer reviewer of research methodology, experimental design, statistical analysis, and scientific writing
     tags: [research, peer-review, methodology, statistics, reproducibility, scientific-writing]
     priority: high
-    tools: [Read, Write, Edit, Grep, Glob, WebFetch]
+    tools: [Read, Write, Edit, Grep, Glob, WebFetch, Bash]
     skills:
       - review-research
       - review-data-analysis
       - format-apa-report
       - generate-statistical-tables
+      - validate-references
 
   - id: senior-data-scientist
     path: agents/senior-data-scientist.md
@@ -327,6 +328,7 @@ agents:
       - format-apa-report
       - format-citations
       - validate-references
+      - manage-bibliography
 
   - id: alchemist
     path: agents/alchemist.md
@@ -735,7 +737,8 @@ agents:
     tags: [nlp, natural-language-processing, transformers, text-classification, ner]
     priority: normal
     tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
-    skills: []
+    skills:
+      - benchmark-htr-engines
 
   - id: conservation-entomologist
     path: agents/conservation-entomologist.md
@@ -831,7 +834,7 @@ agents:
   - id: physicist
     path: agents/physicist.md
     description: Classical and applied physics specialist covering electromagnetism, levitation mechanisms, and physical device design from Maxwell's equations to maglev systems
-    tags: [electromagnetism, levitation, maxwell, magnetic-fields, induction, physics, devices]
+    tags: [electromagnetism, levitation, maxwell, magnetic-fields, induction, physics, devices, statics]
     priority: normal
     tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
     skills:

--- a/agents/apa-specialist.md
+++ b/agents/apa-specialist.md
@@ -4,7 +4,7 @@ description: APA 7th edition compliance specialist for academic manuscripts, cov
 tools: [Read, Write, Edit, Bash, Grep, Glob]
 intent: implementing
 model: sonnet
-version: "1.1.0"
+version: "1.2.0"
 author: Philipp Thoss
 created: 2026-02-19
 updated: 2026-07-24
@@ -15,6 +15,7 @@ skills:
   - format-apa-report
   - format-citations
   - validate-references
+  - manage-bibliography
 ---
 
 # APA Specialist Agent
@@ -65,6 +66,7 @@ This agent can execute the following structured procedures from the [skills libr
 ### Citations
 - `format-citations` -- Format citations across academic styles (APA 7, Chicago, Vancouver, IEEE) using CSL processors and R tooling; convert between styles and generate in-text citations and reference lists (complements format-apa-report for the citation layer) **[core]**
 - `validate-references` -- Check BibTeX entries for completeness, DOI resolution, and broken links; verify required fields per entry type, resolve DOIs via the CrossRef API, and flag duplicates and missing fields — the auditing counterpart to this agent's citation checks **[core]**
+- `manage-bibliography` -- Create, merge, and deduplicate BibTeX `.bib` files with R (RefManageR, bibtex): parse entries into structured objects, deduplicate by DOI or title similarity, generate entries from DOI/ISBN/arXiv identifiers, and export clean sorted bibliographies — the .bib maintenance layer feeding this agent's citation auditing **[core]**
 
 ## Usage Scenarios
 
@@ -213,5 +215,5 @@ The agent scans the entire document for statistical symbols and checks each agai
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.1.0
+**Version**: 1.2.0
 **Last Updated**: 2026-07-24

--- a/agents/devops-engineer.md
+++ b/agents/devops-engineer.md
@@ -4,10 +4,10 @@ description: Infrastructure and platform engineering agent for CI/CD, Kubernetes
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
 intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "1.1.0"
 author: Philipp Thoss
 created: 2026-02-09
-updated: 2026-02-09
+updated: 2026-07-24
 tags: [devops, kubernetes, ci-cd, gitops, observability, infrastructure, platform-engineering]
 priority: high
 max_context_tokens: 200000
@@ -58,6 +58,9 @@ Core skills (loaded automatically when spawned as subagent) are marked with **[c
 - `optimize-cloud-costs` — Kubecost, right-sizing, HPA/VPA, spot instances
 - `setup-local-kubernetes` — kind / k3d / minikube with skaffold / tilt
 - `write-helm-chart` — Helm chart creation with Go templates and chart tests **[core]**
+
+### Release
+- `create-github-release` — Tag and publish a GitHub release with notes, semantic-version tags, and build artifacts via the gh CLI — the release-publication step that follows the CI/CD pipeline
 
 ### Observability
 - `setup-prometheus-monitoring` — Prometheus scrape configs, recording rules, federation **[core]**
@@ -187,5 +190,5 @@ Agent: Implementing incident response framework:
 ---
 
 **Author**: Philipp Thoss (ORCID: 0000-0002-4672-2792)
-**Version**: 1.0.0
-**Last Updated**: 2026-02-09
+**Version**: 1.1.0
+**Last Updated**: 2026-07-24

--- a/agents/mlops-engineer.md
+++ b/agents/mlops-engineer.md
@@ -4,10 +4,10 @@ description: ML operations agent for experiment tracking, model registry, featur
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
 intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "1.1.0"
 author: Philipp Thoss
 created: 2026-02-09
-updated: 2026-02-09
+updated: 2026-07-24
 tags: [mlops, machine-learning, experiment-tracking, model-serving, feature-store, aiops, drift-monitoring]
 priority: high
 max_context_tokens: 200000
@@ -59,6 +59,7 @@ Core skills (loaded automatically when spawned as subagent) are marked with **[c
 - `detect-anomalies-aiops` — Time series anomaly detection and alert correlation
 - `forecast-operational-metrics` — Prophet / statsmodels capacity forecasting
 - `label-training-data` — Label Studio annotation workflows and agreement metrics
+- `benchmark-htr-engines` — Select an OCR/HTR engine by scoring candidates on the same labelled samples (raw CER, lenient CER, WER, and a critical name/date token diff); secondary model-selection tooling here — primary home is nlp-specialist (metrics / text-processing), while this agent's angle is deployment-side engine selection and re-ranking engines after new models ship (drift-adjacent, alongside `run-ab-test-models` and `label-training-data`)
 
 ### Data Serialization
 - `serialize-data-formats` — Serialize across JSON, Parquet, Protobuf, Arrow formats
@@ -204,5 +205,5 @@ Agent: Implementing AIOps anomaly detection:
 ---
 
 **Author**: Philipp Thoss (ORCID: 0000-0002-4672-2792)
-**Version**: 1.0.0
-**Last Updated**: 2026-02-09
+**Version**: 1.1.0
+**Last Updated**: 2026-07-24

--- a/agents/nlp-specialist.md
+++ b/agents/nlp-specialist.md
@@ -4,14 +4,14 @@ description: Computational natural language processing specialist for text prepr
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
 intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "1.1.0"
 author: Philipp Thoss
 created: 2026-02-19
-updated: 2026-02-19
+updated: 2026-07-24
 tags: [nlp, natural-language-processing, transformers, text-classification, ner]
 priority: normal
 max_context_tokens: 200000
-skills: []
+skills: [benchmark-htr-engines]
 # Note: All agents inherit default skills (meditate, heal) from the registry.
 # Only list them here if they are core to this agent's methodology.
 # Future skills: build-text-classification-pipeline, fine-tune-transformer-model, evaluate-nlp-model
@@ -71,6 +71,7 @@ Understanding which agent handles what prevents misrouted requests:
 - **Generation**: BLEU, ROUGE (1/2/L), METEOR, BERTScore, perplexity
 - **Similarity**: Cosine similarity, Spearman correlation for STS tasks
 - **NER-Specific**: Entity-level F1, partial match scoring, span overlap
+- **HTR/OCR Benchmarking**: Zero-dependency raw CER, lenient CER (Unicode-NFC + case-fold normalizer), and WER edit-distance scoring to select handwriting/OCR engines, plus a critical name/date token diff that surfaces confident-but-wrong names and dates a low aggregate CER hides -- see `benchmark-htr-engines`
 
 ### Tooling
 - **spaCy**: Pipelines, custom components, rule-based matching, dependency parsing
@@ -81,7 +82,11 @@ Understanding which agent handles what prevents misrouted requests:
 
 ## Available Skills
 
-No domain-specific skills are assigned yet. Planned future skills:
+One domain skill is assigned; the rest remain planned.
+
+- `benchmark-htr-engines` **[core]** -- Select an OCR/HTR engine by benchmarking candidates on the same labelled samples: score with zero-dependency raw CER, lenient CER, WER, and a critical name/date token diff, sourcing ground truth from open datasets (e.g. Hugging Face PAGE-XML corpora) or hand-transcription. Reuses the agent's Unicode-normalization/case-folding preprocessing and its hf-mcp-server integration for dataset discovery
+
+Planned future skills:
 
 - `build-text-classification-pipeline` -- End-to-end text classification from data loading to evaluation
 - `fine-tune-transformer-model` -- Fine-tune a HuggingFace transformer for a specific NLP task
@@ -170,5 +175,5 @@ Design and implement a text preprocessing pipeline for a specific corpus.
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-19
+**Version**: 1.1.0
+**Last Updated**: 2026-07-24

--- a/agents/physicist.md
+++ b/agents/physicist.md
@@ -4,11 +4,11 @@ description: Classical and applied physics specialist covering electromagnetism,
 tools: [Read, Write, Edit, Grep, Glob, WebFetch, WebSearch]
 intent: implementing
 model: sonnet
-version: "2.0.0"
+version: "2.1.0"
 author: Philipp Thoss
 created: 2026-03-11
-updated: 2026-06-15
-tags: [electromagnetism, levitation, maxwell, magnetic-fields, induction, physics, devices]
+updated: 2026-07-24
+tags: [electromagnetism, levitation, maxwell, magnetic-fields, induction, physics, devices, statics]
 priority: normal
 max_context_tokens: 200000
 skills:
@@ -36,6 +36,7 @@ This agent assists with classical physics problems at the level where fields, fo
 - **Magnetic Levitation**: Earnshaw's theorem and its workarounds (diamagnetic, superconducting Meissner/flux-pinning, active feedback, spin-stabilized), force balance, stability analysis
 - **Acoustic Levitation**: Standing wave formation, pressure node trapping, ultrasonic transducer selection, radiation pressure calculations, phased array manipulation
 - **Levitation Trade Studies**: Comparative analysis of magnetic, acoustic, aerodynamic (hovercraft, air bearings, Coanda), and electrostatic (Coulomb, ion trap) mechanisms
+- **Structural Statics (Tensegrity)**: Compression-tension analysis of tensegrity structures as classical mechanics — nodal force balance, self-stress states from the equilibrium-matrix null space, the extended Maxwell rigidity count (b − dj + k + s = m), prestress stabilization of infinitesimal mechanisms, and Euler strut buckling — run in the same characterize → classify → verify pattern as its field and levitation analyses
 - **Authoring & Applying Results**: Can now write its own outputs directly — design calculation sheets, analysis write-ups, derivations, and trade-study reports — and apply changes to design files and documentation, rather than only handing back proposed edits
 
 ## Available Skills
@@ -54,6 +55,9 @@ This agent can execute the following structured procedures from the [skills libr
 - `analyze-magnetic-levitation` — Analyze magnetic levitation systems including Earnshaw's theorem and circumvention mechanisms **[core]**
 - `design-acoustic-levitation` — Design acoustic levitation setups using standing wave node trapping
 - `evaluate-levitation-mechanism` — Compare and select among levitation mechanisms for a given application
+
+### Structural Mechanics / Statics
+- `analyze-tensegrity-system` — Analyze a tensegrity system: inventory compression struts and tension cables, classify the type (class 1/2, biological/architectural), compute prestress equilibrium, and verify stability via Maxwell's rigidity criterion
 
 ## Usage Scenarios
 
@@ -184,7 +188,7 @@ The agent runs evaluate-levitation-mechanism as a trade study. Requirements: con
 - **No Numerical Simulation**: Provides analytical solutions and design calculations — which it can now write up and apply to files directly — but does not run finite-element analysis (FEA) or computational electromagnetics (CEM). It still defaults to proposing and reviewing analysis first, and keeps review and implementation separable when asked to do so
 - **Material Properties**: Uses standard reference values; real materials may vary with temperature, frequency, and manufacturing process
 - **Idealized Geometries**: Analytical solutions assume idealized shapes (infinite solenoid, thin wire); real devices need FEA for precise optimization
-- **No Mechanical Design**: Sizes electromagnetic components but does not design housings, thermal management, or mechanical structures
+- **Structural Analysis, Not Mechanical Design**: Analyzes structural statics as classical mechanics — tensegrity force balance, self-stress and prestress stability, Maxwell rigidity counts, and Euler buckling margins — and sizes electromagnetic components. It does not, however, design mechanical hardware: housings, thermal management, or load-bearing enclosures. Just as it provides analytical solutions without running FEA, it characterizes and verifies a structure's statics without carrying out the mechanical *design* of the physical device around it
 
 ## See Also
 
@@ -197,5 +201,5 @@ The agent runs evaluate-levitation-mechanism as a trade study. Requirements: con
 ---
 
 **Author**: Philipp Thoss
-**Version**: 2.0.0
-**Last Updated**: 2026-06-15
+**Version**: 2.1.0
+**Last Updated**: 2026-07-24

--- a/agents/quarto-developer.md
+++ b/agents/quarto-developer.md
@@ -4,10 +4,10 @@ description: Quarto CLI specialist for multilingual QMD files, technical documen
 tools: [Read, Write, Edit, Bash, Grep, Glob]
 intent: implementing
 model: sonnet
-version: "1.0.0"
+version: "1.1.0"
 author: Philipp Thoss
 created: 2026-02-12
-updated: 2026-02-12
+updated: 2026-07-24
 tags: [quarto, qmd, documentation, publishing, multilingual, technical-writing]
 priority: normal
 max_context_tokens: 200000
@@ -57,6 +57,11 @@ This agent can execute the following structured procedures from the [skills libr
 - `format-apa-report` — Format Quarto reports following APA 7th edition style **[core]**
 - `build-parameterized-report` — Create parameterized Quarto reports that render with different inputs **[core]**
 - `generate-statistical-tables` — Generate publication-ready tables using gt and kableExtra **[core]**
+
+### Citations
+- `manage-bibliography` — Create, merge, and deduplicate BibTeX bibliography files with R packages (RefManageR, bibtex), generating entries from DOI/ISBN/arXiv IDs
+- `format-citations` — Format citations across academic styles (APA 7, Chicago, Vancouver, IEEE) using CSL processors and Quarto's built-in citation engine
+- `validate-references` — Check BibTeX entries for completeness, DOI resolution via CrossRef, broken links, and duplicate entries
 
 ### R Documentation
 - `write-vignette` — Create R package vignettes using Quarto or R Markdown **[core]**
@@ -269,5 +274,5 @@ Agent: **Stage 1: Architect**
 ---
 
 **Author**: Philipp Thoss
-**Version**: 1.0.0
-**Last Updated**: 2026-02-12
+**Version**: 1.1.0
+**Last Updated**: 2026-07-24

--- a/agents/security-analyst.md
+++ b/agents/security-analyst.md
@@ -4,10 +4,10 @@ description: Specialized agent for security auditing, vulnerability assessment, 
 tools: [Read, Write, Edit, Bash, Grep, Glob, WebFetch]
 intent: implementing
 model: sonnet
-version: "2.0.0"
+version: "2.1.0"
 author: Philipp Thoss
 created: 2025-01-25
-updated: 2026-06-15
+updated: 2026-07-24
 tags: [security, vulnerability-assessment, defensive, audit, compliance]
 priority: critical
 max_context_tokens: 200000
@@ -54,6 +54,13 @@ Core skills (loaded automatically when spawned as subagent) are marked with **[c
 
 ### Repository Security
 - `configure-git-repository` — Configure a Git repository with proper .gitignore and conventions
+
+### Redaction & Disclosure
+Independent-checker rider: `enforce-redaction-gate` already cross-references this agent's core `security-audit-codebase`, and here the analyst re-runs the gate on a redacted tree as a second pair of eyes (author/checker split).
+- `enforce-redaction-gate` — Statically enforce a privacy/redaction boundary on an artifact tree before publication, via a two-tier leak gate (shape-based deny-list plus a structure-aware tier over JSON/HTML/SVG/Markdown/code) with a strict exit-code contract and label-only output
+- `redact-for-public-disclosure` — Redact reverse-engineering findings for public disclosure while preserving methodology and teaching value, using a private/public repo split, deny-list maintenance, an orphan-commit publish pattern, and a CI gate
+- `redact-wire-capture` — Redact a network/MITM capture directory in place, scrubbing credential tokens, keys, ids, emails, and paths while preserving token-class prefixes and leaving public identifiers untouched
+- `redact-visualization-for-disclosure` — Redact rendered visual artifacts (Mermaid diagrams, SVGs, HTML dashboards) via an ordered longest-first identifier mapping table, then re-render and verify through the redaction gate
 
 ## Usage Scenarios
 
@@ -284,6 +291,6 @@ SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
 ---
 
 **Author**: Philipp Thoss
-**Version**: 2.0.0
-**Last Updated**: 2026-06-15
+**Version**: 2.1.0
+**Last Updated**: 2026-07-24
 **Security Classification**: Defensive Use Only

--- a/agents/senior-researcher.md
+++ b/agents/senior-researcher.md
@@ -1,13 +1,13 @@
 ---
 name: senior-researcher
 description: Expert peer reviewer of research methodology, experimental design, statistical analysis, and scientific writing
-tools: [Read, Write, Edit, Grep, Glob, WebFetch]
+tools: [Read, Write, Edit, Grep, Glob, WebFetch, Bash]
 intent: implementing
 model: opus
-version: "2.0.0"
+version: "2.1.0"
 author: Philipp Thoss
 created: 2026-02-08
-updated: 2026-06-15
+updated: 2026-07-24
 tags: [research, peer-review, methodology, statistics, reproducibility, scientific-writing]
 priority: high
 max_context_tokens: 200000
@@ -16,6 +16,7 @@ skills:
   - review-data-analysis
   - format-apa-report
   - generate-statistical-tables
+  - validate-references
 ---
 
 # Senior Researcher Agent
@@ -38,10 +39,13 @@ This agent provides senior-level peer review of research work, from study protoc
 
 ## Available Skills
 
-- `review-research` — Structured peer review of methodology, statistics, reproducibility, and bias
-- `review-data-analysis` — Deep review of data quality, assumptions, leakage, and model validation
-- `format-apa-report` — APA 7th edition formatting standards for research reports
-- `generate-statistical-tables` — Publication-ready statistical table creation and review
+Core skills (loaded automatically when spawned as subagent) are marked with **[core]**.
+
+- `review-research` — Structured peer review of methodology, statistics, reproducibility, and bias **[core]**
+- `review-data-analysis` — Deep review of data quality, assumptions, leakage, and model validation **[core]**
+- `format-apa-report` — APA 7th edition formatting standards for research reports **[core]**
+- `generate-statistical-tables` — Publication-ready statistical table creation and review **[core]**
+- `validate-references` — Check BibTeX entries for completeness, DOI resolution via the CrossRef API, URL accessibility, and duplicate entries before journal submission **[core]**
 
 ## Usage Scenarios
 
@@ -131,5 +135,5 @@ Running multiple t-tests between each pair (3 comparisons) without correction in
 ---
 
 **Author**: Philipp Thoss
-**Version**: 2.0.0
-**Last Updated**: 2026-06-15
+**Version**: 2.1.0
+**Last Updated**: 2026-07-24

--- a/guides/_registry.yml
+++ b/guides/_registry.yml
@@ -270,7 +270,7 @@ guides:
     title: "Choosing an HTR/OCR Engine"
     description: "Decision framework for selecting a handwritten-text-recognition engine — deployment model, API entitlement, vision-LLM vs dedicated HTR, CER pitfalls"
     category: reference
-    agents: []
+    agents: [nlp-specialist]
     teams: []
     skills: [benchmark-htr-engines, label-training-data]
 

--- a/guides/choosing-an-htr-ocr-engine.md
+++ b/guides/choosing-an-htr-ocr-engine.md
@@ -2,7 +2,7 @@
 title: "Choosing an HTR/OCR Engine"
 description: "Decision framework for selecting a handwritten-text-recognition engine — deployment model, API entitlement, vision-LLM vs dedicated HTR, CER pitfalls"
 category: reference
-agents: []
+agents: [nlp-specialist]
 teams: []
 skills: [benchmark-htr-engines, label-training-data]
 ---


### PR DESCRIPTION
Part 1 of #403 (the pre-verified coverage-gap plan). Executes **§2a extend-agent** — the cheapest tier, body/frontmatter edits only, no new files. **Refs #403; does not close it** — the new agents (B1 memex-keeper, B2 artisan) and four teams (C1–C4) follow as separate PRs; the five §2d/§4 workflows stay untouched (#288-gated).

## De-orphans three of the five zero-coverage domains
| Domain | Action |
|---|---|
| `tensegrity` | **A1** physicist ← `analyze-tensegrity-system` (body "Structural Mechanics / Statics", Capabilities bullet, reworded "No Mechanical Design" limitation to split structural *analysis* in-scope from mechanical *design* out, + `statics` tag) |
| `ocr` | **A2** nlp-specialist ← `benchmark-htr-engines` (its first core skill) + the HTR/OCR guide's `agents` field; **A3** mlops-engineer carries it body-only as secondary (nlp-specialist is primary) |
| `citations` | **A4** apa-specialist ← `manage-bibliography` (completes the domain begun in #411); **A5** quarto-developer lists the three citations skills body-only |

## Riders for the pending team proposals (maintainer-approved)
- **A8** security-analyst ← 4 redaction/disclosure skills (for C2 empirical-disclosure)
- **A8** devops-engineer ← `create-github-release` (for C3; you chose devops-engineer to own release publication)
- **Q1** senior-researcher ← `validate-references` + `Bash` (your opt-in)

## Method
Authored via an 8-agent workflow (each edits its own file; descriptions sourced from each skill's real SKILL.md), registry synced by hand for the 4 frontmatter changes + the guide `agents` field.

**Adversarial verification** — 8 default-refuted skeptics, one per edit: **6 SOUND, 2 defects caught and folded**:
1. A forward-reference to the not-yet-built `empirical-disclosure` team in security-analyst → removed (re-added when C2 lands).
2. senior-researcher marked only the new skill `[core]`, making its 4 existing core skills read as non-core → all 5 now marked (matches the CLAUDE.md convention and the #411 apa-specialist fold).

## Gates (all green)
- `validate:integrity` — PASSED (registry↔file skill/tag/tool parity, glyph/palette coverage, orphan check)
- `check-readmes` — up to date
- `content-style --added` — 0 blocking
- `line-endings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)