### PR TITLE
fix(cli): report broken symlinks in six adapter audits (#438)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ CONTINUE_HERE.md
 # Universal adapter install target (created by CLI tests)
 .agents/
 
+# Adapter broken-symlink audit fixture (created by CLI tests)
+.tmp-test-audit/
+
 # Node dependencies
 node_modules/
 

--- a/cli/adapters/copilot.js
+++ b/cli/adapters/copilot.js
@@ -73,7 +73,12 @@ export class CopilotAdapter extends FrameworkAdapter {
     const skillsDir = this._skillsDir(projectDir);
     if (existsSync(skillsDir)) {
       for (const name of readdirSync(skillsDir)) {
-        items.push({ id: name, type: 'skill', path: resolve(skillsDir, name) });
+        const fullPath = resolve(skillsDir, name);
+        // existsSync follows the link, so it is false for a dangling symlink.
+        // Real (copied) skill directories resolve, so they are never flagged.
+        let broken = false;
+        try { broken = !existsSync(fullPath); } catch { broken = true; }
+        items.push({ id: name, type: 'skill', path: fullPath, broken });
       }
     }
     return items;
@@ -81,11 +86,13 @@ export class CopilotAdapter extends FrameworkAdapter {
 
   async audit(projectDir) {
     const installed = await this.listInstalled(projectDir);
+    const broken = installed.filter(i => i.broken);
+    const valid = installed.filter(i => !i.broken);
     return {
       framework: CopilotAdapter.displayName,
-      ok: installed.length > 0 ? [`${installed.length} skills installed`] : [],
+      ok: valid.length > 0 ? [`${valid.length} skills installed`] : [],
       warnings: installed.length === 0 ? ['No Copilot skills installed'] : [],
-      errors: [],
+      errors: broken.length > 0 ? [`${broken.length} broken skill symlinks`] : [],
     };
   }
 }

--- a/cli/adapters/cursor.js
+++ b/cli/adapters/cursor.js
@@ -83,14 +83,17 @@ export class CursorAdapter extends FrameworkAdapter {
     const skillsDir = resolve(projectDir, '.cursor/skills');
     if (existsSync(skillsDir)) {
       for (const name of readdirSync(skillsDir)) {
-        items.push({ id: name, type: 'skill', path: resolve(skillsDir, name), format: 'skills' });
+        const fullPath = resolve(skillsDir, name);
+        // existsSync follows the link — false for a broken symlink.
+        items.push({ id: name, type: 'skill', path: fullPath, format: 'skills', broken: !existsSync(fullPath) });
       }
     }
     const rulesDir = resolve(projectDir, '.cursor/rules');
     if (existsSync(rulesDir)) {
       for (const name of readdirSync(rulesDir)) {
         if (name.endsWith('.mdc')) {
-          items.push({ id: name.replace(/\.mdc$/, ''), type: 'skill', path: resolve(rulesDir, name), format: 'mdc' });
+          // Legacy .mdc rules are written files, not links — they cannot dangle.
+          items.push({ id: name.replace(/\.mdc$/, ''), type: 'skill', path: resolve(rulesDir, name), format: 'mdc', broken: false });
         }
       }
     }
@@ -99,11 +102,13 @@ export class CursorAdapter extends FrameworkAdapter {
 
   async audit(projectDir) {
     const installed = await this.listInstalled(projectDir);
+    const broken = installed.filter(i => i.broken).length;
+    const valid = installed.length - broken;
     return {
       framework: CursorAdapter.displayName,
-      ok: installed.length > 0 ? [`${installed.length} items installed`] : [],
+      ok: valid > 0 ? [`${valid} items installed`] : [],
       warnings: installed.length === 0 ? ['No Cursor content installed'] : [],
-      errors: [],
+      errors: broken > 0 ? [`${broken} broken skill symlinks`] : [],
     };
   }
 }

--- a/cli/adapters/gemini.js
+++ b/cli/adapters/gemini.js
@@ -51,7 +51,8 @@ export class GeminiAdapter extends FrameworkAdapter {
     const dir = this._skillsDir(projectDir);
     if (existsSync(dir)) {
       for (const name of readdirSync(dir)) {
-        items.push({ id: name, type: 'skill', path: resolve(dir, name) });
+        const fullPath = resolve(dir, name);
+        items.push({ id: name, type: 'skill', path: fullPath, broken: !existsSync(fullPath) });
       }
     }
     return items;
@@ -59,11 +60,13 @@ export class GeminiAdapter extends FrameworkAdapter {
 
   async audit(projectDir) {
     const installed = await this.listInstalled(projectDir);
+    const broken = installed.filter(i => i.broken);
+    const valid = installed.filter(i => !i.broken);
     return {
       framework: GeminiAdapter.displayName,
-      ok: installed.length > 0 ? [`${installed.length} skills installed`] : [],
+      ok: valid.length > 0 ? [`${valid.length} skills installed`] : [],
       warnings: installed.length === 0 ? ['No Gemini skills installed'] : [],
-      errors: [],
+      errors: broken.length > 0 ? [`${broken.length} broken skill symlinks`] : [],
     };
   }
 }

--- a/cli/adapters/hermes.js
+++ b/cli/adapters/hermes.js
@@ -84,7 +84,8 @@ export class HermesAdapter extends FrameworkAdapter {
         const domainDir = resolve(base, domain);
         try {
           for (const name of readdirSync(domainDir)) {
-            items.push({ id: name, type: 'skill', domain, path: resolve(domainDir, name) });
+            const fullPath = resolve(domainDir, name);
+            items.push({ id: name, type: 'skill', domain, path: fullPath, broken: !existsSync(fullPath) });
           }
         } catch { /* not a directory */ }
       }
@@ -92,7 +93,8 @@ export class HermesAdapter extends FrameworkAdapter {
     const agentsBase = this._agentsBase();
     if (existsSync(agentsBase)) {
       for (const name of readdirSync(agentsBase)) {
-        items.push({ id: name.replace(/\.md$/, ''), type: 'agent', path: resolve(agentsBase, name) });
+        const fullPath = resolve(agentsBase, name);
+        items.push({ id: name.replace(/\.md$/, ''), type: 'agent', path: fullPath, broken: !existsSync(fullPath) });
       }
     }
     return items;
@@ -100,11 +102,13 @@ export class HermesAdapter extends FrameworkAdapter {
 
   async audit() {
     const installed = await this.listInstalled();
+    const broken = installed.filter(i => i.broken);
+    const valid = installed.filter(i => !i.broken);
     return {
       framework: HermesAdapter.displayName,
-      ok: installed.length > 0 ? [`${installed.length} items installed`] : [],
+      ok: valid.length > 0 ? [`${valid.length} items installed`] : [],
       warnings: installed.length === 0 ? ['No Hermes content installed'] : [],
-      errors: [],
+      errors: broken.length > 0 ? [`${broken.length} broken links`] : [],
     };
   }
 }

--- a/cli/adapters/openclaw.js
+++ b/cli/adapters/openclaw.js
@@ -95,7 +95,9 @@ export class OpenClawAdapter extends FrameworkAdapter {
     if (existsSync(wsDir)) {
       for (const name of readdirSync(wsDir)) {
         if (name === 'AGENTS.md') continue;
-        items.push({ id: name, type: 'skill', path: resolve(wsDir, name) });
+        const fullPath = resolve(wsDir, name);
+        // existsSync follows the link — false for a broken symlink.
+        items.push({ id: name, type: 'skill', path: fullPath, broken: !existsSync(fullPath) });
       }
     }
     return items;
@@ -103,11 +105,13 @@ export class OpenClawAdapter extends FrameworkAdapter {
 
   async audit(projectDir, scope) {
     const installed = await this.listInstalled(projectDir, scope);
+    const broken = installed.filter(i => i.broken).length;
+    const valid = installed.length - broken;
     return {
       framework: OpenClawAdapter.displayName,
-      ok: installed.length > 0 ? [`${installed.length} skills in workspace`] : [],
+      ok: valid > 0 ? [`${valid} skills in workspace`] : [],
       warnings: installed.length === 0 ? ['No skills in ~/.openclaw/workspace/'] : [],
-      errors: [],
+      errors: broken > 0 ? [`${broken} broken skill symlinks`] : [],
     };
   }
 }

--- a/cli/adapters/vibe.js
+++ b/cli/adapters/vibe.js
@@ -100,14 +100,17 @@ system_prompt_id = "${item.id}"
     const skillsDir = this._skillsBase(projectDir, scope);
     if (existsSync(skillsDir)) {
       for (const name of readdirSync(skillsDir)) {
-        items.push({ id: name, type: 'skill', path: resolve(skillsDir, name) });
+        const fullPath = resolve(skillsDir, name);
+        // existsSync follows the link, so it is false for a dangling symlink.
+        items.push({ id: name, type: 'skill', path: fullPath, broken: !existsSync(fullPath) });
       }
     }
     const agentsDir = this._agentsBase();
     if (existsSync(agentsDir)) {
       for (const name of readdirSync(agentsDir)) {
         if (name.endsWith('.toml')) {
-          items.push({ id: name.replace(/\.toml$/, ''), type: 'agent', path: resolve(agentsDir, name) });
+          // Agent .toml files are generated in place, not linked — they cannot dangle.
+          items.push({ id: name.replace(/\.toml$/, ''), type: 'agent', path: resolve(agentsDir, name), broken: false });
         }
       }
     }
@@ -116,11 +119,15 @@ system_prompt_id = "${item.id}"
 
   async audit(projectDir, scope) {
     const installed = await this.listInstalled(projectDir, scope);
+    // Only skills are symlinked; agent .toml files are generated in place and
+    // are flagged broken:false, so they can never be counted here.
+    const broken = installed.filter(i => i.broken);
+    const valid = installed.filter(i => !i.broken);
     return {
       framework: VibeAdapter.displayName,
-      ok: installed.length > 0 ? [`${installed.length} items installed`] : [],
+      ok: valid.length > 0 ? [`${valid.length} items installed`] : [],
       warnings: installed.length === 0 ? ['No Vibe content installed'] : [],
-      errors: [],
+      errors: broken.length > 0 ? [`${broken.length} broken skill symlinks`] : [],
     };
   }
 }

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -254,6 +254,7 @@ describe('adapter audits detect broken symlinks', () => {
   const tmpRoot = resolve(ROOT, '.tmp-test-audit');
   const fakeHome = resolve(tmpRoot, 'home');
   const realSkill = resolve(ROOT, 'skills/commit-changes');
+  const realAgent = resolve(ROOT, 'agents/code-reviewer.md');
   let savedHome;
 
   // path: where the adapter looks, relative to its own base (project or home).
@@ -262,7 +263,13 @@ describe('adapter audits detect broken symlinks', () => {
     { name: 'cursor', base: 'project', dir: '.cursor/skills', ok: '1 items installed', err: '1 broken skill symlinks', audit: (d) => new CursorAdapter().audit(d) },
     { name: 'gemini', base: 'project', dir: '.gemini/skills', ok: '1 skills installed', err: '1 broken skill symlinks', audit: (d) => new GeminiAdapter().audit(d) },
     { name: 'vibe', base: 'project', dir: '.vibe/skills', ok: '1 items installed', err: '1 broken skill symlinks', audit: (d) => new VibeAdapter().audit(d, 'project') },
-    { name: 'hermes', base: 'home', dir: '.hermes/skills/general', ok: '1 items installed', err: '1 broken links', audit: () => new HermesAdapter().audit() },
+    // hermes symlinks agents as well as skills, from two independent
+    // expressions (hermes.js:88 and :97). Covering only the skills dir would
+    // leave the agent branch dead under test — reverting it would stay green
+    // while a dangling ~/.hermes/agents/<id>.md audited clean, which is the
+    // #438 defect surviving in the content type this adapter's "broken links"
+    // wording exists to describe.
+    { name: 'hermes', base: 'home', dir: '.hermes/skills/general', agentDir: '.hermes/agents', ok: '2 items installed', err: '2 broken links', audit: () => new HermesAdapter().audit() },
     { name: 'openclaw', base: 'home', dir: '.openclaw/workspace', ok: '1 skills in workspace', err: '1 broken skill symlinks', audit: () => new OpenClawAdapter().audit(ROOT, 'project') },
   ];
 
@@ -276,6 +283,12 @@ describe('adapter audits detect broken symlinks', () => {
       mkdirSync(skillsDir, { recursive: true });
       symlinkSync(realSkill, resolve(skillsDir, 'good-skill'));
       symlinkSync(resolve(tmpRoot, 'no-such-target'), resolve(skillsDir, 'ghost-skill'));
+      if (c.agentDir) {
+        const agentsDir = resolve(fakeHome, c.agentDir);
+        mkdirSync(agentsDir, { recursive: true });
+        symlinkSync(realAgent, resolve(agentsDir, 'good-agent.md'));
+        symlinkSync(resolve(tmpRoot, 'no-such-agent.md'), resolve(agentsDir, 'ghost-agent.md'));
+      }
     }
     // os.homedir() reads $HOME on POSIX, which is how the home-based adapters
     // are steered at the fixture. Restored in after().

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -8,11 +8,17 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { execSync } from 'child_process';
-import { existsSync, mkdirSync, rmSync, readlinkSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, rmSync, readlinkSync, readFileSync, writeFileSync, symlinkSync } from 'fs';
 import { resolve } from 'path';
 
 // Direct imports for unit tests.
 import { ClaudeCodeAdapter } from '../adapters/claude-code.js';
+import { CopilotAdapter } from '../adapters/copilot.js';
+import { CursorAdapter } from '../adapters/cursor.js';
+import { GeminiAdapter } from '../adapters/gemini.js';
+import { HermesAdapter } from '../adapters/hermes.js';
+import { OpenClawAdapter } from '../adapters/openclaw.js';
+import { VibeAdapter } from '../adapters/vibe.js';
 import { renderSprite, composite, canRenderPixelArt } from '../lib/pixel-renderer.js';
 import {
   CAMPFIRE_BURNING, CAMPFIRE_EMBERS, CAMPFIRE_COLD,
@@ -226,6 +232,70 @@ describe('audit', () => {
     assert.deepEqual(result.errors, []);
     assert.ok(result.ok.some((line) => /skills installed/.test(line)));
   });
+});
+
+// ── Adapter audits: broken symlink detection (#438) ──────────────
+//
+// Every adapter that installs content as a symlink must report a dangling one
+// as an error. Before #438, six of them counted a broken symlink as installed
+// and returned `errors: []`, so a half-destroyed install audited clean.
+//
+// Each case builds one valid and one dangling symlink and asserts the exact
+// error string, so a regression to `errors: []` fails rather than degrading
+// quietly. The wording differs per adapter by design and follows what each
+// installs: "broken skill symlinks" where only skills are linked, "broken
+// links" for hermes, which links agents too.
+//
+// `hermes` and `openclaw` resolve their target from `homedir()` rather than a
+// project dir, so HOME is redirected into the fixture for the whole block.
+// That also pins `vibe`, whose agents dir is home-based — without it, a real
+// ~/.vibe/agents on the dev machine would leak .toml entries into the counts.
+describe('adapter audits detect broken symlinks', () => {
+  const tmpRoot = resolve(ROOT, '.tmp-test-audit');
+  const fakeHome = resolve(tmpRoot, 'home');
+  const realSkill = resolve(ROOT, 'skills/commit-changes');
+  let savedHome;
+
+  // path: where the adapter looks, relative to its own base (project or home).
+  const cases = [
+    { name: 'copilot', base: 'project', dir: '.github/skills', ok: '1 skills installed', err: '1 broken skill symlinks', audit: (d) => new CopilotAdapter().audit(d) },
+    { name: 'cursor', base: 'project', dir: '.cursor/skills', ok: '1 items installed', err: '1 broken skill symlinks', audit: (d) => new CursorAdapter().audit(d) },
+    { name: 'gemini', base: 'project', dir: '.gemini/skills', ok: '1 skills installed', err: '1 broken skill symlinks', audit: (d) => new GeminiAdapter().audit(d) },
+    { name: 'vibe', base: 'project', dir: '.vibe/skills', ok: '1 items installed', err: '1 broken skill symlinks', audit: (d) => new VibeAdapter().audit(d, 'project') },
+    { name: 'hermes', base: 'home', dir: '.hermes/skills/general', ok: '1 items installed', err: '1 broken links', audit: () => new HermesAdapter().audit() },
+    { name: 'openclaw', base: 'home', dir: '.openclaw/workspace', ok: '1 skills in workspace', err: '1 broken skill symlinks', audit: () => new OpenClawAdapter().audit(ROOT, 'project') },
+  ];
+
+  const dirFor = (c) => (c.base === 'home' ? resolve(fakeHome, c.dir) : resolve(tmpRoot, c.name, c.dir));
+
+  before(() => {
+    rmSync(tmpRoot, { recursive: true, force: true }); // leftover from a crashed run
+    mkdirSync(fakeHome, { recursive: true });
+    for (const c of cases) {
+      const skillsDir = dirFor(c);
+      mkdirSync(skillsDir, { recursive: true });
+      symlinkSync(realSkill, resolve(skillsDir, 'good-skill'));
+      symlinkSync(resolve(tmpRoot, 'no-such-target'), resolve(skillsDir, 'ghost-skill'));
+    }
+    // os.homedir() reads $HOME on POSIX, which is how the home-based adapters
+    // are steered at the fixture. Restored in after().
+    savedHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+  });
+
+  after(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  for (const c of cases) {
+    it(`${c.name}: reports a dangling symlink as an error`, async () => {
+      const result = await c.audit(resolve(tmpRoot, c.name));
+      assert.deepEqual(result.errors, [c.err]);
+      assert.deepEqual(result.ok, [c.ok]);
+    });
+  }
 });
 
 // ── Init ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #438.

Six adapters installed content as symlinks but never checked whether those links resolve. A dangling entry counted as installed and `errors` came back empty, so a half-destroyed install audited clean.

## Scope is wider than the issue claimed

#438 was filed from `a7c1308c`'s file list rather than from `main`, and was wrong in both directions. `pi.js` does not exist on `main` — it is new adapter work arriving with the #256 draft. Meanwhile `cursor`, `hermes`, `openclaw` and `vibe` have the identical defect and went unmentioned.

Surveying all 13 adapters instead of trusting the list (`listAdapters()` returns 13; `base.js` and `index.js` are the abstract base and the registry):

| Category | Adapters | Action |
|---|---|---|
| Symlink-based, missing the check | `copilot`, `cursor`, `gemini`, `hermes`, `openclaw`, `vibe` | fixed here |
| Symlink-based, already correct | `claude-code`, `opencode`, `universal` | untouched |
| Copy/write-based — no link can dangle | `ai-edge`, `aider`, `codex`, `windsurf` | correctly excluded |

The four excluded adapters install by copying files or writing a marked section into an instructions file. A broken-link check there would be meaningless, not merely unnecessary.

## The fix

Each adapter now sets `broken` per item in `listInstalled` and reports it in `audit`, following the shape already in `claude-code.js:191-201` and `universal.js:107-123`. `existsSync` follows a link, so it is false exactly when the target does not resolve. `copilot` additionally wraps it in a `try`/`catch`, mirroring `claude-code.js:165`; the other five use the plain form matching `universal` and `opencode`. The guard is defensive in all three references — `existsSync` returns false rather than throwing — so the two forms behave identically.

**Mixed installers needed care** so healthy non-symlink content is not flagged:

- `cursor`'s legacy `.mdc` rules and `vibe`'s generated agent `.toml` files are written in place, so both are explicitly `broken: false` rather than left to an undefined field.
- `copilot`'s `listInstalled` deliberately keeps listing real directories under `.github/skills`. Adding an `lstat` filter would silently drop hand-placed content from both `list` and the audit counts — a wider behaviour change than this issue. A real directory resolves, so it lands in `valid` regardless.

**Wording follows what each adapter links.** `N broken skill symlinks` where only skills are symlinked; `hermes` gets opencode's `N broken links` because it links agents too.

**The `ok` line switches from total to valid** across all six, matching `claude-code.js:196` and `universal.js:119`, so a fully-dangling install no longer reports "N installed" beside its own errors. `opencode` still counts totals there and is now the lone outlier — changing a working adapter's output is outside this issue, but worth a decision later.

## Tests

One valid and one dangling symlink per adapter, asserting the exact `errors` and `ok` strings so a regression to `errors: []` fails loudly rather than degrading quietly.

`hermes` and `openclaw` resolve their target from `homedir()` rather than a project dir, so `HOME` is redirected into the fixture for the whole block (`os.homedir()` reads `$HOME` on POSIX). That also pins `vibe`, whose agents dir is home-based — without it, a real `~/.vibe/agents` on a dev machine would leak `.toml` entries into the counts and make the assertions machine-dependent.

Verified by reverting **only** the six adapters and re-running:

```
without the adapter fixes:  6 tests, 0 pass, 6 fail
with them restored:         6 tests, 6 pass, 0 fail
```

That direction matters: a test that only ever passes proves nothing about whether it can detect the defect.

## Adversarial review (Copilot substitute)

Copilot was quota-blocked, so a 16-agent adversarial pass reviewed `bf022739`. Twelve findings, eleven refuted, one survived — and two of the *refuted* ones still pointed at inaccurate prose in the commit message. All folded in `72a0d72b`.

**The survivor was a real coverage hole.** The fixture created only `.hermes/skills/general`, never `.hermes/agents`, so `hermes.js:97` — the agent branch that also computes `broken` — was dead code under test. hermes links agents as well as skills from an independent expression, and that content type is exactly what its "broken links" wording describes. Reverting only that line left the whole suite green, meaning a dangling `~/.hermes/agents/<id>.md` audited clean: the #438 defect surviving in the one content type the test could not see. The fixture now builds a valid and a dangling agent link too (hermes reports 2 valid / 2 broken), and the same revert now fails the hermes case and only that case.

**Two claim corrections**, neither affecting code: there are **13** adapters, not 15 (the prose contradicted this PR's own table), and the `try`/`catch` is `copilot`-only rather than universal across the six.

## Validation

- `npm run test:cli` — 87 pass, 0 fail (up from 81)
- `npm run validate:integrity` — PASSED (2 warnings, both pre-existing: B9 glyph coverage for `artisan` / `memex-keeper`, tracked as #432)
- `npm run validate:line-endings` — no committed CRLF
- `node scripts/check-content-style.js --added origin/main` — 0 blocking errors
- `node --check` on all six adapters
- Fixture dir is gitignored and removed in `after()`; confirmed absent after a full run

## Note for #256

`pi.js` arrives on the `rust-cli` branch with its own copy of this defect, which `a7c1308c` already fixes there. Nothing to do here, but its audit should be correct at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfDBmye23EDgcQQ5ELXAA8
