### PR TITLE
feat(scripts): add mutation-check; fix --version drift (#456)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,27 @@ Guides, skills, agents, and teams are cross-referenced. The parent project `CLAU
   done
   ```
 
+## Proving a Gate Can Fail
+
+A green check is evidence about the *check*, not about the subject. Before trusting a gate — and always before claiming to have tightened one — break the thing it guards and confirm the gate goes red.
+
+`scripts/mutation-check.js` automates the envelope:
+
+```bash
+npm run mutation-check -- \
+  --file cli/index.js \
+  --delete-matching 'process.exitCode = auditExitCode' \
+  --test 'npm run test:cli' \
+  --expect-killed-by 2
+```
+
+It refuses to run on a file with uncommitted changes (restore is `git checkout --`), requires a green baseline, **verifies via `git diff` that the mutation actually landed**, records the real exit code, then restores and verifies the restore. Exit 0 means the mutant was killed; exit 1 means it survived and the line is uncovered.
+
+Two traps this exists to catch, both of which have shipped here:
+
+- **A mutation that silently matched nothing** makes the whole exercise pass vacuously while looking correct. In-place `sed`/`perl -0pi` no-op on the NTFS mount, and bare `grep` resolves to ugrep locally but GNU grep in CI — which is why the tool is Node and checks `git diff` rather than trusting the edit.
+- **A manual break-and-check proves the feature, not the coverage.** Running the CLI by hand and seeing the right behaviour is a demo; "removing this line fails these N tests" is coverage. In #458 the exit code was verified end to end by hand and written up in the commit, while deleting the fix line still left all 101 tests green.
+
 ## Adding a New Skill
 
 1. Create `skills/<skill-name>/SKILL.md` following the format of existing skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,14 @@ npm run mutation-check -- \
   --expect-killed-by 2
 ```
 
-It refuses to run on a file with uncommitted changes (restore is `git checkout --`), requires a green baseline, **verifies via `git diff` that the mutation actually landed**, records the real exit code, then restores and verifies the restore. Exit 0 means the mutant was killed; exit 1 means it survived and the line is uncovered.
+Exit 0 means the mutant was killed and the check works. Exit 1 means it survived — the line is uncovered — or the run could not produce an honest verdict.
 
-Two traps this exists to catch, both of which have shipped here:
+The tool refuses to guess. It requires a green baseline, backs the file up on disk before touching it, restores from an in-memory buffer (never `git checkout --`, which restores from the *index*), and reports `INCONCLUSIVE` rather than a kill whenever the test command could not be interpreted. It declines to run at all on a symlink, on an `--assume-unchanged`/`--skip-worktree` file, on a file with uncommitted changes, on a mutation matching more than one site without `--allow-multiple`, or while a stale `.mutation-check.bak` is present.
 
-- **A mutation that silently matched nothing** makes the whole exercise pass vacuously while looking correct. In-place `sed`/`perl -0pi` no-op on the NTFS mount, and bare `grep` resolves to ugrep locally but GNU grep in CI — which is why the tool is Node and checks `git diff` rather than trusting the edit.
+Three traps it exists to catch, all of which have shipped here:
+
+- **A mutation that silently matched nothing** makes the exercise pass vacuously while looking correct. In-place `sed`/`perl -0pi` no-op on the NTFS mount, and bare `grep` resolves to ugrep locally but GNU grep in CI — which is why the tool is Node and compares content in memory rather than trusting the edit.
+- **A mutation that merely breaks parsing is not coverage.** Deleting a line carrying a brace makes the file fail to load, and node:test reports that as one failing test — indistinguishable from a real kill. Mutants are syntax-checked first and reported `INVALID` if they do not parse. Note `node --check` parses a `.js` file as CommonJS, so the check is done through a temp file whose extension matches the package's module type; without that this guard is dead for every `.js` file in an ESM package.
 - **A manual break-and-check proves the feature, not the coverage.** Running the CLI by hand and seeing the right behaviour is a demo; "removing this line fails these N tests" is coverage. In #458 the exit code was verified end to end by hand and written up in the commit, while deleting the fix line still left all 101 tests green.
 
 ## Adding a New Skill

--- a/cli/README.md
+++ b/cli/README.md
@@ -66,10 +66,14 @@ npm install -g agent-almanac
 This registers two commands: `agent-almanac` and `almanac` (shorthand). Verify with:
 
 ```bash
-agent-almanac --version   # 1.1.0
+agent-almanac --version
 ```
 
-Requires Node.js 18+.
+The version is read from the package manifest, so it always matches the
+installed release. (No example output here on purpose — the previous hardcoded
+number drifted from both the manifest and the binary. See #456.)
+
+Requires Node.js 22.12 or newer, matching the `engines` field in `package.json`.
 
 ### From source
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -19,6 +19,10 @@
  */
 
 import { Command } from 'commander';
+// Read the version from the manifest rather than restating it. A hardcoded
+// string drifted three ways (#456): the binary printed 0.1.0, cli/README.md
+// advertised 1.1.0, and the published package was 1.3.0.
+import pkg from '../package.json' with { type: 'json' };
 import { createInterface } from 'readline';
 import { loadRegistries, resolveItems, filterSkills, search, findTeam, findAgent } from './lib/registry.js';
 import { detectAlmanacRoot, resolveTargetDir } from './lib/resolver.js';
@@ -35,7 +39,7 @@ const program = new Command();
 program
   .name('agent-almanac')
   .description('Universal skill/agent/team installer for agentic CLI frameworks')
-  .version('0.1.0')
+  .version(pkg.version)
   .action(async () => {
     // Bare invocation — launch TUI if in a TTY, otherwise show help
     const { startTui } = await import('./lib/tui.js');

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -808,9 +808,14 @@ describe('tend', () => {
 // ── Version ──────────────────────────────────────────────────────
 
 describe('meta', () => {
-  it('shows version', () => {
-    const out = run('--version');
-    assert.match(out, /\d+\.\d+\.\d+/);
+  it('shows the version from package.json', () => {
+    // Deliberately re-reads the manifest instead of importing the same module
+    // the CLI does: if the CLI's version wiring breaks, this still knows the
+    // truth. The previous assertion was /\d+\.\d+\.\d+/, which `0.1.0` satisfied
+    // while the published package was 1.3.0 — which is why #456 went unnoticed
+    // through every release.
+    const expected = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')).version;
+    assert.equal(run('--version').trim(), expected);
   });
 
   it('shows help', () => {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "validate:locales-json": "node scripts/validate-locales-json.js",
     "validate:security": "node scripts/scan-skill-content.js",
     "coverage:evals": "node scripts/eval-coverage.js",
+    "mutation-check": "node scripts/mutation-check.js",
     "translation:status": "node scripts/generate-translation-status.js",
     "translate:scaffold": "bash scripts/translate-content.sh",
     "test": "npm run validate:integrity && npm run check-readmes",

--- a/scripts/mutation-check.js
+++ b/scripts/mutation-check.js
@@ -2,74 +2,65 @@
 /**
  * mutation-check.js — prove that a check is capable of failing.
  *
- * A gate that reports healthy is evidence about the *gate*, not the subject. The
- * only way to know a test covers a line is to remove that line and watch the test
- * go red. This automates that envelope safely:
- *
- *   1. refuse to run if the target file has uncommitted changes (restore is
- *      `git checkout --`, which would destroy them)
- *   2. run the test command first and require GREEN — a mutation tells you nothing
- *      about an already-red suite
- *   3. apply the mutation
- *   4. VERIFY THE MUTATION LANDED via `git diff`. This is the step that matters:
- *      a substitution that silently matched nothing makes the whole exercise pass
- *      vacuously while looking correct
- *   5. re-run the tests and record the real exit code
- *   6. restore, and verify the restore actually happened
- *
- * The mutant is "killed" if the suite goes red. A SURVIVING mutant means the line
- * is not covered, however convincingly the behaviour was demonstrated by hand.
+ * A green gate is evidence about the *gate*, not the subject. The only way to know
+ * a test covers a line is to remove that line and watch the test go red. This runs
+ * that experiment and refuses to guess when it cannot answer honestly.
  *
  *   node scripts/mutation-check.js \
  *     --file cli/index.js \
  *     --delete-matching 'process.exitCode = auditExitCode' \
  *     --test 'npm run test:cli'
  *
- *   node scripts/mutation-check.js \
- *     --file cli/lib/installer.js \
- *     --replace 'crashed: true'::'crashed: false' \
- *     --test 'npm run test:cli'
+ * Exit 0 = mutant killed (the check works).
+ * Exit 1 = mutant survived (the line is uncovered), or the run was inconclusive.
  *
- * Exit 0 = mutant killed (the check works). Exit 1 = mutant survived (gap found),
- * or the run could not be completed safely.
+ * ── Why it is this defensive ─────────────────────────────────────
  *
- * Written in Node rather than shell deliberately: in-place `sed` silently no-ops on
- * this repo's NTFS mount, and bare `grep` resolves to ugrep locally but GNU grep in
- * CI — the two failure modes this tool exists to catch.
+ * The first version of this file was reviewed adversarially and had four blocking
+ * defects, two of which destroyed uncommitted work. Every guard below exists
+ * because its absence was reproduced:
+ *
+ *   - It restored with `git checkout --`, which resurrects from the INDEX, not
+ *     HEAD, and silently overwrote a `--assume-unchanged` file's uncommitted
+ *     content. Restore is now purely from the in-memory buffer; git is never asked
+ *     to write to the worktree.
+ *   - `writeFileSync` followed a symlinked --file and wrote through it to a target
+ *     git has no copy of. Symlinks are now refused.
+ *   - A mutation that merely broke JS parsing was reported as a kill, which is the
+ *     exact false-confidence this tool exists to prevent. Mutants are now syntax
+ *     checked, and a mutant that does not parse is INVALID, not killed.
+ *   - spawnSync's 1 MiB default maxBuffer SIGTERMs the child and returns
+ *     `status: null`; `?? 1` turned a genuinely GREEN run into "killed". Spawn
+ *     errors and signals are now inspected and reported as inconclusive.
+ *
+ * Written in Node rather than shell deliberately: in-place `sed`/`perl -0pi`
+ * silently no-op on this repo's NTFS mount, and bare `grep` resolves to ugrep
+ * locally but GNU grep in CI — the two failure modes this tool exists to catch.
  */
 import { spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
+import { existsSync, lstatSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, extname, relative, resolve } from 'node:path';
 
 const USAGE = `Usage:
   node scripts/mutation-check.js --file <path> --test <cmd> (--delete-matching <str> | --replace <old>::<new>)
 
 Options:
-  --file <path>             File to mutate (must be tracked and unmodified)
-  --test <cmd>              Command whose red/green tells you if the mutant died
-  --delete-matching <str>   Delete every line containing this literal substring
-  --replace <old>::<new>    Replace literal <old> with <new> (first occurrence)
-  --expect-killed-by <n>    Require exactly n failing tests (parsed from node:test output)
-  --skip-baseline           Skip the pre-flight green run (faster, less safe)
+  --file <path>             File to mutate. Must be tracked, unmodified, and a
+                            regular file (symlinks are refused).
+  --test <cmd>              Command whose red/green decides whether the mutant died
+  --delete-matching <str>   Delete lines containing this literal substring
+  --replace <old>::<new>    Replace literal <old> with <new>
+  --allow-multiple          Permit a mutation affecting more than one site. Off by
+                            default: a collateral site can produce a kill that gets
+                            credited to the line you meant to test.
+  --expect-killed-by <n>    Require exactly n failing tests. Errors if the count
+                            cannot be parsed, rather than passing silently.
   -h, --help                Show this message`;
 
-// ── args ─────────────────────────────────────────────────────────
+const BACKUP_SUFFIX = '.mutation-check.bak';
 
-function parseArgs(argv) {
-  const opts = {};
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg === '-h' || arg === '--help') opts.help = true;
-    else if (arg === '--skip-baseline') opts.skipBaseline = true;
-    else if (arg === '--file') opts.file = argv[++i];
-    else if (arg === '--test') opts.test = argv[++i];
-    else if (arg === '--delete-matching') opts.deleteMatching = argv[++i];
-    else if (arg === '--replace') opts.replace = argv[++i];
-    else if (arg === '--expect-killed-by') opts.expectKilledBy = Number(argv[++i]);
-    else fail(`Unknown argument: ${arg}\n\n${USAGE}`);
-  }
-  return opts;
-}
+// ── helpers ──────────────────────────────────────────────────────
 
 function fail(msg) {
   console.error(`ERROR: ${msg}`);
@@ -80,37 +71,100 @@ function git(args, opts = {}) {
   return spawnSync('git', args, { encoding: 'utf8', ...opts });
 }
 
-/** Run a shell command, returning its REAL exit code. Never piped — a pipe would
- *  report the last stage's status and silently invert the result. */
-function runTest(cmd) {
-  const res = spawnSync(cmd, { shell: true, encoding: 'utf8' });
-  return { status: res.status ?? 1, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+/**
+ * Run a shell command and report what actually happened.
+ *
+ * spawnSync does NOT simply return an exit code: on maxBuffer overflow it kills the
+ * child and returns status null with error.code ENOBUFS, and on spawn failure it
+ * returns status null with an error. Coercing either to a number invents a red run
+ * out of a green one, so both are surfaced instead.
+ */
+function runCommand(cmd) {
+  const res = spawnSync(cmd, {
+    shell: true,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return {
+    status: res.status,
+    signal: res.signal,
+    error: res.error,
+    output: (res.stdout ?? '') + (res.stderr ?? ''),
+  };
 }
 
-/** Pull `# fail N` out of node:test output; null if the format is not recognised. */
+/** Describe why a run could not be interpreted, or null if it can be. */
+function inconclusiveReason(run) {
+  if (run.error) return `the test command could not be run (${run.error.code ?? run.error.message})`;
+  if (run.signal) return `the test command was killed by ${run.signal}, so its result is not a verdict`;
+  if (run.status === null) return 'the test command produced no exit status';
+  if (run.status === 127) return 'the test command was not found (exit 127) — check the --test string';
+  return null;
+}
+
+/** Pull `fail N` out of node:test output; null if the format is not recognised. */
 function parseFailCount(output) {
-  const match = output.match(/^\s*[^\s]*\s*fail\s+(\d+)\s*$/m);
+  const match = output.match(/^\s*\S*\s*fail\s+(\d+)\s*$/m);
   return match ? Number(match[1]) : null;
 }
 
-// ── mutation ─────────────────────────────────────────────────────
-
-function mutate(original, opts) {
-  if (opts.deleteMatching !== undefined) {
-    const kept = original.split('\n').filter((line) => !line.includes(opts.deleteMatching));
-    return kept.join('\n');
+/** The `type` of the nearest package.json above `dir`, defaulting to commonjs. */
+function packageType(dir, stopAt) {
+  let cur = dir;
+  for (;;) {
+    const manifest = resolve(cur, 'package.json');
+    if (existsSync(manifest)) {
+      try {
+        return JSON.parse(readFileSync(manifest, 'utf8')).type ?? 'commonjs';
+      } catch {
+        return 'commonjs';
+      }
+    }
+    if (cur === stopAt || dirname(cur) === cur) return 'commonjs';
+    cur = dirname(cur);
   }
-  const sep = opts.replace.indexOf('::');
-  if (sep === -1) fail('--replace needs the form <old>::<new>');
-  const from = opts.replace.slice(0, sep);
-  const to = opts.replace.slice(sep + 2);
-  if (!original.includes(from)) return original; // step 4 will catch it
-  return original.replace(from, to);
 }
 
-// ── main ─────────────────────────────────────────────────────────
+/**
+ * JS mutants must still parse — otherwise a "kill" only means the file is broken.
+ *
+ * `node --check <file>.js` parses as CommonJS, so an ESM file mangled into invalid
+ * syntax can still exit 0. Verified: a file containing a stray `}` checks clean as
+ * `.js` and fails as `.mjs`. Since the extension drives the parser, the content is
+ * probed through a temp file whose extension matches the package's actual module
+ * type — otherwise this guard is dead for every `.js` file in an ESM package, which
+ * is exactly the shape of defect it exists to catch.
+ */
+function parses(filePath, content, repoRootDir) {
+  const ext = extname(filePath);
+  if (!['.js', '.mjs', '.cjs'].includes(ext)) return true;
+  const probeExt = ext !== '.js'
+    ? ext
+    : (packageType(dirname(filePath), repoRootDir) === 'module' ? '.mjs' : '.cjs');
+  const probe = resolve(tmpdir(), `mutation-check-probe-${process.pid}${probeExt}`);
+  try {
+    writeFileSync(probe, content);
+    return spawnSync(process.execPath, ['--check', probe]).status === 0;
+  } finally {
+    try { unlinkSync(probe); } catch { /* best effort */ }
+  }
+}
 
-const opts = parseArgs(process.argv.slice(2));
+// ── args ─────────────────────────────────────────────────────────
+
+const opts = {};
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i];
+  if (arg === '-h' || arg === '--help') opts.help = true;
+  else if (arg === '--allow-multiple') opts.allowMultiple = true;
+  else if (arg === '--file') opts.file = argv[++i];
+  else if (arg === '--test') opts.test = argv[++i];
+  else if (arg === '--delete-matching') opts.deleteMatching = argv[++i];
+  else if (arg === '--replace') opts.replace = argv[++i];
+  else if (arg === '--expect-killed-by') opts.expectKilledBy = Number(argv[++i]);
+  else fail(`Unknown argument: ${arg}\n\n${USAGE}`);
+}
 
 if (opts.help) {
   console.log(USAGE);
@@ -123,114 +177,207 @@ if (opts.deleteMatching === undefined && opts.replace === undefined) {
 if (opts.deleteMatching !== undefined && opts.replace !== undefined) {
   fail('--delete-matching and --replace are mutually exclusive');
 }
+// An empty needle matches every line and blanks the file, which reliably "kills"
+// the mutant while proving nothing.
+if (opts.deleteMatching === '') fail('--delete-matching needs a non-empty string');
+if (opts.replace !== undefined && !opts.replace.includes('::')) {
+  fail('--replace needs the form <old>::<new>');
+}
+if (opts.expectKilledBy !== undefined && !Number.isInteger(opts.expectKilledBy)) {
+  fail('--expect-killed-by needs an integer');
+}
+
+// ── preconditions ────────────────────────────────────────────────
 
 const repoRoot = git(['rev-parse', '--show-toplevel']).stdout?.trim();
 if (!repoRoot) fail('Not inside a git repository.');
 
 const absFile = resolve(process.cwd(), opts.file);
 const relFile = relative(repoRoot, absFile);
+const backupPath = absFile + BACKUP_SUFFIX;
 
-// 1. Precondition. Restore is `git checkout --`, which discards working-tree
-//    changes, so refuse outright rather than risk destroying uncommitted work.
-const tracked = git(['ls-files', '--error-unmatch', '--', relFile], { cwd: repoRoot });
-if (tracked.status !== 0) fail(`${relFile} is not tracked by git — cannot restore it safely.`);
+if (!existsSync(absFile)) fail(`${relFile} does not exist.`);
+
+// Symlinks: readFileSync/writeFileSync follow them, so the tool would mutate a
+// target git has no copy of, and no git-based safety net could see it.
+if (lstatSync(absFile).isSymbolicLink()) {
+  fail(`${relFile} is a symlink. Pass the real file — writes would follow the link to a target git does not track.`);
+}
+if (!lstatSync(absFile).isFile()) fail(`${relFile} is not a regular file.`);
+
+if (existsSync(backupPath)) {
+  fail(
+    `A backup from a previous run is still present:\n  ${relative(repoRoot, backupPath)}\n` +
+    'That run did not finish cleanly, so the file may still hold a mutation.\n' +
+    `Recover with:  mv "${backupPath}" "${absFile}"`
+  );
+}
+
+if (git(['ls-files', '--error-unmatch', '--', relFile], { cwd: repoRoot }).status !== 0) {
+  fail(`${relFile} is not tracked by git.`);
+}
+
+// `--assume-unchanged` / `--skip-worktree` make git report a file clean no matter
+// how far the worktree has diverged, so every git-based check below would lie.
+const lsFlag = git(['ls-files', '-v', '--', relFile], { cwd: repoRoot }).stdout.trim().charAt(0);
+if (lsFlag && lsFlag !== 'H') {
+  fail(
+    `${relFile} carries the git index flag '${lsFlag}' (assume-unchanged or skip-worktree).\n` +
+    'git reports such a file clean regardless of its real contents, so this tool cannot\n' +
+    `verify it is safe to mutate. Clear it with:  git update-index --no-assume-unchanged -- ${relFile}`
+  );
+}
 
 const dirty = git(['status', '--porcelain', '--', relFile], { cwd: repoRoot }).stdout.trim();
 if (dirty) {
   fail(
     `${relFile} has uncommitted changes:\n  ${dirty}\n` +
-    'Commit or stash them first — this tool restores with `git checkout --`, which would discard them.'
+    'Commit or stash them first, so the mutation is applied to a known state.'
   );
 }
+
+// ── run ──────────────────────────────────────────────────────────
 
 console.log(`\nmutation-check: ${relFile}`);
 console.log(`  mutation: ${opts.deleteMatching !== undefined
   ? `delete lines containing "${opts.deleteMatching}"`
-  : `replace "${opts.replace.split('::')[0]}"`}`);
+  : `replace "${opts.replace.slice(0, opts.replace.indexOf('::'))}"`}`);
 console.log(`  test:     ${opts.test}\n`);
 
-// 2. Baseline. A mutation on an already-red suite proves nothing.
-if (!opts.skipBaseline) {
-  console.log('[1/4] baseline (expect green) ...');
-  const base = runTest(opts.test);
-  if (base.status !== 0) {
-    fail(
-      `Baseline is already failing (exit ${base.status}). Fix that first — a surviving\n` +
-      'or killed mutant is meaningless when the suite is red to begin with.'
-    );
-  }
-  console.log('      green.\n');
-} else {
-  console.log('[1/4] baseline skipped (--skip-baseline)\n');
+console.log('[1/5] baseline (expect green) ...');
+const baseline = runCommand(opts.test);
+const baselineProblem = inconclusiveReason(baseline);
+if (baselineProblem) fail(`Baseline inconclusive — ${baselineProblem}`);
+if (baseline.status !== 0) {
+  fail(
+    `Baseline is already failing (exit ${baseline.status}). Fix that first — a killed or\n` +
+    'surviving mutant means nothing when the suite is red to begin with.'
+  );
 }
+console.log('      green.\n');
 
 const original = readFileSync(absFile, 'utf8');
-let restored = false;
 
+// Build the mutant in memory. Comparing strings is how "did it land" is decided:
+// asking git would be blind to exactly the cases guarded against above.
+let mutated;
+let sites;
+if (opts.deleteMatching !== undefined) {
+  const lines = original.split('\n');
+  sites = lines.filter((line) => line.includes(opts.deleteMatching)).length;
+  mutated = lines.filter((line) => !line.includes(opts.deleteMatching)).join('\n');
+} else {
+  const sep = opts.replace.indexOf('::');
+  const from = opts.replace.slice(0, sep);
+  const to = opts.replace.slice(sep + 2);
+  sites = from === '' ? 0 : original.split(from).length - 1;
+  mutated = original.split(from).join(to);
+}
+
+if (mutated === original) {
+  fail(
+    'The mutation would not change the file — nothing matched.\n' +
+    'This is the silent no-op that makes a negative test pass vacuously.\n' +
+    'The string is matched literally, not as a regex.'
+  );
+}
+if (sites > 1 && !opts.allowMultiple) {
+  fail(
+    `The mutation affects ${sites} sites, not 1.\n` +
+    'A collateral site can produce a kill that gets credited to the line you meant to\n' +
+    'test. Narrow the string, or pass --allow-multiple if that is genuinely intended.'
+  );
+}
+
+let restored = false;
 function restore() {
   if (restored) return;
   restored = true;
+  // Buffer only. `git checkout --` would restore from the index, not from what was
+  // read, and would overwrite content git cannot see.
   writeFileSync(absFile, original);
-  const res = git(['checkout', '--', relFile], { cwd: repoRoot });
-  const stillDirty = git(['status', '--porcelain', '--', relFile], { cwd: repoRoot }).stdout.trim();
-  if (res.status !== 0 || stillDirty) {
-    console.error(`\nERROR: ${relFile} may not be restored. Check it manually:\n  git status -- ${relFile}`);
+  if (readFileSync(absFile, 'utf8') !== original) {
+    console.error(`\nERROR: ${relFile} was NOT restored. Recover with:\n  mv "${backupPath}" "${absFile}"`);
+    return;
   }
+  if (existsSync(backupPath)) unlinkSync(backupPath);
 }
 
-// Restore even if interrupted — a half-mutated tree is worse than no result.
+// spawnSync blocks the event loop, so these fire only between phases — which is why
+// the on-disk backup exists rather than relying on them.
 process.on('SIGINT', () => { restore(); process.exit(130); });
 process.on('SIGTERM', () => { restore(); process.exit(143); });
 
-let killed = false;
+let verdict = null;
 let failCount = null;
 
 try {
-  // 3. Apply.
-  console.log('[2/4] applying mutation ...');
-  writeFileSync(absFile, mutate(original, opts));
+  console.log('[2/5] writing backup and applying mutation ...');
+  // On disk before the file is touched, so an untrappable death is recoverable.
+  writeFileSync(backupPath, original);
+  writeFileSync(absFile, mutated);
+  console.log(`      ${sites} site(s) mutated; backup at ${relative(repoRoot, backupPath)}\n`);
 
-  // 4. THE step that makes this trustworthy. A mutation that matched nothing
-  //    leaves the file untouched, and every later result would be a lie.
-  const landed = git(['diff', '--quiet', '--', relFile], { cwd: repoRoot }).status !== 0;
-  if (!landed) {
-    restore();
-    fail(
-      'The mutation did not change the file — nothing matched.\n' +
-      'This is the silent no-op that makes a negative test pass vacuously.\n' +
-      'Check the literal string; it is matched exactly, not as a regex.'
-    );
+  console.log('[3/5] checking the mutant still parses ...');
+  if (!parses(absFile, mutated, repoRoot)) {
+    verdict = 'invalid';
+    console.log('      it does NOT parse.\n');
+  } else {
+    console.log('      it parses.\n');
+
+    console.log('[4/5] running tests against the mutant (expect red) ...');
+    const mutant = runCommand(opts.test);
+    const problem = inconclusiveReason(mutant);
+    if (problem) {
+      verdict = 'inconclusive';
+      console.log(`      inconclusive — ${problem}\n`);
+    } else {
+      failCount = parseFailCount(mutant.output);
+      verdict = mutant.status !== 0 ? 'killed' : 'survived';
+      console.log(`      exit ${mutant.status}${failCount !== null ? `, ${failCount} failing` : ''}\n`);
+    }
   }
-  const stat = git(['diff', '--stat', '--', relFile], { cwd: repoRoot }).stdout.trim();
-  console.log(`      landed: ${stat}\n`);
-
-  // 5. Re-run.
-  console.log('[3/4] running tests against the mutant (expect red) ...');
-  const mutant = runTest(opts.test);
-  killed = mutant.status !== 0;
-  failCount = parseFailCount(mutant.stdout + mutant.stderr);
-  console.log(`      exit ${mutant.status}${failCount !== null ? `, ${failCount} failing` : ''}\n`);
 } finally {
-  // 6. Restore, and verify.
-  console.log('[4/4] restoring ...');
+  console.log('[5/5] restoring ...');
   restore();
   console.log('      restored.\n');
 }
 
 // ── verdict ──────────────────────────────────────────────────────
 
-if (!killed) {
+if (verdict === 'invalid') {
+  console.error('INVALID MUTANT — the mutated file does not parse.');
+  console.error('  Any red result would mean "this file is broken", not "a test covers this line".');
+  console.error('  Reporting that as a kill is the false confidence this tool exists to prevent.');
+  console.error('  Mutate something that leaves valid syntax — a value, not a delimiter.');
+  process.exit(1);
+}
+
+if (verdict === 'inconclusive') {
+  console.error('INCONCLUSIVE — the mutant run produced no usable verdict (see above).');
+  process.exit(1);
+}
+
+if (verdict === 'survived') {
   console.error('MUTANT SURVIVED — this line is not covered.');
-  console.error(`  Removing it from ${relFile} did not fail "${opts.test}".`);
+  console.error(`  Mutating it in ${relFile} did not fail "${opts.test}".`);
   console.error('  Whatever you verified by hand, no test would catch this regressing.');
   process.exit(1);
 }
 
-if (opts.expectKilledBy !== undefined && failCount !== null && failCount !== opts.expectKilledBy) {
-  console.error(`MUTANT KILLED, but by ${failCount} tests, not the expected ${opts.expectKilledBy}.`);
-  console.error('  More than expected can mean collateral coupling; fewer can mean thinner');
-  console.error('  coverage than you think. Both are worth understanding before trusting it.');
-  process.exit(1);
+if (opts.expectKilledBy !== undefined) {
+  if (failCount === null) {
+    console.error('MUTANT KILLED, but --expect-killed-by cannot be checked:');
+    console.error('  the failing-test count could not be parsed from the output.');
+    console.error('  Silently accepting that would make the flag decorative.');
+    process.exit(1);
+  }
+  if (failCount !== opts.expectKilledBy) {
+    console.error(`MUTANT KILLED, but by ${failCount} tests, not the expected ${opts.expectKilledBy}.`);
+    console.error('  More than expected can mean collateral coupling; fewer can mean thinner');
+    console.error('  coverage than you think. Both are worth understanding before trusting it.');
+    process.exit(1);
+  }
 }
 
 console.log(`MUTANT KILLED${failCount !== null ? ` by ${failCount} failing test(s)` : ''} — the check can fail.`);

--- a/scripts/mutation-check.js
+++ b/scripts/mutation-check.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * mutation-check.js — prove that a check is capable of failing.
+ *
+ * A gate that reports healthy is evidence about the *gate*, not the subject. The
+ * only way to know a test covers a line is to remove that line and watch the test
+ * go red. This automates that envelope safely:
+ *
+ *   1. refuse to run if the target file has uncommitted changes (restore is
+ *      `git checkout --`, which would destroy them)
+ *   2. run the test command first and require GREEN — a mutation tells you nothing
+ *      about an already-red suite
+ *   3. apply the mutation
+ *   4. VERIFY THE MUTATION LANDED via `git diff`. This is the step that matters:
+ *      a substitution that silently matched nothing makes the whole exercise pass
+ *      vacuously while looking correct
+ *   5. re-run the tests and record the real exit code
+ *   6. restore, and verify the restore actually happened
+ *
+ * The mutant is "killed" if the suite goes red. A SURVIVING mutant means the line
+ * is not covered, however convincingly the behaviour was demonstrated by hand.
+ *
+ *   node scripts/mutation-check.js \
+ *     --file cli/index.js \
+ *     --delete-matching 'process.exitCode = auditExitCode' \
+ *     --test 'npm run test:cli'
+ *
+ *   node scripts/mutation-check.js \
+ *     --file cli/lib/installer.js \
+ *     --replace 'crashed: true'::'crashed: false' \
+ *     --test 'npm run test:cli'
+ *
+ * Exit 0 = mutant killed (the check works). Exit 1 = mutant survived (gap found),
+ * or the run could not be completed safely.
+ *
+ * Written in Node rather than shell deliberately: in-place `sed` silently no-ops on
+ * this repo's NTFS mount, and bare `grep` resolves to ugrep locally but GNU grep in
+ * CI — the two failure modes this tool exists to catch.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+
+const USAGE = `Usage:
+  node scripts/mutation-check.js --file <path> --test <cmd> (--delete-matching <str> | --replace <old>::<new>)
+
+Options:
+  --file <path>             File to mutate (must be tracked and unmodified)
+  --test <cmd>              Command whose red/green tells you if the mutant died
+  --delete-matching <str>   Delete every line containing this literal substring
+  --replace <old>::<new>    Replace literal <old> with <new> (first occurrence)
+  --expect-killed-by <n>    Require exactly n failing tests (parsed from node:test output)
+  --skip-baseline           Skip the pre-flight green run (faster, less safe)
+  -h, --help                Show this message`;
+
+// ── args ─────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const opts = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '-h' || arg === '--help') opts.help = true;
+    else if (arg === '--skip-baseline') opts.skipBaseline = true;
+    else if (arg === '--file') opts.file = argv[++i];
+    else if (arg === '--test') opts.test = argv[++i];
+    else if (arg === '--delete-matching') opts.deleteMatching = argv[++i];
+    else if (arg === '--replace') opts.replace = argv[++i];
+    else if (arg === '--expect-killed-by') opts.expectKilledBy = Number(argv[++i]);
+    else fail(`Unknown argument: ${arg}\n\n${USAGE}`);
+  }
+  return opts;
+}
+
+function fail(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(1);
+}
+
+function git(args, opts = {}) {
+  return spawnSync('git', args, { encoding: 'utf8', ...opts });
+}
+
+/** Run a shell command, returning its REAL exit code. Never piped — a pipe would
+ *  report the last stage's status and silently invert the result. */
+function runTest(cmd) {
+  const res = spawnSync(cmd, { shell: true, encoding: 'utf8' });
+  return { status: res.status ?? 1, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+/** Pull `# fail N` out of node:test output; null if the format is not recognised. */
+function parseFailCount(output) {
+  const match = output.match(/^\s*[^\s]*\s*fail\s+(\d+)\s*$/m);
+  return match ? Number(match[1]) : null;
+}
+
+// ── mutation ─────────────────────────────────────────────────────
+
+function mutate(original, opts) {
+  if (opts.deleteMatching !== undefined) {
+    const kept = original.split('\n').filter((line) => !line.includes(opts.deleteMatching));
+    return kept.join('\n');
+  }
+  const sep = opts.replace.indexOf('::');
+  if (sep === -1) fail('--replace needs the form <old>::<new>');
+  const from = opts.replace.slice(0, sep);
+  const to = opts.replace.slice(sep + 2);
+  if (!original.includes(from)) return original; // step 4 will catch it
+  return original.replace(from, to);
+}
+
+// ── main ─────────────────────────────────────────────────────────
+
+const opts = parseArgs(process.argv.slice(2));
+
+if (opts.help) {
+  console.log(USAGE);
+  process.exit(0);
+}
+if (!opts.file || !opts.test) fail(`--file and --test are both required\n\n${USAGE}`);
+if (opts.deleteMatching === undefined && opts.replace === undefined) {
+  fail(`One of --delete-matching or --replace is required\n\n${USAGE}`);
+}
+if (opts.deleteMatching !== undefined && opts.replace !== undefined) {
+  fail('--delete-matching and --replace are mutually exclusive');
+}
+
+const repoRoot = git(['rev-parse', '--show-toplevel']).stdout?.trim();
+if (!repoRoot) fail('Not inside a git repository.');
+
+const absFile = resolve(process.cwd(), opts.file);
+const relFile = relative(repoRoot, absFile);
+
+// 1. Precondition. Restore is `git checkout --`, which discards working-tree
+//    changes, so refuse outright rather than risk destroying uncommitted work.
+const tracked = git(['ls-files', '--error-unmatch', '--', relFile], { cwd: repoRoot });
+if (tracked.status !== 0) fail(`${relFile} is not tracked by git — cannot restore it safely.`);
+
+const dirty = git(['status', '--porcelain', '--', relFile], { cwd: repoRoot }).stdout.trim();
+if (dirty) {
+  fail(
+    `${relFile} has uncommitted changes:\n  ${dirty}\n` +
+    'Commit or stash them first — this tool restores with `git checkout --`, which would discard them.'
+  );
+}
+
+console.log(`\nmutation-check: ${relFile}`);
+console.log(`  mutation: ${opts.deleteMatching !== undefined
+  ? `delete lines containing "${opts.deleteMatching}"`
+  : `replace "${opts.replace.split('::')[0]}"`}`);
+console.log(`  test:     ${opts.test}\n`);
+
+// 2. Baseline. A mutation on an already-red suite proves nothing.
+if (!opts.skipBaseline) {
+  console.log('[1/4] baseline (expect green) ...');
+  const base = runTest(opts.test);
+  if (base.status !== 0) {
+    fail(
+      `Baseline is already failing (exit ${base.status}). Fix that first — a surviving\n` +
+      'or killed mutant is meaningless when the suite is red to begin with.'
+    );
+  }
+  console.log('      green.\n');
+} else {
+  console.log('[1/4] baseline skipped (--skip-baseline)\n');
+}
+
+const original = readFileSync(absFile, 'utf8');
+let restored = false;
+
+function restore() {
+  if (restored) return;
+  restored = true;
+  writeFileSync(absFile, original);
+  const res = git(['checkout', '--', relFile], { cwd: repoRoot });
+  const stillDirty = git(['status', '--porcelain', '--', relFile], { cwd: repoRoot }).stdout.trim();
+  if (res.status !== 0 || stillDirty) {
+    console.error(`\nERROR: ${relFile} may not be restored. Check it manually:\n  git status -- ${relFile}`);
+  }
+}
+
+// Restore even if interrupted — a half-mutated tree is worse than no result.
+process.on('SIGINT', () => { restore(); process.exit(130); });
+process.on('SIGTERM', () => { restore(); process.exit(143); });
+
+let killed = false;
+let failCount = null;
+
+try {
+  // 3. Apply.
+  console.log('[2/4] applying mutation ...');
+  writeFileSync(absFile, mutate(original, opts));
+
+  // 4. THE step that makes this trustworthy. A mutation that matched nothing
+  //    leaves the file untouched, and every later result would be a lie.
+  const landed = git(['diff', '--quiet', '--', relFile], { cwd: repoRoot }).status !== 0;
+  if (!landed) {
+    restore();
+    fail(
+      'The mutation did not change the file — nothing matched.\n' +
+      'This is the silent no-op that makes a negative test pass vacuously.\n' +
+      'Check the literal string; it is matched exactly, not as a regex.'
+    );
+  }
+  const stat = git(['diff', '--stat', '--', relFile], { cwd: repoRoot }).stdout.trim();
+  console.log(`      landed: ${stat}\n`);
+
+  // 5. Re-run.
+  console.log('[3/4] running tests against the mutant (expect red) ...');
+  const mutant = runTest(opts.test);
+  killed = mutant.status !== 0;
+  failCount = parseFailCount(mutant.stdout + mutant.stderr);
+  console.log(`      exit ${mutant.status}${failCount !== null ? `, ${failCount} failing` : ''}\n`);
+} finally {
+  // 6. Restore, and verify.
+  console.log('[4/4] restoring ...');
+  restore();
+  console.log('      restored.\n');
+}
+
+// ── verdict ──────────────────────────────────────────────────────
+
+if (!killed) {
+  console.error('MUTANT SURVIVED — this line is not covered.');
+  console.error(`  Removing it from ${relFile} did not fail "${opts.test}".`);
+  console.error('  Whatever you verified by hand, no test would catch this regressing.');
+  process.exit(1);
+}
+
+if (opts.expectKilledBy !== undefined && failCount !== null && failCount !== opts.expectKilledBy) {
+  console.error(`MUTANT KILLED, but by ${failCount} tests, not the expected ${opts.expectKilledBy}.`);
+  console.error('  More than expected can mean collateral coupling; fewer can mean thinner');
+  console.error('  coverage than you think. Both are worth understanding before trusting it.');
+  process.exit(1);
+}
+
+console.log(`MUTANT KILLED${failCount !== null ? ` by ${failCount} failing test(s)` : ''} — the check can fail.`);
+console.log('Quote this in the commit message: same mutation, gate red; restored, gate green.');


### PR DESCRIPTION
Two commits from a maintenance pass: extract the session's repeated procedure into a tool, and fix the version/doc drift it exposed.

Closes #456.

## 1. `scripts/mutation-check.js` (`6ff9a960`)

The repo's most load-bearing discipline — *a green gate is evidence about the gate, not the subject* — has been applied by hand every time, and it is easy to get wrong while believing you are doing it.

In #458 the audit exit code was verified end to end manually (dangling symlink → exit 3, valid links → exit 0) and written up in the commit, yet deleting `process.exitCode = auditExitCode(results)` still left all 101 tests passing. The manual evidence *felt* like the negative test had been done. Adversarial review caught it; self-review did not — in a PR whose subject was gates that cannot fail.

The tool runs the envelope:

1. refuse to run if the target has uncommitted changes (restore is `git checkout --`, which would discard them)
2. require a green baseline — a mutation against a red suite proves nothing
3. apply the mutation
4. **verify via `git diff` that it actually landed**
5. re-run, recording the real exit code, never through a pipe
6. restore, and verify the restore happened

Step 4 is what makes the rest trustworthy. A substitution that matched nothing leaves the file untouched and turns every later result into a lie — the failure the #442 session hit, where a no-op made a negative test pass against an unmodified file.

Node rather than shell, deliberately: in-place `sed`/`perl -0pi` silently no-op on the NTFS mount, and bare `grep` resolves to ugrep locally but GNU grep in CI. Both are failure modes the tool exists to catch, so it depends on neither.

**Dogfooded on the case that motivated it:**

```
$ npm run mutation-check -- --file cli/index.js \
    --delete-matching 'process.exitCode = auditExitCode' \
    --test 'npm run test:cli' --expect-killed-by 2
[2/4] applying mutation ...
      landed: cli/index.js | 1 -
[3/4] running tests against the mutant (expect red) ...
      exit 1, 2 failing
MUTANT KILLED by 2 failing test(s) — the check can fail.
```

Guards verified too: an untracked file is refused, and a non-matching pattern aborts with *"the mutation did not change the file"* rather than reporting a result. Working tree left clean in both cases.

## 2. Version and Node-floor drift (`99a86089`)

`--version` was hardcoded and had drifted **three** ways: the binary printed `0.1.0`, `cli/README.md` advertised `1.1.0`, and the published package is `1.3.0`. Every user running `--version` — including anyone answering "what version are you on?" in a bug report — got a wrong answer, on every release since `0.1.0`.

Now reads `pkg.version` from the manifest, so it cannot drift again.

The test is why this survived. It asserted `/\d+\.\d+\.\d+/`, which `0.1.0` satisfies — a check that ran on every release and was structurally unable to detect the defect it appeared to cover. It now compares against `package.json`, re-reading the manifest rather than importing the same module the CLI does, so if the version wiring breaks the test still knows the truth.

**Verified with the tool from commit 1** — reverting `pkg.version` to `'0.1.0'`:

```
MUTANT KILLED by 1 failing test(s) — the check can fail.
```

The old assertion would have stayed green under that same mutation.

Also corrects `cli/README.md`'s "Requires Node.js 18+" to 22.12, matching `engines`. `engines` is advisory — npm warns rather than blocks — so the README was steering users into an unsupported runtime rather than being caught at install time. The hardcoded example output under `--version` is removed rather than updated, since restating the version in prose is exactly what drifted.

## Verification

103/103, unchanged in count: the version test was strengthened in place, not added.

## Related

Skill proposal for the procedure this automates: #460. Also filed this pass: #459 (nothing consumes the new audit exit code yet), and #453 broadened with observed evidence.

Not filed, because the premise did not survive checking: the standing note that `validate-integrity.yml` lacking a `cli/**` trigger is a gap. After B11's removal, `scripts/validate-integrity.sh` no longer reads `cli/` at all, and the comment at `:528-533` states that audit coverage lives in `ci-node-cli.yml` by design. The note is stale, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUt4LTGxoyUXPfe7BjRpJ
