### PR TITLE
ci/cli: delete B11, align opencode ok-line (#443, #445)

### DIFF
--- a/cli/adapters/opencode.js
+++ b/cli/adapters/opencode.js
@@ -88,9 +88,10 @@ export class OpenCodeAdapter extends FrameworkAdapter {
   async audit(projectDir, scope) {
     const installed = await this.listInstalled(projectDir, scope);
     const broken = installed.filter(i => i.broken);
+    const valid = installed.filter(i => !i.broken);
     return {
       framework: OpenCodeAdapter.displayName,
-      ok: installed.length > 0 ? [`${installed.length} items installed`] : [],
+      ok: valid.length > 0 ? [`${valid.length} items installed`] : [],
       warnings: installed.length === 0 ? ['No OpenCode content installed'] : [],
       errors: broken.length > 0 ? [`${broken.length} broken links`] : [],
     };

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -18,6 +18,7 @@ import { CursorAdapter } from '../adapters/cursor.js';
 import { GeminiAdapter } from '../adapters/gemini.js';
 import { HermesAdapter } from '../adapters/hermes.js';
 import { OpenClawAdapter } from '../adapters/openclaw.js';
+import { OpenCodeAdapter } from '../adapters/opencode.js';
 import { VibeAdapter } from '../adapters/vibe.js';
 import { renderSprite, composite, canRenderPixelArt } from '../lib/pixel-renderer.js';
 import {
@@ -234,17 +235,20 @@ describe('audit', () => {
   });
 });
 
-// ── Adapter audits: broken symlink detection (#438) ──────────────
+// ── Adapter audits: broken symlink detection (#438, #445) ────────
 //
 // Every adapter that installs content as a symlink must report a dangling one
-// as an error. Before #438, six of them counted a broken symlink as installed
-// and returned `errors: []`, so a half-destroyed install audited clean.
+// as an error, and must not count it as installed. Before #438, six of them
+// returned `errors: []` outright, so a half-destroyed install audited clean.
+// opencode did report the error but still counted the dangling item in `ok`;
+// #445 aligned it, so all nine now split valid from broken the same way.
 //
-// Each case builds one valid and one dangling symlink and asserts the exact
-// error string, so a regression to `errors: []` fails rather than degrading
-// quietly. The wording differs per adapter by design and follows what each
-// installs: "broken skill symlinks" where only skills are linked, "broken
-// links" for hermes, which links agents too.
+// Each case builds one valid and one dangling symlink and asserts BOTH the
+// exact error and the exact ok string, so neither a regression to `errors: []`
+// nor a drift back to counting totals passes. The wording differs per adapter
+// by design and follows what each installs: "broken skill symlinks" where only
+// skills are linked, "broken links" for hermes and opencode, which link agents
+// too.
 //
 // `hermes` and `openclaw` resolve their target from `homedir()` rather than a
 // project dir, so HOME is redirected into the fixture for the whole block.
@@ -271,6 +275,10 @@ describe('adapter audits detect broken symlinks', () => {
     // wording exists to describe.
     { name: 'hermes', base: 'home', dir: '.hermes/skills/general', agentDir: '.hermes/agents', ok: '2 items installed', err: '2 broken links', audit: () => new HermesAdapter().audit() },
     { name: 'openclaw', base: 'home', dir: '.openclaw/workspace', ok: '1 skills in workspace', err: '1 broken skill symlinks', audit: () => new OpenClawAdapter().audit(ROOT, 'project') },
+    // opencode already reported broken links before #438; #445 aligned its ok
+    // line to valid-only like the rest. One dir is enough here: unlike hermes,
+    // its skills and agents flow through the same expression (opencode.js:82).
+    { name: 'opencode', base: 'project', dir: '.opencode/skills', ok: '1 items installed', err: '1 broken links', audit: (d) => new OpenCodeAdapter().audit(d, 'project') },
   ];
 
   const dirFor = (c) => (c.base === 'home' ? resolve(fakeHome, c.dir) : resolve(tmpRoot, c.name, c.dir));

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -243,6 +243,11 @@ describe('audit', () => {
 // opencode did report the error but still counted the dangling item in `ok`;
 // #445 aligned it, so all nine now split valid from broken the same way.
 //
+// Nine adapters split, but this block holds SEVEN cases. claude-code is
+// covered by its own direct audit test above; universal is not covered by any
+// broken-symlink test yet (#447) — its `N broken symlinks: <ids>` wording at
+// universal.js:123 is unexercised.
+//
 // Each case builds one valid and one dangling symlink and asserts BOTH the
 // exact error and the exact ok string, so neither a regression to `errors: []`
 // nor a drift back to counting totals passes. The wording differs per adapter

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -525,54 +525,12 @@ if [ -n "$b10_missing" ]; then
 fi
 [ "$b10_warn" -eq 0 ] && echo "OK: All registry domains have DOMAIN_STYLES entries"
 
-# B11: CLI audit (optional, only if CLI is available)
-echo "--- B11: CLI audit ---"
-if ! command -v node >/dev/null 2>&1 || [ ! -f "cli/index.js" ]; then
-  echo "SKIP: CLI not available (node or cli/index.js missing)"
-elif [ ! -d "node_modules/commander" ]; then
-  # validate-integrity.yml checks out without `npm ci`, so the CLI cannot even
-  # load here: node exits 1 with ERR_MODULE_NOT_FOUND before printing anything.
-  # The previous `|| true` discarded that exit code and grepped the loader
-  # error for a lowercase "error" it does not contain, so this check reported
-  # "OK: CLI audit passed" against a CLI that never ran -- in CI, always
-  # (#373). Skip honestly instead. The audit itself is covered in
-  # ci-node-cli.yml, which does install dependencies and whose test:cli asserts
-  # on the Claude Code section directly.
-  echo "SKIP: CLI dependencies not installed (run 'npm ci' to exercise B11)"
-else
-  # The reporter prints findings as "  ERR  <msg>" (cli/lib/reporter.js), and
-  # the crash path prepends "Audit failed: " via auditAll(). Neither contains a
-  # lowercase "error", which is why the old pattern never fired locally either
-  # while the claude-code audit was throwing (#365). Match the markers the
-  # reporter actually emits, and treat a non-zero exit as a failure too.
-  # Warn-only, as before: making `audit` signal through its exit status is #439.
-  audit_pattern='(^|[[:space:]])ERR([[:space:]]|$)|Audit failed'
-  cli_rc=0
-  cli_out=$(node cli/index.js audit 2>&1) || cli_rc=$?
-  # Strip ANSI before matching. printAudit renders the marker as
-  # chalk.red('ERR'), so with colour enabled the line reads
-  # "  <ESC>[31mERR<ESC>[39m  <msg>": the byte before ERR is 'm' and the byte
-  # after is ESC, so a whitespace-anchored pattern cannot match. "Audit failed"
-  # would still catch an adapter crash, since that text sits outside the colour
-  # codes -- but the marker-only errors would go dark: "N broken skill
-  # symlinks" (claude-code.js:197), "agents symlink is broken" (:201), and
-  # "N broken symlinks: ..." (universal.js:123). auditSection() in
-  # cli/test/cli.test.js strips ANSI for exactly this reason; this is the
-  # shell-side half of that same fix.
-  esc=$(printf '\033')
-  cli_out=$(printf '%s\n' "$cli_out" | sed -E "s/${esc}\[[0-9;]*m//g")
-  if [ "$cli_rc" -ne 0 ] || printf '%s\n' "$cli_out" | grep -qE "$audit_pattern"; then
-    echo "WARN: CLI audit reported errors (exit $cli_rc):"
-    # A non-zero exit with no matching line means the CLI died before printing
-    # an audit at all; fall back to the tail so the failure is diagnosable.
-    # Without the fallback the empty grep aborts the script under pipefail.
-    printf '%s\n' "$cli_out" | grep -E "$audit_pattern" | sed 's/^/  /' \
-      || printf '%s\n' "$cli_out" | tail -5 | sed 's/^/  /'
-    warn_count=$((warn_count + 1))
-  else
-    echo "OK: CLI audit passed"
-  fi
-fi
+# B11 (CLI audit) was removed: it could not fire on a real failure, never ran
+# in CI (this job performs no `npm ci`, so the CLI died at module resolution),
+# and would not have triggered anyway -- `cli/**` is absent from this
+# workflow's paths. Audit coverage lives in ci-node-cli.yml, whose test:cli
+# asserts the adapter results directly (#373, #438). Do not re-add a stdout
+# grep here. See #443.
 
 # B12: Global discovery-hub coverage (warn-only; #324/#325)
 # Repo-internal skill symlinks are the hard gate (B1); the global hub


### PR DESCRIPTION
Closes #443. Closes #445.

Two decisions from the #442/#444 follow-up, both maintainer-directed.

## Delete B11 (#443)

Removed rather than repaired. The case accumulated across three discoveries, each exposed by the previous fix:

1. **It could never fire on a real failure.** The decision grep was `grep -q "error"`; the reporter emits `  ERR  <msg>` and the crash path prepends `Audit failed: `. Neither contains a lowercase `error`. Repaired in #442 — which surfaced the rest.
2. **It has never run in CI.** `validate-integrity.yml` performs no `npm ci`, so `node cli/index.js audit` dies at module resolution with `ERR_MODULE_NOT_FOUND` and exits 1 before printing anything. No revision of that workflow has ever contained `npm ci` or `setup-node` (6 revisions checked). On run `30098319127` the step took **0.22s** against a real audit's ~3s, and printed `OK: CLI audit passed`.
3. **It would not trigger even if that were fixed.** `cli/**` is absent from the workflow's `paths:`. #444 rewrote six adapter audits; the checks that ran were `Analyze`, `CodeQL`, `cli-test`, `line-endings` — no `validate`.

Keeping it meant three fixes (pattern, dependencies, trigger) to reproduce a signal that already exists.

**Coverage is not lost.** `ci-node-cli.yml` triggers on `cli/**`, runs `npm ci`, and its `test:cli` asserts the audit directly — the section-scoped assertions from #373 plus seven adapter broken-symlink cases from #438 and #445. Those assert on the returned object rather than grepping stdout, and each was verified to fail when the code under test is reverted. Strictly stronger than a warn-only grep.

`B12` is deliberately **not** renumbered, so existing references stay valid. A comment records where audit coverage lives, so the next reader does not re-add a check that cannot fail.

## Align opencode (#445)

`opencode` counted every installed item in `ok` while reporting broken ones separately — an install with 3 items where 1 dangles printed `OK 3 items installed` beside `ERR 1 broken links`, implying 3 usable items when only 2 were. After #438 it was the last of nine still doing this, putting two accounting conventions in one report.

It now filters `valid` like `claude-code.js:196` and `universal.js:119`. Wording stays `N items installed` — opencode installs agents as well as skills, so the noun was already right. `errors` untouched.

Excluded from #438 on purpose: that issue covered adapters reporting nothing at all, and opencode already detected broken links correctly (`opencode.js:82`, `:95`). Only the denominator was wrong.

## Tests

`opencode` joins the #438 fixture block, which now covers **all nine** symlink adapters. One fixture dir suffices: unlike hermes, whose skills and agents come from two independent expressions, opencode builds both content types through the same line (`opencode.js:82`).

The block now pins `ok` as well as `errors`, so a drift back to counting totals fails rather than passing quietly — previously only `errors` was load-bearing.

Verified by reverting the one-line change:

```
opencode reverted to totals:  7 tests, 6 pass, 1 fail  ← only opencode
restored:                     7 tests, 7 pass, 0 fail
```

## Validation

- `npm run test:cli` — 88 pass, 0 fail (up from 87)
- `npm run validate:integrity` — PASSED, sequence now B10 → B12, same 2 pre-existing warnings (B9 glyph coverage, tracked as #432)
- `npm run validate:line-endings` — no committed CRLF
- `bash -n scripts/validate-integrity.sh` — syntax OK
- No dangling `B11` references remain (`rg --type md --type sh --type yaml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfDBmye23EDgcQQ5ELXAA8


## Correction

The substitute review refuted all four of its findings as code defects, but one carried a factual hit, corrected in `045a7f6b`.

This body and `9c246dac`'s message originally said **nine** adapter broken-symlink cases. There are **seven**. Nine *adapters* split valid from broken; the fixture block holds seven cases — I conflated the two.

The other two are not equivalently covered, which is the useful part:

- `claude-code` has a direct audit test (`cli.test.js:232`), but it asserts `errors: []` on a healthy tree. That proves the audit does not throw; it cannot catch a regression in the broken-detection path.
- `universal` has **no** broken-symlink test. It is also the only adapter that enumerates ids rather than counting — `N broken symlinks: <ids>` (`universal.js:123`) — so a regression could drop the id list while keeping the count correct. Filed as #447.

The block comment now records this so the "all nine" sentence above it does not mislead.

Also disambiguated: `9c246dac` cites `opencode.js:95` for broken-link detection. That is correct against the pre-change file the sentence describes, but resolves to the `warnings` line at HEAD, since #445 added a line above it. It is `:96` now.

No code change; 88/88 still passes.