### PR TITLE
ci: content-security self-gate + eval-coverage report (#436, #435 from #422)

### DIFF
--- a/.github/workflows/validate-security.yml
+++ b/.github/workflows/validate-security.yml
@@ -1,0 +1,31 @@
+name: Validate Skill Content Security
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - 'scripts/scan-skill-content.js'
+      - '.github/workflows/validate-security.yml'
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'scripts/scan-skill-content.js'
+      - '.github/workflows/validate-security.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  content-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Scan skill content for secrets and dangerous executables
+        run: node scripts/scan-skill-content.js

--- a/.github/workflows/validate-tests.yml
+++ b/.github/workflows/validate-tests.yml
@@ -111,3 +111,12 @@ jobs:
             fi
           done
           exit $failed
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Report skill eval coverage (informational)
+        # Report-only: coverage is low by design today, so this never fails the build.
+        # Surfaces covered/total and the delta; raise a floor with `--min` once coverage climbs (#435).
+        run: node scripts/eval-coverage.js

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "validate:line-endings": "node scripts/check-line-endings.js",
     "validate:skill-sections": "node scripts/audit-skill-sections.js --missing",
     "validate:locales-json": "node scripts/validate-locales-json.js",
+    "validate:security": "node scripts/scan-skill-content.js",
+    "coverage:evals": "node scripts/eval-coverage.js",
     "translation:status": "node scripts/generate-translation-status.js",
     "translate:scaffold": "bash scripts/translate-content.sh",
     "test": "npm run validate:integrity && npm run check-readmes",

--- a/scripts/eval-coverage.js
+++ b/scripts/eval-coverage.js
@@ -27,7 +27,14 @@ const scenariosDir = join(repoRoot, 'tests', 'scenarios');
 const args = process.argv.slice(2);
 const jsonOut = args.includes('--json');
 const minIdx = args.indexOf('--min');
-const minPct = minIdx !== -1 ? Number(args[minIdx + 1]) : null;
+let minPct = null;
+if (minIdx !== -1) {
+  minPct = Number(args[minIdx + 1]);
+  if (!Number.isFinite(minPct)) {
+    console.error('eval-coverage: --min requires a numeric percentage, e.g. --min 25');
+    process.exit(2);
+  }
+}
 
 // ── registry skill ids (6-space "- id:" entries under the skills list) ───────
 const registry = readFileSync(registryPath, 'utf8');
@@ -53,7 +60,11 @@ function walk(dir, acc = []) {
 const coveredSkills = new Set();
 for (const file of walk(scenariosDir)) {
   const content = readFileSync(file, 'utf8');
-  for (const m of content.matchAll(/^target:\s*([a-z0-9][a-z0-9-]*)\s*$/gm)) {
+  // only the YAML frontmatter block declares the real target — a `target:` line quoted
+  // inside a fenced example block must not count as coverage
+  const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const scope = fm ? fm[1] : '';
+  for (const m of scope.matchAll(/^target:\s*([a-z0-9][a-z0-9-]*)\s*$/gm)) {
     if (skillSet.has(m[1])) coveredSkills.add(m[1]);
   }
 }

--- a/scripts/eval-coverage.js
+++ b/scripts/eval-coverage.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * eval-coverage.js — per-skill eval/scenario coverage report (#435, from #422 P1).
+ *
+ * agent-almanac is not eval-less: tests/scenarios/ holds a real contract (Ground-Truth
+ * tables, weighted Acceptance Criteria, PASS thresholds, a 5-dim rubric). But coverage
+ * is low and invisible. This report makes it measured: for each registry skill, it
+ * checks whether any scenario declares `target: <skill-id>`, and prints
+ * covered/total (pct) plus the uncovered ids.
+ *
+ * Report-only by default (coverage is low by design today, so gating would fail every
+ * PR). Pass --min <pct> to exit non-zero below a floor once coverage is raised.
+ *
+ *   node scripts/eval-coverage.js              # human report, always exit 0
+ *   node scripts/eval-coverage.js --json        # machine-readable
+ *   node scripts/eval-coverage.js --min 25      # exit 1 if coverage < 25%
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const registryPath = join(repoRoot, 'skills', '_registry.yml');
+const scenariosDir = join(repoRoot, 'tests', 'scenarios');
+
+const args = process.argv.slice(2);
+const jsonOut = args.includes('--json');
+const minIdx = args.indexOf('--min');
+const minPct = minIdx !== -1 ? Number(args[minIdx + 1]) : null;
+
+// ── registry skill ids (6-space "- id:" entries under the skills list) ───────
+const registry = readFileSync(registryPath, 'utf8');
+const skillIds = [...registry.matchAll(/^ {6}- id:\s*([a-z0-9][a-z0-9-]*)\s*$/gm)].map((m) => m[1]);
+const skillSet = new Set(skillIds);
+
+// ── scenario targets ─────────────────────────────────────────────────────────
+function walk(dir, acc = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return acc;
+  }
+  for (const name of entries) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, acc);
+    else if (p.endsWith('.md')) acc.push(p);
+  }
+  return acc;
+}
+
+const coveredSkills = new Set();
+for (const file of walk(scenariosDir)) {
+  const content = readFileSync(file, 'utf8');
+  for (const m of content.matchAll(/^target:\s*([a-z0-9][a-z0-9-]*)\s*$/gm)) {
+    if (skillSet.has(m[1])) coveredSkills.add(m[1]);
+  }
+}
+
+const total = skillIds.length;
+const covered = coveredSkills.size;
+const pct = total ? (covered / total) * 100 : 0;
+const uncovered = skillIds.filter((id) => !coveredSkills.has(id)).sort();
+
+if (jsonOut) {
+  console.log(JSON.stringify({ total, covered, pct: Number(pct.toFixed(1)), coveredSkills: [...coveredSkills].sort(), uncovered }, null, 2));
+} else {
+  console.log(`Eval coverage: ${covered}/${total} skills have a scenario (${pct.toFixed(1)}%)`);
+  console.log(`Covered: ${[...coveredSkills].sort().join(', ') || '(none)'}`);
+  console.log(`Uncovered: ${uncovered.length} skill(s)`);
+  if (minPct !== null) {
+    console.log(`\nFloor: ${minPct}% — ${pct >= minPct ? 'PASS' : 'BELOW FLOOR'}`);
+  }
+}
+
+process.exit(minPct !== null && pct < minPct ? 1 : 0);

--- a/scripts/scan-skill-content.js
+++ b/scripts/scan-skill-content.js
@@ -4,29 +4,31 @@
  *
  * Skill content flows OUTWARD to every consumer via the discovery symlink farm and
  * `install-almanac-content`, so a leaked credential or an unsafe executable committed
- * in a skill reaches everyone. This gate scans skill files for two high-signal,
- * low-false-positive classes and fails closed:
+ * in a skill reaches everyone. This gate scans skill files for two high-signal classes
+ * and fails closed:
  *
  *   1. SECRET LEAKS in any skill file (SKILL.md, references/**, scripts/**) — real
  *      credential shapes only, placeholder-aware so the security-*teaching* skills
  *      (which quote token shapes as examples) do not false-fire.
- *   2. DANGEROUS EXECUTABLES in skills/ ** /scripts/** only (real code, not prose) —
- *      `curl … | bash`, `wget … | sh`, `eval "$(curl …`, broad `rm -rf`, `chmod 777`.
+ *   2. DANGEROUS EXECUTABLES in skills/ ** /scripts/** only — `curl … | bash`,
+ *      `bash -c "$(curl …)"`, `bash <(curl …)`, `eval "$(curl …)"`, broad `rm -rf`,
+ *      world-writable `chmod`.
  *
- * Prose in SKILL.md is instructional, so dangerous-command patterns there are NOT
- * flagged (the corpus documents them as things to avoid); only committed executables
- * under a scripts/ dir are treated as runnable.
+ * SCOPING NOTE (deliberate): the danger scan covers committed executables under a
+ * scripts/ dir, NOT SKILL.md prose. Skill prose legitimately documents install
+ * commands (e.g. setup-local-kubernetes / setup-service-mesh show `curl … | sh`), so
+ * scanning prose would false-fire on real content. Prose-level danger detection with an
+ * allowlist over those install skills is deferred to v2 (see #436).
  *
  * Suppress a verified-safe match with an inline `<!-- security-scan-ignore: reason -->`
- * on the matching line or the line directly above it (a reason is required — narrow at
- * the source, no blanket suppression).
+ * (or `# security-scan-ignore: reason`) on the matching line or the line directly above,
+ * OR mark a value as a documented example with a placeholder marker (example, <...>,
+ * YOUR_…, placeholder). A reason is required — narrow at the source, no blanket suppression.
  *
  *   node scripts/scan-skill-content.js            # exit 0 = clean, exit 1 = finding
  *   node scripts/scan-skill-content.js --json      # machine-readable findings
- *
- * Mirrors the CI gate (.github/workflows/validate-security.yml).
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, lstatSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 
@@ -35,9 +37,11 @@ const repoRoot = resolve(scriptDir, '..');
 const skillsDir = join(repoRoot, 'skills');
 const jsonOut = process.argv.includes('--json');
 
-// ── secret shapes (real credentials, not placeholders) ───────────────────────
+// ── secret shapes ────────────────────────────────────────────────────────────
 const SECRET_RULES = [
   { id: 'private-key', re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/ },
+  // an END footer alone catches a header split across lines by markdown reflow
+  { id: 'private-key-footer', re: /-----END (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/ },
   { id: 'aws-access-key', re: /\bAKIA[0-9A-Z]{16}\b/ },
   { id: 'github-token', re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/ },
   { id: 'slack-token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
@@ -45,25 +49,21 @@ const SECRET_RULES = [
   { id: 'stripe-key', re: /\b(?:sk|rk)_live_[A-Za-z0-9]{24,}\b/ },
   {
     id: 'generic-secret-assignment',
-    // key = "value" where value is >=16 chars, mixed, no whitespace
-    re: /\b(?:password|passwd|secret|api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret)\b\s*[:=]\s*["'`]([^"'`\s]{16,})["'`]/i,
+    // optional prefix/suffix so compound env names match (AWS_SECRET_ACCESS_KEY, DB_PASSWORD_PROD)
+    re: /\b(?:[A-Za-z0-9]+[_-])*(?:password|passwd|secret|api[_-]?key|secret[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|access[_-]?key)(?:[_-][A-Za-z0-9]+)*\b\s*[:=]\s*["'`]?([^"'`\s]{16,})["'`]?/i,
     valueGroup: 1,
   },
 ];
 
-// A match is a placeholder / teaching example (not a real leak) when the line or the
-// captured value carries any of these markers. Keeps the security skills from firing.
 const PLACEHOLDER_MARKERS = [
   'example', 'xxxx', 'yyyy', 'your_', 'your-', 'placeholder', 'dummy', 'redacted',
-  'changeme', 'change-me', 'todo', 'fixme', 'foo', 'bar', 'sample', 'test',
-  '...', '<', '>', '{{', '}}', '${', 'abc123', 'notarealkey', 'fake', 'sk_test_',
+  'changeme', 'change-me', 'todo', 'fixme', 'foo', 'bar', 'sample',
+  '...', '<', '>', '{{', '}}', '${', 'notarealkey', 'fake',
 ];
-// Regex-definition context: the "secret" is actually a detection pattern in a security
-// skill (e.g. a character class or quantifier next to the match).
 const REGEX_CONTEXT = /\[[0-9a-zA-Z_\\-]{2,}\]|\\[dws]|\{\d+(?:,\d*)?\}|\(\?:|\/[gimsuy]*\s*[,)]/;
 
-// Example/teaching context — applies to ALL rules. A match here is documentation
-// (an explicit placeholder marker, or a detection pattern quoted in a security skill).
+// Example/teaching context — applies to the high-precision SHAPE rules (private-key,
+// AKIA, ghp_, …): an explicit placeholder marker or a regex-detection quote.
 function isExampleContext(line, value) {
   const hayVal = (value || '').toLowerCase();
   if (PLACEHOLDER_MARKERS.some((m) => hayVal.includes(m))) return true;
@@ -71,54 +71,92 @@ function isExampleContext(line, value) {
   return false;
 }
 
-// Value heuristics — applies ONLY to the generic key=value rule, whose captured value
-// must look like a real random secret. High-precision shape rules (private-key, AKIA,
-// ghp_, …) skip these so a genuine leaked key is never masked by, e.g., its own dashes.
-function isWeakSecretValue(value) {
+// The generic key=value rule does NOT use the loose marker substring check (a real
+// secret containing "test"/"foo" must not self-mask). It fires unless the captured
+// value is provably not a real random secret.
+function isWeakSecretValue(raw) {
+  if (!raw) return true;
+  const value = raw.replace(/[,;:)\]}'"`.]+$/, ''); // strip trailing punctuation from the capture
   if (!value) return true;
-  // env / command / template references are not literal secrets ($VAR, ${VAR}, $(...), %VAR%)
-  if (/[$%]/.test(value)) return true;
-  // ALL_CAPS token used as a stand-in value
-  if (/^[A-Z_]{3,}$/.test(value)) return true;
-  // dictionary placeholders: lowercase words joined by -, _ or space (webhook-password)
-  if (/^[a-z]+([-_ ][a-z]+)+$/.test(value)) return true;
-  // the value names its own kind → a label, not a secret
-  if (/(?:^|[-_])(?:key|secret|password|passwd|token|jwt|webhook|signing|user|client|cookie|value|here|string)(?:$|[-_])/i.test(value)) return true;
-  // obvious sequences / repeated fillers
-  if (/0123456789|1234567890|abcdefabcdef|abcdef0123456789|deadbeef|0000000000/i.test(value)) return true;
-  if (/(.)\1{4,}/.test(value)) return true; // 5+ of the same char in a row
-  // low character diversity is not a real secret
-  if (new Set(value).size < 6) return true;
+  if (REGEX_CONTEXT.test(value)) return true;                // a detection pattern, not a literal
+  if (/[$%<>]/.test(value)) return true;                     // env/cmd/template ref or <placeholder>
+  if (/^[A-Z_]{3,}$/.test(value)) return true;               // ALL_CAPS stand-in
+  if (/^[a-z][a-z0-9]*(?:_[a-z0-9]+)+$/i.test(value)) return true; // snake_case identifier / variable ref (resolved_api_key)
+  if (/^[a-z]+([-_ /][a-z]+)+$/i.test(value)) return true;   // dictionary words joined by -_/space (webhook-password, argocd/git-creds)
+  // names its own kind, or is an obvious example value
+  if (/(?:password|passwd|secret|api[_-]?key|token|credential|creds|example|placeholder|changeme|redacted|dummy|sample|your[_-]|abc123|xxxx|yyyy)/i.test(value)) return true;
+  if (/0123456789|1234567890|abcdefabcdef|abcdef0123456789|deadbeef|0000000000|\.\.\./i.test(value)) return true;
+  if (/(.)\1{4,}/.test(value)) return true;                  // 5+ repeated char
+  if (new Set(value).size < 6) return true;                  // low diversity
   return false;
 }
 
-// ── dangerous executable patterns (scripts/ only) ────────────────────────────
+// ── dangerous executable patterns (scripts/ only, run on continuation-joined lines) ──
 const DANGER_RULES = [
-  { id: 'curl-pipe-shell', re: /\bcurl\b[^\n|]*\|\s*(?:sudo\s+)?(?:bash|sh|zsh)\b/ },
-  { id: 'wget-pipe-shell', re: /\bwget\b[^\n|]*\|\s*(?:sudo\s+)?(?:bash|sh|zsh)\b/ },
+  { id: 'curl-pipe-shell', re: /\bcurl\b[^|]*\|\s*(?:sudo\s+)?(?:bash|sh|zsh)\b/ },
+  { id: 'wget-pipe-shell', re: /\bwget\b[^|]*\|\s*(?:sudo\s+)?(?:bash|sh|zsh)\b/ },
+  { id: 'shell-c-cmdsub', re: /\b(?:bash|sh|zsh)\b\s+(?:-[A-Za-z]*c[A-Za-z]*\s+)?["'`]?\$\(\s*(?:curl|wget)\b/ },
+  { id: 'shell-procsub', re: /\b(?:bash|sh|zsh)\b\s+["'`]?<\(\s*(?:curl|wget)\b/ },
   { id: 'eval-curl', re: /\beval\b\s*["'`]?\$\(\s*(?:curl|wget)\b/ },
-  { id: 'rm-rf-root', re: /\brm\s+-[a-z]*rf?[a-z]*\s+(?:\/(?:\s|$|\*)|~\/?(?:\s|$|\*)|\$HOME\b|\$\{HOME\})/ },
+  // rm with recursive AND force (short or long, any order) targeting a root-ish path
+  { id: 'rm-rf-root', re: /\brm\b(?=[^\n]*(?:-[A-Za-z]*r|--recursive))(?=[^\n]*(?:-[A-Za-z]*f|--force))[^\n]*?\s(?:\/(?:\s|$|\*)|~\/?(?:\s|$|\*)|\$HOME\b|\$\{HOME\})/ },
   { id: 'chmod-777', re: /\bchmod\s+(?:-[A-Za-z]+\s+)*777\b/ },
+  // world/other-writable symbolic mode (chmod a+rwx, o+w, ugo+rwx …)
+  { id: 'chmod-world-write', re: /\bchmod\s+(?:-[A-Za-z]+\s+)*(?:a|o|ugo|go)\+[rwxXst]*w/ },
 ];
 
-// ── file walk ────────────────────────────────────────────────────────────────
+const BINARY_EXT = /\.(png|jpe?g|gif|webp|ico|svg|pdf|zip|gz|bz2|xz|7z|rar|tar|woff2?|ttf|otf|eot|mp4|mp3|wav|wasm|exe|so|dll|dylib|class|jar|db|sqlite|bin)$/i;
+
 function walk(dir, acc = []) {
-  for (const name of readdirSync(dir)) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return acc;
+  }
+  for (const name of entries) {
     const p = join(dir, name);
-    const st = statSync(p);
+    let st;
+    try {
+      st = lstatSync(p); // lstat: do not follow symlinks (no cycle risk, no escaping skills/)
+    } catch {
+      continue;
+    }
+    if (st.isSymbolicLink()) continue;
     if (st.isDirectory()) walk(p, acc);
-    else acc.push(p);
+    else if (st.isFile()) acc.push(p);
   }
   return acc;
 }
 
-const BINARY_EXT = /\.(png|jpe?g|gif|webp|ico|pdf|zip|gz|woff2?|ttf|otf|mp4|mp3|wasm)$/i;
-
 function isSuppressed(lines, idx) {
   const here = lines[idx] || '';
   const above = lines[idx - 1] || '';
-  return /<!--\s*security-scan-ignore:\s*\S/.test(here) || /<!--\s*security-scan-ignore:\s*\S/.test(above)
-    || /#\s*security-scan-ignore:\s*\S/.test(here) || /#\s*security-scan-ignore:\s*\S/.test(above);
+  const re = /(?:<!--|#)\s*security-scan-ignore:\s*\S/;
+  return re.test(here) || re.test(above);
+}
+
+// join backslash line-continuations into logical lines, keeping the first line number
+function logicalLines(physical) {
+  const out = [];
+  let buf = null;
+  let start = 0;
+  physical.forEach((line, i) => {
+    if (buf === null) {
+      start = i;
+      buf = line;
+    } else {
+      buf += ' ' + line;
+    }
+    if (/\\\s*$/.test(line)) {
+      buf = buf.replace(/\\\s*$/, ' ');
+    } else {
+      out.push({ text: buf, line: start });
+      buf = null;
+    }
+  });
+  if (buf !== null) out.push({ text: buf, line: start });
+  return out;
 }
 
 const findings = [];
@@ -137,34 +175,42 @@ for (const abs of walk(skillsDir)) {
   filesScanned++;
   const lines = content.split(/\r?\n/);
 
+  // secrets: per physical line
   lines.forEach((line, i) => {
     if (isSuppressed(lines, i)) return;
-
     for (const rule of SECRET_RULES) {
       const m = line.match(rule.re);
       if (!m) continue;
       const value = rule.valueGroup ? m[rule.valueGroup] : m[0];
-      if (isExampleContext(line, value)) continue;
-      // the generic key=value rule additionally requires a real-looking (high-entropy) value
-      if (rule.valueGroup && isWeakSecretValue(value)) continue;
+      if (rule.valueGroup) {
+        if (isWeakSecretValue(value)) continue;
+      } else if (isExampleContext(line, value)) {
+        continue;
+      }
       findings.push({ severity: 'CRITICAL', kind: 'secret', rule: rule.id, file: rel, line: i + 1 });
     }
+  });
 
-    if (inScripts) {
+  // dangerous executables: continuation-joined logical lines, scripts/ only
+  if (inScripts) {
+    for (const { text, line } of logicalLines(lines)) {
+      if (isSuppressed(lines, line)) continue;
       for (const rule of DANGER_RULES) {
-        if (rule.re.test(line)) {
-          findings.push({ severity: 'HIGH', kind: 'dangerous-exec', rule: rule.id, file: rel, line: i + 1 });
+        if (rule.re.test(text)) {
+          findings.push({ severity: 'HIGH', kind: 'dangerous-exec', rule: rule.id, file: rel, line: line + 1 });
         }
       }
     }
-  });
+  }
 }
+
+const HINT = 'verify and remove; if it is a documented example use a placeholder marker (example, <placeholder>, YOUR_TOKEN) or an inline "security-scan-ignore: <reason>"';
 
 if (jsonOut) {
   console.log(JSON.stringify({ filesScanned, findings }, null, 2));
 } else {
   for (const f of findings) {
-    console.error(`::error file=${f.file},line=${f.line}::[${f.severity}] ${f.kind} (${f.rule}) — verify and remove, or suppress with an inline "security-scan-ignore: <reason>" if it is a documented example`);
+    console.error(`::error file=${f.file},line=${f.line}::[${f.severity}] ${f.kind} (${f.rule}) — ${HINT}`);
   }
   if (findings.length === 0) {
     console.log(`scan-skill-content: OK — ${filesScanned} skill file(s) scanned, 0 findings`);

--- a/scripts/scan-skill-content.js
+++ b/scripts/scan-skill-content.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * scan-skill-content.js — content-security self-gate over skills/ (#436, from #422 P0).
+ *
+ * Skill content flows OUTWARD to every consumer via the discovery symlink farm and
+ * `install-almanac-content`, so a leaked credential or an unsafe executable committed
+ * in a skill reaches everyone. This gate scans skill files for two high-signal,
+ * low-false-positive classes and fails closed:
+ *
+ *   1. SECRET LEAKS in any skill file (SKILL.md, references/**, scripts/**) — real
+ *      credential shapes only, placeholder-aware so the security-*teaching* skills
+ *      (which quote token shapes as examples) do not false-fire.
+ *   2. DANGEROUS EXECUTABLES in skills/ ** /scripts/** only (real code, not prose) —
+ *      `curl … | bash`, `wget … | sh`, `eval "$(curl …`, broad `rm -rf`, `chmod 777`.
+ *
+ * Prose in SKILL.md is instructional, so dangerous-command patterns there are NOT
+ * flagged (the corpus documents them as things to avoid); only committed executables
+ * under a scripts/ dir are treated as runnable.
+ *
+ * Suppress a verified-safe match with an inline `<!-- security-scan-ignore: reason -->`
+ * on the matching line or the line directly above it (a reason is required — narrow at
+ * the source, no blanket suppression).
+ *
+ *   node scripts/scan-skill-content.js            # exit 0 = clean, exit 1 = finding
+ *   node scripts/scan-skill-content.js --json      # machine-readable findings
+ *
+ * Mirrors the CI gate (.github/workflows/validate-security.yml).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..');
+const skillsDir = join(repoRoot, 'skills');
+const jsonOut = process.argv.includes('--json');
+
+// ── secret shapes (real credentials, not placeholders) ───────────────────────
+const SECRET_RULES = [
+  { id: 'private-key', re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/ },
+  { id: 'aws-access-key', re: /\bAKIA[0-9A-Z]{16}\b/ },
+  { id: 'github-token', re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/ },
+  { id: 'slack-token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+  { id: 'google-api-key', re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
+  { id: 'stripe-key', re: /\b(?:sk|rk)_live_[A-Za-z0-9]{24,}\b/ },
+  {
+    id: 'generic-secret-assignment',
+    // key = "value" where value is >=16 chars, mixed, no whitespace
+    re: /\b(?:password|passwd|secret|api[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret)\b\s*[:=]\s*["'`]([^"'`\s]{16,})["'`]/i,
+    valueGroup: 1,
+  },
+];
+
+// A match is a placeholder / teaching example (not a real leak) when the line or the
+// captured value carries any of these markers. Keeps the security skills from firing.
+const PLACEHOLDER_MARKERS = [
+  'example', 'xxxx', 'yyyy', 'your_', 'your-', 'placeholder', 'dummy', 'redacted',
+  'changeme', 'change-me', 'todo', 'fixme', 'foo', 'bar', 'sample', 'test',
+  '...', '<', '>', '{{', '}}', '${', 'abc123', 'notarealkey', 'fake', 'sk_test_',
+];
+// Regex-definition context: the "secret" is actually a detection pattern in a security
+// skill (e.g. a character class or quantifier next to the match).
+const REGEX_CONTEXT = /\[[0-9a-zA-Z_\\-]{2,}\]|\\[dws]|\{\d+(?:,\d*)?\}|\(\?:|\/[gimsuy]*\s*[,)]/;
+
+// Example/teaching context — applies to ALL rules. A match here is documentation
+// (an explicit placeholder marker, or a detection pattern quoted in a security skill).
+function isExampleContext(line, value) {
+  const hayVal = (value || '').toLowerCase();
+  if (PLACEHOLDER_MARKERS.some((m) => hayVal.includes(m))) return true;
+  if (REGEX_CONTEXT.test(line)) return true;
+  return false;
+}
+
+// Value heuristics — applies ONLY to the generic key=value rule, whose captured value
+// must look like a real random secret. High-precision shape rules (private-key, AKIA,
+// ghp_, …) skip these so a genuine leaked key is never masked by, e.g., its own dashes.
+function isWeakSecretValue(value) {
+  if (!value) return true;
+  // env / command / template references are not literal secrets ($VAR, ${VAR}, $(...), %VAR%)
+  if (/[$%]/.test(value)) return true;
+  // ALL_CAPS token used as a stand-in value
+  if (/^[A-Z_]{3,}$/.test(value)) return true;
+  // dictionary placeholders: lowercase words joined by -, _ or space (webhook-password)
+  if (/^[a-z]+([-_ ][a-z]+)+$/.test(value)) return true;
+  // the value names its own kind → a label, not a secret
+  if (/(?:^|[-_])(?:key|secret|password|passwd|token|jwt|webhook|signing|user|client|cookie|value|here|string)(?:$|[-_])/i.test(value)) return true;
+  // obvious sequences / repeated fillers
+  if (/0123456789|1234567890|abcdefabcdef|abcdef0123456789|deadbeef|0000000000/i.test(value)) return true;
+  if (/(.)\1{4,}/.test(value)) return true; // 5+ of the same char in a row
+  // low character diversity is not a real secret
+  if (new Set(value).size < 6) return true;
+  return false;
+}
+
+// ── dangerous executable patterns (scripts/ only) ────────────────────────────
+const DANGER_RULES = [
+  { id: 'curl-pipe-shell', re: /\bcurl\b[^\n|]*\|\s*(?:sudo\s+)?(?:bash|sh|zsh)\b/ },
+  { id: 'wget-pipe-shell', re: /\bwget\b[^\n|]*\|\s*(?:sudo\s+)?(?:bash|sh|zsh)\b/ },
+  { id: 'eval-curl', re: /\beval\b\s*["'`]?\$\(\s*(?:curl|wget)\b/ },
+  { id: 'rm-rf-root', re: /\brm\s+-[a-z]*rf?[a-z]*\s+(?:\/(?:\s|$|\*)|~\/?(?:\s|$|\*)|\$HOME\b|\$\{HOME\})/ },
+  { id: 'chmod-777', re: /\bchmod\s+(?:-[A-Za-z]+\s+)*777\b/ },
+];
+
+// ── file walk ────────────────────────────────────────────────────────────────
+function walk(dir, acc = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, acc);
+    else acc.push(p);
+  }
+  return acc;
+}
+
+const BINARY_EXT = /\.(png|jpe?g|gif|webp|ico|pdf|zip|gz|woff2?|ttf|otf|mp4|mp3|wasm)$/i;
+
+function isSuppressed(lines, idx) {
+  const here = lines[idx] || '';
+  const above = lines[idx - 1] || '';
+  return /<!--\s*security-scan-ignore:\s*\S/.test(here) || /<!--\s*security-scan-ignore:\s*\S/.test(above)
+    || /#\s*security-scan-ignore:\s*\S/.test(here) || /#\s*security-scan-ignore:\s*\S/.test(above);
+}
+
+const findings = [];
+let filesScanned = 0;
+
+for (const abs of walk(skillsDir)) {
+  if (BINARY_EXT.test(abs)) continue;
+  const rel = relative(repoRoot, abs).split(sep).join('/');
+  const inScripts = rel.includes('/scripts/');
+  let content;
+  try {
+    content = readFileSync(abs, 'utf8');
+  } catch {
+    continue;
+  }
+  filesScanned++;
+  const lines = content.split(/\r?\n/);
+
+  lines.forEach((line, i) => {
+    if (isSuppressed(lines, i)) return;
+
+    for (const rule of SECRET_RULES) {
+      const m = line.match(rule.re);
+      if (!m) continue;
+      const value = rule.valueGroup ? m[rule.valueGroup] : m[0];
+      if (isExampleContext(line, value)) continue;
+      // the generic key=value rule additionally requires a real-looking (high-entropy) value
+      if (rule.valueGroup && isWeakSecretValue(value)) continue;
+      findings.push({ severity: 'CRITICAL', kind: 'secret', rule: rule.id, file: rel, line: i + 1 });
+    }
+
+    if (inScripts) {
+      for (const rule of DANGER_RULES) {
+        if (rule.re.test(line)) {
+          findings.push({ severity: 'HIGH', kind: 'dangerous-exec', rule: rule.id, file: rel, line: i + 1 });
+        }
+      }
+    }
+  });
+}
+
+if (jsonOut) {
+  console.log(JSON.stringify({ filesScanned, findings }, null, 2));
+} else {
+  for (const f of findings) {
+    console.error(`::error file=${f.file},line=${f.line}::[${f.severity}] ${f.kind} (${f.rule}) — verify and remove, or suppress with an inline "security-scan-ignore: <reason>" if it is a documented example`);
+  }
+  if (findings.length === 0) {
+    console.log(`scan-skill-content: OK — ${filesScanned} skill file(s) scanned, 0 findings`);
+  } else {
+    console.error(`\nscan-skill-content: ${findings.length} finding(s) across ${filesScanned} files:`);
+    for (const f of findings) console.error(`  - [${f.severity}] ${f.file}:${f.line} ${f.kind}/${f.rule}`);
+  }
+}
+
+process.exit(findings.length > 0 ? 1 : 0);

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -361,7 +361,7 @@ npm run translation:status
 
 > **Do not skip.** A new skill with no scenario widens the eval-coverage gap (~2% of skills covered today — tracked in #435). Author a scenario now, or record in the PR why the skill is not scenario-testable.
 
-Create `tests/scenarios/skills/test-<skill-name>-<focus>.md` from `tests/scenarios/_template.md`, with `target: <skill-name>` and `test-level: skill` in the frontmatter and all required sections (Objective, Pre-conditions, Task, Expected Behaviors, Acceptance Criteria, Observation Protocol). Increment `total_tests` in `tests/_registry.yml`.
+Create `tests/scenarios/skills/test-<skill-name>-<focus>.md` from `tests/_template.md`, with `target: <skill-name>` and `test-level: skill` in the frontmatter and all required sections (Objective, Pre-conditions, Task, Expected Behaviors, Acceptance Criteria, Observation Protocol). Increment `total_tests` in `tests/_registry.yml`.
 
 ```bash
 npm run coverage:evals    # <skill-name> should now appear under "Covered"

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.5"
+  version: "1.6"
   domain: general
   complexity: intermediate
   language: multi
@@ -357,6 +357,20 @@ npm run translation:status
 
 **On failure:** If scaffold fails, verify the skill exists in `skills/_registry.yml` before scaffolding — the script reads the registry. If `translation:status` shows the new files as stale, check that `source_commit` matches the commit hash where the English source was last modified.
 
+### Step 15: Author a Test Scenario (Coverage)
+
+> **Do not skip.** A new skill with no scenario widens the eval-coverage gap (~2% of skills covered today — tracked in #435). Author a scenario now, or record in the PR why the skill is not scenario-testable.
+
+Create `tests/scenarios/skills/test-<skill-name>-<focus>.md` from `tests/scenarios/_template.md`, with `target: <skill-name>` and `test-level: skill` in the frontmatter and all required sections (Objective, Pre-conditions, Task, Expected Behaviors, Acceptance Criteria, Observation Protocol). Increment `total_tests` in `tests/_registry.yml`.
+
+```bash
+npm run coverage:evals    # <skill-name> should now appear under "Covered"
+```
+
+**Expected:** the scenario passes `.github/workflows/validate-tests.yml` (frontmatter fields, required sections, registry count, target-exists), and `npm run coverage:evals` lists `<skill-name>` as covered.
+
+**On failure:** if the skill genuinely resists a black-box scenario (e.g., a pure meta/self-care skill with no observable output contract), record that decision in the PR rather than forcing a hollow scenario — but authoring one is the default.
+
 ## Validation
 
 - [ ] SKILL.md exists at `skills/<skill-name>/SKILL.md`
@@ -367,6 +381,7 @@ npm run translation:status
 - [ ] Every procedure step has concrete code and Expected/On failure pairs
 - [ ] Related Skills reference valid skill names
 - [ ] Skill is listed in `_registry.yml` with correct path
+- [ ] A test scenario targets the skill (or the PR records why it is not scenario-testable)
 - [ ] `total_skills` count in registry is updated
 - [ ] SKILL.md is ≤500 lines (extract to `references/EXAMPLES.md` if over)
 - [ ] Estimated translation expansion is acceptable (English source ≤~400 lines so translations stay <500)


### PR DESCRIPTION
Two governance gates borrowed from the #422 NVIDIA gap analysis. Closes #436, closes #435.

## #436 — content-security self-gate (`validate-security.yml`)
`scripts/scan-skill-content.js` scans every skill file and fails closed on:
- **Secret leaks** (all skill files): private-key headers, `AKIA`/`ghp_`/`xox`/`AIza`/`sk_live` shapes, and a generic compound-name `key=value` rule — placeholder-aware (env refs, snake_case identifiers, dictionary words, sequences, low entropy, example markers) so the security-*teaching* skills don't false-fire.
- **Dangerous executables** (`skills/**/scripts/**` only): `curl|bash`, `bash -c "$(curl)"`, `bash <(curl)`, `eval $(curl)`, broad `rm -rf`, world-writable `chmod` — with line-continuation joining.

Deliberate scoping: danger-scan covers committed executables, not SKILL.md prose (6 skills legitimately document install `curl|sh`). Prose-danger detection is deferred to v2. Suppress a documented example with `security-scan-ignore: <reason>` or a placeholder marker. `npm run validate:security`.

## #435 — per-skill eval-coverage report
`scripts/eval-coverage.js` reports how many registry skills have a scenario (`target: <id>` in a scenario's frontmatter) — **9/369 (2.4%)** today. `--json`, `--min <pct>` to gate later. A **report-only** step in `validate-tests.yml` surfaces the number; `create-skill` gains **Step 15** (author a scenario or record why not). `npm run coverage:evals`. Machine-scored evals + uplift-baseline deferred to a v2 epic.

## Adversarial verification
A skeptic review (a security-analyst pass) found **real holes in both gates, all folded** (commit `cbd37e7`):
- Scanner: a placeholder-marker substring could **self-mask a real secret** (`password = "TestEnv…RealPass"`); the generic rule **missed compound env names** (`AWS_SECRET_ACCESS_KEY`); danger-scan **missed `bash -c "$(curl)"` / `bash <(curl)` / line-continuation**. Fixed + hardened (lstat/symlink guard, split-PEM footer, `rm` long-flags, symbolic `chmod`).
- Coverage: a `target:` in a **fenced example** inflated the count (now frontmatter-only); `--min` with no value silently passed (now errors).
- create-skill: Step 15 pointed at a **non-existent template path** (fixed to `tests/_template.md`).

**Re-verified:** 0 findings across 426 corpus files (incl. security skills); a canary catches every evasion above; coverage unchanged at 9/369.

## Gates (local, green)
`validate:integrity` PASSED · `validate:security` 0 findings · `coverage:evals` 9/369 · `content-style --added` 0 blocking · `line-endings` clean · `check-readmes` up to date · create-skill sections intact, 426 lines (<500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)