### PR TITLE
ci(viz): trigger Pages on SKILL.md bodies, drop the unread guides path (#451, #452)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,10 +5,20 @@ on:
     branches: [main]
     paths:
       - 'viz/**'
+      # build-data.js opens every skills/<id>/SKILL.md and derives the node title,
+      # metadata.tags, and the entire skill-to-skill link set, so editing a
+      # `## Related Skills` section changes the published graph (#451). Scoped to
+      # */SKILL.md rather than 'skills/**' because references/ and examples/ are
+      # never opened; _template is excluded for the same reason, since the read
+      # loop iterates the registry and _template has no entry there.
       - 'skills/_registry.yml'
+      - 'skills/*/SKILL.md'
+      - '!skills/_template/SKILL.md'
       - 'agents/_registry.yml'
       - 'teams/_registry.yml'
-      - 'guides/_registry.yml'
+      # guides/_registry.yml is deliberately absent -- no deploy step reads it
+      # (#452). agents/*.md and teams/*.md likewise: build-data.js reads only
+      # their registries, never their bodies.
       - 'i18n/**'
       - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ CI auto-commits README updates when registry files change on `main` (`.github/wo
 
 ## Viz Deploy Model
 
-The visualization deploys to GitHub Pages from `.github/workflows/deploy-pages.yml`, which regenerates `viz/public/data/skills.json` before `vite build`. A registry change therefore reaches the page only through `build-data.js`, which reads three registries — `skills`, `agents`, `teams`. The workflow also triggers on `guides/_registry.yml`, which nothing in the graph consumes; a guides-only change redeploys identical output.
+The visualization deploys to GitHub Pages from `.github/workflows/deploy-pages.yml`, which regenerates `viz/public/data/skills.json` before `vite build`. A registry change therefore reaches the page only through `build-data.js`, which reads three registries — `skills`, `agents`, `teams` — and every `skills/<id>/SKILL.md` body, from which it derives the node title, `metadata.tags`, and the entire skill-to-skill link set. The trigger paths therefore include `skills/*/SKILL.md` (#451). They deliberately exclude `guides/_registry.yml`, which no deploy step reads (#452), `skills/_template/SKILL.md`, which has no registry entry, and `agents/*.md` / `teams/*.md`, whose bodies `build-data.js` never opens.
 
 The site makes three kinds of runtime fetch, and only the first is CI-derived:
 


### PR DESCRIPTION
Closes #451, closes #452.

Two trigger-path defects in `.github/workflows/deploy-pages.yml`, opposite in sign, fixed in one edit.

## #451 — under-triggering (the one that ships wrong data)

`viz/build-data.js` opens every `skills/<id>/SKILL.md` and derives three things that land in the published graph:

| Derived | Site | Stale symptom |
| --- | --- | --- |
| node title (first `#` heading) | `build-data.js:124-129` | node shows its old label |
| `metadata.tags` | `:133-143` | tag filters use stale tags |
| **the whole skill→skill link set** from `## Related Skills` | `:149-196`, pushed as links at `:193-195` | **the graph's edge set is wrong** |

None of that was in the trigger paths. Editing a Related-Skills section changed what the site should show, and no deploy fired — the published graph kept the old edges until an unrelated push happened to redeploy.

This is #363 inverted: not a generated artifact going stale in-tree, but a *source* file whose edits never reached the build. It fires on ordinary maintenance — cross-referencing skills is step 5 of "Adding a New Skill" and touches no registry.

## #452 — over-triggering

The block also triggered a full Pages deploy on `guides/_registry.yml`, which no deploy step reads. `build-data.js` has no `GUIDES_DIR` and no `guides` string; guides are not scanned even inside the i18n tree. Its real consumers — `generate-readmes.js:35`, `generate-translation-status.js:40`, `cli/lib/registry.js:26` — all live outside this workflow.

## Scoping

`skills/*/SKILL.md`, not `skills/**`. The wider glob would match `references/`, `examples/`, and `skills/README.md` — none of which the build opens, and the last of which `update-readmes.yml` auto-commits.

`!skills/_template/SKILL.md` excludes the one SKILL.md with no registry entry (370 on disk, 369 in the registry). The read loop iterates the registry, so the template is never opened; including it would be a fresh instance of exactly the waste #452 removes. Negation idiom matches `update-readmes.yml:23-27`.

## Verification, and its honest limit

**GitHub evaluates `paths` server-side, and only for pushes to `main`.** This workflow has no `pull_request` block to borrow, and `workflow_dispatch` ignores `paths` entirely. So the real filter *cannot* run before merge. Stating that plainly rather than implying CI green means the trigger works.

What was checked locally:

- the YAML parses, and the negation is ordered after the positive it narrows (order is significant)
- all 369 registry `path:` values are `<id>/SKILL.md`, and every SKILL.md on disk sits at exactly one directory level — so the glob cannot under-reach
- a picomatch approximation over ten cases, **including both controls**:

```
  ok   true  skills/meditate/SKILL.md              #451, the scenario in the issue
  ok   true  skills/_registry.yml                  control: registry still fires
  ok   false guides/_registry.yml                  #452 removed
  ok   false skills/_template/SKILL.md             template excluded
  ok   false skills/*/references/EXAMPLES.md       references never opened
  ok   false skills/README.md                      auto-committed README must not re-trigger
  ok   false agents/code-reviewer.md               agent bodies never opened
  ok   true  agents/_registry.yml                  agent registry still fires
  ok   true  viz/js/app.js                         control: viz still fires
  ok   false README.md                             control: unrelated file declines
```

The two controls are what make this non-vacuous: without `viz/js/app.js` the matcher could be dead and every `false` would read as green; without `README.md` it could match everything and every `true` would read as green.

picomatch is **not** GitHub's engine. This narrows the risk; it does not eliminate it.

## Optional: a real pre-merge probe

The only way to exercise GitHub's actual engine before merge is a throwaway branch carrying a byte-identical `paths:` block with `branches: [probe/...]`, then one single-file push per case — `paths` is evaluated against a whole push's diff, so batching destroys the discrimination. Five pushes, then delete the branch and paste the SHA→run table here.

Not done unilaterally: it is five pushes and a temporary workflow on your repo. Say the word and I'll run it before merge.

## Post-merge check (unavoidable either way)

The merge commit touches `deploy-pages.yml`, which is itself in the path list, so a deploy fires on merge regardless — that run proves nothing about the filter. The real confirmation is the *next* SKILL.md-only change: it should produce a deploy, and the next guides-only change should not.

## Follow-ups identified, not folded in

- `i18n/**` over-triggers the same way (`build-data.js` reads `i18n/_config.yml` by content and the per-locale trees by *existence* only). Tightening it carries the under-trigger risk this PR exists to remove, so it wants its own probe.
- `update-readmes.yml:65` auto-commits `viz/README.md` and ten `translation_status.yml` files over a deploy key, and its own comment notes that such a push *does* re-trigger workflows — so most content changes to main already buy a second no-op Pages deploy. Strictly larger than #452.
- Nothing gates the correspondence between `build-data.js`'s input set and this `paths:` block, so this fixes today's drift, not the drift class.

I'll file those three unless you'd rather they were folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUt4LTGxoyUXPfe7BjRpJ
