### PR TITLE
feat(cli): give audit a real exit code, and mark crashes structurally (#439)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -32,6 +32,31 @@ agent-almanac audit                  # Health check installed content
 agent-almanac uninstall <names...>   # Remove installed content
 ```
 
+### Audit exit codes
+
+`audit` always prints its full report before exiting, so a non-zero status never
+costs you the reason for it.
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Audit ran and found no errors |
+| `2` | An adapter crashed, so that framework has no verdict at all |
+| `3` | Audit ran and found errors |
+
+`1` is deliberately not used for audit findings. It already means "usage or
+loader error" — an unknown `--framework`, an undetectable almanac root, or
+missing dependencies — so reusing it would leave automation unable to tell *"the
+CLI is not installed here"* from *"your install is broken"*.
+
+A crash outranks a finding: a finding is a completed audit that found something,
+whereas a crash means that framework produced no verdict at all. Warnings never
+affect the exit code, since they describe ordinary states such as `No Copilot
+skills installed`.
+
+```bash
+agent-almanac audit || echo "audit reported problems (exit $?)"
+```
+
 ## Install
 
 ```bash

--- a/cli/adapters/base.js
+++ b/cli/adapters/base.js
@@ -18,6 +18,10 @@
  * @property {string[]} ok - OK messages
  * @property {string[]} warnings - Warning messages
  * @property {string[]} errors - Error messages
+ * @property {boolean} [crashed] - True when audit() threw and produced no verdict.
+ *   Set by auditAll(), not by adapters — see cli/lib/installer.js. Absent on
+ *   entries obtained by calling an adapter's audit() directly.
+ * @property {Error} [error] - The original throw, present only when crashed
  */
 
 export class FrameworkAdapter {

--- a/cli/index.js
+++ b/cli/index.js
@@ -24,7 +24,7 @@ import { loadRegistries, resolveItems, filterSkills, search, findTeam, findAgent
 import { detectAlmanacRoot, resolveTargetDir } from './lib/resolver.js';
 import { detectFrameworks } from './lib/detector.js';
 import { getAdapter, getAdaptersForDetections, listAdapters } from './adapters/index.js';
-import { installAll, uninstallAll, auditAll } from './lib/installer.js';
+import { installAll, uninstallAll, auditAll, auditExitCode } from './lib/installer.js';
 import { loadManifest, resolveManifest, generateManifest, writeManifest } from './lib/manifest.js';
 import { loadState, saveState, recordGather, recordScatter, recordWarm, markWelcomed, getFireStates, getFireState, findSharedSkills } from './lib/state.js';
 import * as campfire from './lib/campfire-reporter.js';
@@ -274,13 +274,44 @@ program
   .option('-g, --global', 'Audit global scope')
   .option('--scope <scope>', 'Scope: project, workspace, global', 'project')
   .option('--source <path>', 'Path to agent-almanac root')
+  .addHelpText('after', `
+Exit codes:
+  0  audit ran and found no errors
+  2  an adapter crashed, so that framework has no verdict
+  3  audit ran and found errors
+
+  1 is reserved for usage and loader errors (unknown --framework,
+  undetectable almanac root, missing dependencies).
+
+Examples:
+  agent-almanac audit
+  agent-almanac audit --framework claude-code
+  agent-almanac audit --global`)
   .action(async (options) => {
     const ctx = getContext(options);
 
     console.log('\nAudit results:\n');
     const results = await auditAll(ctx.adapters, ctx.projectDir, ctx.scope);
     reporter.printAudit(results);
+
+    // An empty result set prints nothing at all, which reads exactly like a
+    // clean bill of health (#439).
+    //
+    // This is currently unreachable, and deliberately kept anyway. The universal
+    // rule at cli/lib/detector.js:20 is `existsSync(...) || true`, which is
+    // always true, so detection never returns an empty list and --framework
+    // always yields exactly one adapter. Should that `|| true` be corrected,
+    // this branch starts mattering immediately; it is three lines to keep and a
+    // silent false-clean to omit. Tracked in #457 — do not read the presence of
+    // this guard as evidence that the empty case has been observed.
+    if (results.length === 0) {
+      reporter.warn('No frameworks detected — nothing was audited.');
+    }
     console.log();
+
+    // Every result is printed before this point: the report is the useful
+    // output, and exiting non-zero must not cost the user the reason why.
+    process.exitCode = auditExitCode(results);
   });
 
 // ── bundle ──────────────────────────────────────────────────

--- a/cli/lib/installer.js
+++ b/cli/lib/installer.js
@@ -114,23 +114,35 @@ export async function uninstallAll(resolved, adapters, projectDir, scope, option
 
 /**
  * Audit all adapters.
+ *
+ * A crash and a finding are different kinds of result: a finding means the
+ * adapter ran and reported something, while a crash means it produced no
+ * verdict at all — so a fully broken install reads as "nothing installed,
+ * nothing wrong" (#365). `crashed` carries that distinction structurally, so
+ * callers never have to match on the `Audit failed:` message prefix (#439).
+ *
  * @param {import('../adapters/base.js').FrameworkAdapter[]} adapters
  * @param {string} projectDir
  * @param {string} scope
- * @returns {Promise<object[]>}
+ * @returns {Promise<import('../adapters/base.js').AuditEntry[]>}
  */
 export async function auditAll(adapters, projectDir, scope) {
   const results = [];
   for (const adapter of adapters) {
     try {
       const result = await adapter.audit(projectDir, scope);
-      results.push(result);
+      // Normalised here rather than in all 14 adapters: returning from audit()
+      // is what proves the adapter ran to completion, so this is the only place
+      // that can set the flag authoritatively.
+      results.push({ ...result, crashed: false });
     } catch (err) {
       results.push({
         framework: adapter.constructor.displayName,
         ok: [],
         warnings: [],
         errors: [`Audit failed: ${err.message}`],
+        crashed: true,
+        error: err,
       });
     }
   }

--- a/cli/lib/installer.js
+++ b/cli/lib/installer.js
@@ -148,3 +148,41 @@ export async function auditAll(adapters, projectDir, scope) {
   }
   return results;
 }
+
+/**
+ * Exit codes for `audit` (#439).
+ *
+ * 1 is deliberately absent. It already means "usage or loader error": getContext()
+ * exits 1 for an undetectable almanac root and for an unknown --framework, and node
+ * itself exits 1 with ERR_MODULE_NOT_FOUND when the CLI's deps are missing. Reusing
+ * it would leave automation unable to tell "the CLI is not installed here" from
+ * "your install is broken" — the ambiguity that made check B11 unfixable (#443).
+ */
+export const AUDIT_EXIT = {
+  CLEAN: 0,
+  CRASHED: 2,
+  FINDINGS: 3,
+};
+
+/**
+ * Reduce audit results to a process exit code.
+ *
+ * A crash outranks a finding: a finding is a completed audit that found
+ * something, while a crash means that framework has no verdict at all, so it is
+ * the more urgent thing to report. Warnings never affect the code — they
+ * describe ordinary states such as "No Copilot skills installed", so failing on
+ * them would make a machine with one framework installed exit non-zero for
+ * every other adapter.
+ *
+ * An empty result set is CLEAN. "Nothing was detected" is surfaced by the
+ * command as a warning rather than a failure, since a fresh clone with nothing
+ * installed yet is a legitimate state.
+ *
+ * @param {import('../adapters/base.js').AuditEntry[]} results
+ * @returns {number}
+ */
+export function auditExitCode(results) {
+  if (results.some((r) => r.crashed)) return AUDIT_EXIT.CRASHED;
+  if (results.some((r) => (r.errors || []).length > 0)) return AUDIT_EXIT.FINDINGS;
+  return AUDIT_EXIT.CLEAN;
+}

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -26,6 +26,7 @@ import {
   getCampfireSprite,
   createAgentGlyph, getAgentPng, getTeamStrip, getCampfirePng, getCampfireFrames, GLYPH_SIZE,
 } from '../lib/sprites.js';
+import { auditAll } from '../lib/installer.js';
 import { buildFireScene } from '../lib/scene.js';
 import { canInlineImage, renderInlineImage } from '../lib/inline-image.js';
 
@@ -232,6 +233,66 @@ describe('audit', () => {
     const result = await new ClaudeCodeAdapter().audit(ROOT, 'project');
     assert.deepEqual(result.errors, []);
     assert.ok(result.ok.some((line) => /skills installed/.test(line)));
+  });
+});
+
+// ── auditAll: crash vs finding (#439) ────────────────────────────
+//
+// A crash and a finding reach printAudit() with the same shape — same keys,
+// same types, same framework name — so the only way to tell them apart used to
+// be the `Audit failed: ` prefix on the message. That is a stdout grep moved
+// into the data structure, which is the fragility that killed B11 (#443).
+//
+// The distinction is not cosmetic. A finding means the adapter ran and reported
+// something; a crash means it produced no verdict at all, so `ok` is empty and a
+// wholly broken install audits as "nothing installed, nothing wrong" — which is
+// how #365 survived three weeks. auditAll() now records that structurally.
+
+describe('auditAll marks crashes structurally (#439)', () => {
+  class ThrowingAdapter {
+    static displayName = 'Throwing';
+    async audit() { throw new Error('boom'); }
+  }
+  class FindingAdapter {
+    static displayName = 'Finding';
+    async audit() {
+      return { framework: 'Finding', ok: [], warnings: [], errors: ['1 broken skill symlinks'] };
+    }
+  }
+  class CleanAdapter {
+    static displayName = 'Clean';
+    async audit() {
+      return { framework: 'Clean', ok: ['2 skills installed'], warnings: [], errors: [] };
+    }
+  }
+
+  it('flags a thrown audit as crashed and carries the original error', async () => {
+    const [entry] = await auditAll([new ThrowingAdapter()], ROOT, 'project');
+    assert.equal(entry.crashed, true);
+    assert.equal(entry.framework, 'Throwing');
+    assert.match(entry.errors[0], /Audit failed: boom/);
+    assert.ok(entry.error instanceof Error, 'the original throw should be carried');
+  });
+
+  it('does not flag an adapter that reported findings without throwing', async () => {
+    const [entry] = await auditAll([new FindingAdapter()], ROOT, 'project');
+    assert.equal(entry.crashed, false);
+    assert.deepEqual(entry.errors, ['1 broken skill symlinks']);
+  });
+
+  it('separates crash from finding without matching on message text', async () => {
+    const results = await auditAll(
+      [new ThrowingAdapter(), new FindingAdapter(), new CleanAdapter()], ROOT, 'project');
+    assert.deepEqual(results.map((r) => r.crashed), [true, false, false]);
+    // Both the crash and the finding have a non-empty errors[]. That is exactly
+    // why errors.length cannot be the discriminator and the flag has to exist.
+    assert.deepEqual(results.map((r) => r.errors.length > 0), [true, true, false]);
+  });
+
+  it('sets crashed on every entry, so consumers need no undefined check', async () => {
+    const results = await auditAll(
+      [new CleanAdapter(), new ThrowingAdapter()], ROOT, 'project');
+    assert.deepEqual(results.map((r) => Object.hasOwn(r, 'crashed')), [true, true]);
   });
 });
 

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -26,7 +26,7 @@ import {
   getCampfireSprite,
   createAgentGlyph, getAgentPng, getTeamStrip, getCampfirePng, getCampfireFrames, GLYPH_SIZE,
 } from '../lib/sprites.js';
-import { auditAll } from '../lib/installer.js';
+import { auditAll, auditExitCode, AUDIT_EXIT } from '../lib/installer.js';
 import { buildFireScene } from '../lib/scene.js';
 import { canInlineImage, renderInlineImage } from '../lib/inline-image.js';
 
@@ -35,6 +35,29 @@ const ROOT = process.cwd();
 
 function run(args) {
   return execSync(`${CLI} ${args}`, { cwd: ROOT, encoding: 'utf8', timeout: 10000 });
+}
+
+/**
+ * Run the CLI, capturing output even when it exits non-zero.
+ *
+ * run() uses execSync, which throws on a non-zero exit and leaves stdout on
+ * err.stdout — where callers normally drop it. Since #439 `audit` exits 3 on
+ * findings and 2 on a crash, so the audit assertions need the report regardless
+ * of status; using run() there would let the first real finding take down the
+ * whole block with an opaque error instead of a legible failure.
+ *
+ * run() itself is deliberately left throwing: the gather and scatter tests
+ * below assert on that behaviour.
+ *
+ * @returns {{ stdout: string, status: number }}
+ */
+function runAllowFail(args) {
+  try {
+    const stdout = execSync(`${CLI} ${args}`, { cwd: ROOT, encoding: 'utf8', timeout: 10000 });
+    return { stdout, status: 0 };
+  } catch (err) {
+    return { stdout: err.stdout ?? '', status: err.status ?? 1 };
+  }
 }
 
 /**
@@ -198,8 +221,9 @@ describe('audit', () => {
   // assertion its own subprocess made the suite flake on ETIMEDOUT -- and
   // package.json wires this file as prepublishOnly, so a flake blocks release.
   let out;
+  let auditStatus;
   before(() => {
-    out = run('audit');
+    ({ stdout: out, status: auditStatus } = runAllowFail('audit'));
   });
 
   it('reports Claude Code health', () => {
@@ -233,6 +257,13 @@ describe('audit', () => {
     const result = await new ClaudeCodeAdapter().audit(ROOT, 'project');
     assert.deepEqual(result.errors, []);
     assert.ok(result.ok.some((line) => /skills installed/.test(line)));
+  });
+
+  // The machine-readable half of the signal the three assertions above make by
+  // reading prose (#439). This repo audits clean, so a non-zero status here is a
+  // real regression rather than a test artifact.
+  it('exits 0 when the audit is clean', () => {
+    assert.equal(auditStatus, AUDIT_EXIT.CLEAN);
   });
 });
 
@@ -293,6 +324,71 @@ describe('auditAll marks crashes structurally (#439)', () => {
     const results = await auditAll(
       [new CleanAdapter(), new ThrowingAdapter()], ROOT, 'project');
     assert.deepEqual(results.map((r) => Object.hasOwn(r, 'crashed')), [true, true]);
+  });
+});
+
+describe('auditExitCode (#439)', () => {
+  const entry = (over = {}) => (
+    { framework: 'X', ok: [], warnings: [], errors: [], crashed: false, ...over });
+
+  it('pins the numeric contract', () => {
+    // Deliberately literal. Asserting via AUDIT_EXIT everywhere would let a
+    // renumbering pass silently, and these codes are a public contract the
+    // moment they ship in a released CLI.
+    assert.deepEqual(AUDIT_EXIT, { CLEAN: 0, CRASHED: 2, FINDINGS: 3 });
+  });
+
+  it('is CLEAN for a healthy audit', () => {
+    assert.equal(auditExitCode([entry({ ok: ['2 skills installed'] })]), AUDIT_EXIT.CLEAN);
+  });
+
+  it('is FINDINGS when an adapter reported errors', () => {
+    assert.equal(
+      auditExitCode([entry({ errors: ['1 broken skill symlinks'] })]), AUDIT_EXIT.FINDINGS);
+  });
+
+  it('is CRASHED when an adapter threw', () => {
+    assert.equal(
+      auditExitCode([entry({ crashed: true, errors: ['Audit failed: boom'] })]),
+      AUDIT_EXIT.CRASHED);
+  });
+
+  it('ranks a crash above a finding', () => {
+    // A finding is a completed audit that found something; a crash means that
+    // framework produced no verdict at all, so it is the more urgent report.
+    assert.equal(auditExitCode([
+      entry({ errors: ['1 broken skill symlinks'] }),
+      entry({ crashed: true, errors: ['Audit failed: boom'] }),
+    ]), AUDIT_EXIT.CRASHED);
+  });
+
+  it('never fails on warnings alone', () => {
+    // Warnings describe ordinary states ("No Copilot skills installed"), so
+    // failing on them would make a machine with one framework installed exit
+    // non-zero for every other adapter.
+    assert.equal(
+      auditExitCode([entry({ warnings: ['No Copilot skills installed'] })]), AUDIT_EXIT.CLEAN);
+  });
+
+  it('is CLEAN for an empty result set', () => {
+    // "Nothing detected" is surfaced by the command as a warning rather than a
+    // failure — a fresh clone with nothing installed yet is legitimate.
+    assert.equal(auditExitCode([]), AUDIT_EXIT.CLEAN);
+  });
+
+  it('never returns 1, which is reserved for usage and loader errors', () => {
+    // getContext() exits 1 for an undetectable root and unknown --framework, and
+    // node exits 1 with ERR_MODULE_NOT_FOUND when deps are missing. Colliding
+    // with that is what made B11 unfixable (#443).
+    const shapes = [
+      [],
+      [entry()],
+      [entry({ errors: ['e'] })],
+      [entry({ crashed: true })],
+      [entry({ warnings: ['w'] })],
+      [entry({ crashed: true }), entry({ errors: ['e'] })],
+    ];
+    for (const shape of shapes) assert.notEqual(auditExitCode(shape), 1);
   });
 });
 

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -8,7 +8,8 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { execSync } from 'child_process';
-import { existsSync, mkdirSync, rmSync, readlinkSync, readFileSync, writeFileSync, symlinkSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, readlinkSync, readFileSync, writeFileSync, symlinkSync } from 'fs';
+import { tmpdir } from 'os';
 import { resolve } from 'path';
 
 // Direct imports for unit tests.
@@ -221,9 +222,8 @@ describe('audit', () => {
   // assertion its own subprocess made the suite flake on ETIMEDOUT -- and
   // package.json wires this file as prepublishOnly, so a flake blocks release.
   let out;
-  let auditStatus;
   before(() => {
-    ({ stdout: out, status: auditStatus } = runAllowFail('audit'));
+    ({ stdout: out } = runAllowFail('audit'));
   });
 
   it('reports Claude Code health', () => {
@@ -259,12 +259,6 @@ describe('audit', () => {
     assert.ok(result.ok.some((line) => /skills installed/.test(line)));
   });
 
-  // The machine-readable half of the signal the three assertions above make by
-  // reading prose (#439). This repo audits clean, so a non-zero status here is a
-  // real regression rather than a test artifact.
-  it('exits 0 when the audit is clean', () => {
-    assert.equal(auditStatus, AUDIT_EXIT.CLEAN);
-  });
 });
 
 // ── auditAll: crash vs finding (#439) ────────────────────────────
@@ -389,6 +383,95 @@ describe('auditExitCode (#439)', () => {
       [entry({ crashed: true }), entry({ errors: ['e'] })],
     ];
     for (const shape of shapes) assert.notEqual(auditExitCode(shape), 1);
+  });
+});
+
+// ── audit exit codes, end to end (#439) ──────────────────────────
+//
+// The block above covers auditExitCode()'s logic, but it cannot see whether the
+// command ever CALLS it: deleting `process.exitCode = auditExitCode(results)`
+// from cli/index.js leaves every one of those assertions green, so #439 could
+// regress verbatim under a refactor while CI stayed green. That is the same
+// shape as the defect this whole change exists to close, so it is worth the
+// three subprocesses. These tests spawn the real CLI and read its exit status.
+//
+// HOME is redirected at a fixture for the same reason the broken-symlink block
+// does it: detectFrameworks() appends the global rules unconditionally
+// (cli/lib/detector.js), so openclaw and hermes join the adapter list whenever
+// the developer has ~/.openclaw or ~/.hermes. Since the exit code reduces over
+// every adapter, one stale symlink in either would otherwise turn this repo's
+// suite red on an untouched checkout — and block npm publish via prepublishOnly.
+//
+// Fixtures live in the OS temp dir rather than under ROOT, so a crashed run
+// cannot leave state behind that poisons the next one.
+
+describe('audit exit codes end to end (#439)', () => {
+  const realSkill = resolve(ROOT, 'skills/commit-changes');
+  const cliEntry = resolve(ROOT, 'cli/index.js');
+  let tmpRoot;
+  let savedHome;
+
+  /** A project fixture copilot detects, via .github/copilot-instructions.md. */
+  function project(name) {
+    const dir = resolve(tmpRoot, name);
+    mkdirSync(resolve(dir, '.github'), { recursive: true });
+    writeFileSync(resolve(dir, '.github/copilot-instructions.md'), '');
+    return dir;
+  }
+
+  // Absolute entry path: these run with cwd set to the fixture, so the relative
+  // `node cli/index.js` that run() uses would not resolve.
+  function auditStatusIn(dir) {
+    try {
+      execSync(`node ${cliEntry} audit --source ${ROOT}`,
+        { cwd: dir, encoding: 'utf8', timeout: 10000 });
+      return 0;
+    } catch (err) {
+      return err.status ?? 1;
+    }
+  }
+
+  before(() => {
+    tmpRoot = mkdtempSync(resolve(tmpdir(), 'almanac-exit-'));
+    mkdirSync(resolve(tmpRoot, 'home'), { recursive: true });
+
+    const clean = project('clean');
+    mkdirSync(resolve(clean, '.github/skills'), { recursive: true });
+    symlinkSync(realSkill, resolve(clean, '.github/skills/good-skill'));
+
+    // Same fixture as clean, plus one dangling link. That one link is the only
+    // difference between CLEAN and FINDINGS.
+    const findings = project('findings');
+    mkdirSync(resolve(findings, '.github/skills'), { recursive: true });
+    symlinkSync(realSkill, resolve(findings, '.github/skills/good-skill'));
+    symlinkSync(resolve(tmpRoot, 'no-such-target'),
+      resolve(findings, '.github/skills/ghost-skill'));
+
+    // A file where the adapter expects a directory makes readdirSync throw
+    // ENOTDIR — a real adapter crash rather than a synthesised one.
+    const crashed = project('crashed');
+    writeFileSync(resolve(crashed, '.github/skills'), 'not a directory');
+
+    savedHome = process.env.HOME;
+    process.env.HOME = resolve(tmpRoot, 'home');
+  });
+
+  after(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('exits CLEAN when every link resolves', () => {
+    assert.equal(auditStatusIn(resolve(tmpRoot, 'clean')), AUDIT_EXIT.CLEAN);
+  });
+
+  it('exits FINDINGS when an adapter reports a dangling symlink', () => {
+    assert.equal(auditStatusIn(resolve(tmpRoot, 'findings')), AUDIT_EXIT.FINDINGS);
+  });
+
+  it('exits CRASHED when an adapter throws', () => {
+    assert.equal(auditStatusIn(resolve(tmpRoot, 'crashed')), AUDIT_EXIT.CRASHED);
   });
 });
 


### PR DESCRIPTION
Closes #439.

`audit` printed `ERR` lines and exited 0, so a broken install was invisible to any automation that checked status. That is how #365 survived three weeks, and why B11 had to grep stdout to say anything at all (#443).

Staged as two commits, because the second is not honestly reviewable without the first.

## 1. Mark crashes structurally (`2989f705`)

`auditAll()` turned an adapter throw into an `errors[]` entry with the same shape as a real finding — same keys, same types, same framework name. The only discriminator was that a crash's message starts with `Audit failed: `, i.e. a stdout grep relocated into the data structure. That is the fragility `scripts/validate-integrity.sh:528` warns against.

The distinction is not cosmetic. A finding means the adapter ran and reported something; a crash means it produced *no verdict at all*, so `ok[]` is empty and a wholly broken install audits as "nothing installed, nothing wrong".

`auditAll()` now sets `crashed` on every entry and carries the original throw as `error`. Normalised in `auditAll` rather than across all 14 adapters: returning from `audit()` is what proves the adapter ran to completion, so that is the only place able to set it authoritatively. No behaviour change — `printAudit()` reads only `ok`/`warnings`/`errors`, so output bytes and exit codes are untouched.

## 2. Give audit a real exit code (`30bfe69e`)

| Code | Meaning |
| --- | --- |
| `0` | Audit ran and found no errors |
| `2` | An adapter crashed, so that framework has no verdict |
| `3` | Audit ran and found errors |

**Why not 1.** It is already taken three times over: `getContext()` exits 1 for an undetectable almanac root and for an unknown `--framework`, and node exits 1 with `ERR_MODULE_NOT_FOUND` when deps are missing. Reusing it would leave automation unable to tell *"the CLI is not installed here"* from *"your install is broken"* — precisely the ambiguity B11 died of.

**Crash outranks finding**, since a crash is the more urgent report. **Warnings never affect the code** — they describe ordinary states like `No Copilot skills installed`, so failing on them would make a machine with one framework installed exit non-zero for every other adapter. The full report prints *before* the exit code is set, so a non-zero status never costs the user the reason for it.

**Harness.** Adds `runAllowFail()` and switches the `audit` `before()` block to it. `execSync` throws on non-zero and leaves stdout on `err.stdout`, so without this the first real finding would take down the whole audit block with an opaque error instead of a legible failure. `run()` itself stays throwing — the gather and scatter tests assert on that.

## Verification

88 → 101 tests, all green.

Both commits were checked by breaking the subject and watching the gate go red, per the discipline from #443:

- **Commit 1:** removing the `crashed` flag from `installer.js` fails exactly the 4 new tests and leaves the other 88 green — so they are specific to the subject, with no collateral coupling.
- **Commit 2:** verified end to end rather than only by unit test. A fixture directory with a dangling `.github/skills` symlink exits **3** (`ERR 1 broken skill symlinks`); the *same fixture* with every link valid exits **0**. The dangling link is the only difference between red and green.

One test pins the numeric codes literally rather than via `AUDIT_EXIT`, since asserting only through the constant would let a renumbering pass silently.

## One caveat, stated rather than buried

The "no frameworks detected" warning added here is **currently unreachable**. The universal rule at `cli/lib/detector.js:20` is `existsSync(...) || true`, which always matches, so detection never returns an empty list. The guard is three lines and a silent false-clean to omit, so it is kept — with a comment at the call site saying exactly this, and filed as #457. Please do not read its presence as evidence the empty case has been observed.

## Deliberately not in scope

Wiring the CI gate. `.github/workflows/ci-node-cli.yml` is the right home for it (it runs `npm ci` and triggers on `cli/**`, the two structural reasons B11 could never fire) — but adding a step that can turn `main` red is its own decision, and this PR is the enabling change. Happy to follow up.

Also out of scope, found along the way and filed separately: #453 (campfire tests mutate the real repo root), #454 (suite is blind to chalk output), #455 (chalk fallback proxy is broken by construction), #456 (`--version` drift), #457 (the detector `|| true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUt4LTGxoyUXPfe7BjRpJ
