### PR TITLE
fix(cli): repair the chalk fallback, state the universal rule honestly (#455, #457)

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -302,12 +302,13 @@ Examples:
     // clean bill of health (#439).
     //
     // This is currently unreachable, and deliberately kept anyway. The universal
-    // rule at cli/lib/detector.js:20 is `existsSync(...) || true`, which is
-    // always true, so detection never returns an empty list and --framework
-    // always yields exactly one adapter. Should that `|| true` be corrected,
-    // this branch starts mattering immediately; it is three lines to keep and a
-    // silent false-clean to omit. Tracked in #457 — do not read the presence of
-    // this guard as evidence that the empty case has been observed.
+    // rule in cli/lib/detector.js is `check: () => true` — a deliberate constant
+    // (#457), since `.agents/` is the cross-client fallback target — so detection
+    // never returns an empty list, and --framework always yields exactly one
+    // adapter. If universal ever becomes conditional, this branch starts
+    // mattering immediately; it is three lines to keep and a silent false-clean
+    // to omit. Do not read the presence of this guard as evidence that the empty
+    // case has been observed.
     if (results.length === 0) {
       reporter.warn('No frameworks detected — nothing was audited.');
     }

--- a/cli/lib/chalk-stub.js
+++ b/cli/lib/chalk-stub.js
@@ -1,0 +1,69 @@
+/**
+ * chalk-stub.js — the no-colour fallback used when `import('chalk')` fails.
+ *
+ * Both chalk import sites (reporter.js, tui.js) previously built their own
+ * fallback as `new Proxy({}, { get: () => identity })`. That satisfies the direct
+ * styles and breaks the factories: `chalk.hex('#FF6B35')` returned the *string*
+ * `'#FF6B35'`, and calling it threw `TypeError: ... is not a function`. So the
+ * "graceful degradation" path did not degrade — it crashed, and did so at module
+ * load, because every palette here is built from `chalk.hex(...)` at import time
+ * (campfire-reporter.js, tui.js, pixel-renderer.js). Filed as #455.
+ *
+ * Shared rather than duplicated: the identical bug existed twice, and a fix
+ * applied to one copy would have left the other broken.
+ */
+
+/**
+ * chalk members that return a *function* rather than a styled string.
+ *
+ * Enumerated empirically against the pinned chalk 6.0.0 rather than from memory —
+ * chalk 6 added the three `underline*` variants, and a list that omits them
+ * reintroduces the exact bug for those names. Regenerate with:
+ *
+ *   node -e "import('chalk').then(m=>{const c=m.default;for(const n of
+ *     Object.getOwnPropertyNames(Object.getPrototypeOf(c)))
+ *     {try{if(typeof c[n]('#fff')==='function')console.log(n)}catch{}}})"
+ */
+const CHALK_FACTORIES = new Set([
+  'ansi256',
+  'bgAnsi256',
+  'bgHex',
+  'bgRgb',
+  'hex',
+  'rgb',
+  'underlineAnsi256',
+  'underlineHex',
+  'underlineRgb',
+]);
+
+/**
+ * A chalk-shaped object that applies no colour.
+ *
+ * Supports the three call shapes the CLI uses:
+ *   chalk.dim('x')            -> 'x'
+ *   chalk.hex('#FF6B35')('x') -> 'x'
+ *   chalk.bold.cyan('x')      -> 'x'
+ *
+ * @returns {any} a callable, chainable stub
+ */
+export function makeChalkStub() {
+  const identity = (text) => text;
+  return new Proxy(identity, {
+    get(target, prop) {
+      // Must not be a thenable. A stub that answers every property with a
+      // function makes `await chalk` (or any Promise.resolve(chalk)) hang
+      // forever, because the runtime calls .then and waits for a callback that
+      // is never invoked.
+      if (prop === 'then') return undefined;
+      // pixel-renderer.js reads chalk.level and gates on `>= 1`. A stub means no
+      // colour support, so 0 is the truthful answer and keeps that gate closed.
+      if (prop === 'level') return 0;
+      // Symbols (Symbol.toPrimitive, util.inspect.custom, ...) should behave as
+      // they would on a plain function, not become more stubs.
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      // A factory must yield a function; a direct style must yield the string.
+      if (CHALK_FACTORIES.has(prop)) return () => makeChalkStub();
+      return makeChalkStub();
+    },
+  });
+}

--- a/cli/lib/detector.js
+++ b/cli/lib/detector.js
@@ -16,8 +16,13 @@ import { homedir } from 'os';
  * Each rule specifies a marker path (relative to project or home) and metadata.
  */
 const RULES = [
-  // Universal (always check project-level)
-  { id: 'universal', displayName: 'Universal (.agents/)', check: (dir) => existsSync(resolve(dir, '.agents')) || true, marker: '.agents/', scope: 'project' },
+  // Universal is the cross-client fallback: `.agents/skills/` is the de facto
+  // interoperability path, so it is always an eligible target whether or not the
+  // directory exists yet. This was written as `existsSync(...) || true`, which is
+  // unconditionally true — the existsSync was dead, and the expression read as a
+  // debugging leftover rather than a decision (#457). Stated as a constant now,
+  // matching UniversalAdapter.detect(), which already returns true outright.
+  { id: 'universal', displayName: 'Universal (.agents/)', check: () => true, marker: '.agents/', scope: 'project' },
   // Claude Code
   { id: 'claude-code', displayName: 'Claude Code', check: (dir) => existsSync(resolve(dir, '.claude')), marker: '.claude/', scope: 'project' },
   // OpenCode

--- a/cli/lib/reporter.js
+++ b/cli/lib/reporter.js
@@ -5,13 +5,14 @@
  * Uses chalk for colors when available, falls back to plain text.
  */
 
+import { makeChalkStub } from './chalk-stub.js';
+
 let chalk;
 try {
   chalk = (await import('chalk')).default;
 } catch {
-  // Fallback: no colors
-  const identity = (s) => s;
-  chalk = new Proxy({}, { get: () => identity });
+  // Fallback: no colors (#455)
+  chalk = makeChalkStub();
 }
 
 /**

--- a/cli/lib/tui.js
+++ b/cli/lib/tui.js
@@ -9,13 +9,14 @@ import { loadRegistries } from './registry.js';
 import { detectAlmanacRoot } from './resolver.js';
 import { loadState, saveState, recordWarm, recordGather, recordScatter, markWelcomed, computeFireState, findHearthKeepers } from './state.js';
 import { buildFireScene } from './scene.js';
+import { makeChalkStub } from './chalk-stub.js';
 
 let chalk;
 try {
   chalk = (await import('chalk')).default;
 } catch {
-  const id = (s) => s;
-  chalk = new Proxy({}, { get: () => id });
+  // Fallback: no colors (#455)
+  chalk = makeChalkStub();
 }
 
 // ── Color palette ──────────────────────────────────────────────────

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -28,6 +28,8 @@ import {
   createAgentGlyph, getAgentPng, getTeamStrip, getCampfirePng, getCampfireFrames, GLYPH_SIZE,
 } from '../lib/sprites.js';
 import { auditAll, auditExitCode, AUDIT_EXIT } from '../lib/installer.js';
+import { makeChalkStub } from '../lib/chalk-stub.js';
+import { detectFrameworks } from '../lib/detector.js';
 import { buildFireScene } from '../lib/scene.js';
 import { canInlineImage, renderInlineImage } from '../lib/inline-image.js';
 
@@ -383,6 +385,99 @@ describe('auditExitCode (#439)', () => {
       [entry({ crashed: true }), entry({ errors: ['e'] })],
     ];
     for (const shape of shapes) assert.notEqual(auditExitCode(shape), 1);
+  });
+});
+
+// ── chalk fallback (#455) ────────────────────────────────────────
+//
+// The old fallback was `new Proxy({}, { get: () => identity })`, which satisfies
+// the direct styles and breaks the factories: chalk.hex('#FF6B35') returned the
+// STRING '#FF6B35', and calling it threw. Because every palette here is built
+// from chalk.hex(...) at module load (campfire-reporter.js, tui.js,
+// pixel-renderer.js), a chalk that failed to import took the CLI down at import
+// time rather than degrading to plain text.
+//
+// These assert the three call shapes the CLI actually uses, plus the two traps
+// that make a naive stub wrong.
+
+describe('chalk fallback stub (#455)', () => {
+  const chalk = makeChalkStub();
+
+  it('passes text through a direct style', () => {
+    assert.equal(chalk.dim('x'), 'x');
+    assert.equal(chalk.red('x'), 'x');
+  });
+
+  it('returns a callable from a factory, not a string', () => {
+    // The exact defect: this used to be the string '#FF6B35'.
+    assert.equal(typeof chalk.hex('#FF6B35'), 'function');
+    assert.equal(chalk.hex('#FF6B35')('flame'), 'flame');
+    assert.equal(chalk.bgHex('#FFB347')('bg'), 'bg');
+    assert.equal(chalk.rgb(1, 2, 3)('x'), 'x');
+  });
+
+  it('covers the underline* factories chalk 6 added', () => {
+    // A factory list written from memory omits these, which reintroduces the
+    // bug for exactly these names.
+    assert.equal(chalk.underlineHex('#fff')('x'), 'x');
+    assert.equal(chalk.underlineRgb(1, 2, 3)('x'), 'x');
+    assert.equal(chalk.underlineAnsi256(42)('x'), 'x');
+  });
+
+  it('chains', () => {
+    assert.equal(chalk.bold.cyan('x'), 'x');
+    assert.equal(chalk.bold.underline.red('x'), 'x');
+  });
+
+  it('reports level 0 so the pixel-art gate stays closed', () => {
+    // pixel-renderer.js gates canRenderPixelArt() on `level >= 1`. A stub means
+    // no colour support, so 0 is the truthful answer.
+    assert.equal(chalk.level, 0);
+    assert.equal(chalk.level >= 1, false);
+  });
+
+  it('is not a thenable', async () => {
+    // A stub that answers every property with a function makes `await chalk`
+    // hang forever: the runtime calls .then and waits for a callback that is
+    // never invoked. Guard with a race so a regression fails instead of hanging
+    // the whole suite.
+    const settled = await Promise.race([
+      Promise.resolve(chalk).then(() => 'settled'),
+      new Promise((r) => setTimeout(() => r('HUNG'), 500)),
+    ]);
+    assert.equal(settled, 'settled');
+  });
+});
+
+// ── universal detection is a deliberate constant (#457) ──────────
+
+describe('universal framework detection (#457)', () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = mkdtempSync(resolve(tmpdir(), 'almanac-detect-'));
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects universal in a directory with no .agents/', () => {
+    // `.agents/skills/` is the cross-client interoperability path, so universal
+    // is always an eligible install target. The rule used to express this as
+    // `existsSync(...) || true`, which is unconditionally true — the existsSync
+    // was dead code that read like a condition (#457).
+    assert.equal(existsSync(resolve(tmpDir, '.agents')), false, 'fixture must have no .agents/');
+    const ids = detectFrameworks(tmpDir).map((d) => d.id);
+    assert.ok(ids.includes('universal'), 'universal should always be detected');
+  });
+
+  it('does not detect a framework whose marker is absent', () => {
+    // The control. Without this, a detector that returned every rule would
+    // satisfy the assertion above while being completely broken.
+    const ids = detectFrameworks(tmpDir).map((d) => d.id);
+    assert.ok(!ids.includes('claude-code'), 'claude-code has no .claude/ here');
+    assert.ok(!ids.includes('cursor'), 'cursor has no .cursor/ here');
   });
 });
 


### PR DESCRIPTION
Closes #455, closes #457.

Two defects in the same area, both of which read as working code.

## #455 — the no-colour fallback crashed instead of dropping colour

`reporter.js` and `tui.js` each built `new Proxy({}, { get: () => identity })`. That satisfies the direct styles and breaks the factories:

```
chalk.dim('x')            -> 'x'          ✓
chalk.hex('#FF6B35')      -> '#FF6B35'    ✗ a string
chalk.hex('#FF6B35')('f') -> TypeError
```

Every palette in this CLI is built from `chalk.hex(...)` at **module load** (`campfire-reporter.js:24-28`, `tui.js:23-27`, `pixel-renderer.js:21,26`), so a chalk that failed to import took the tool down at import time — exactly when a plain-text fallback would be most useful. With `import('chalk')` forced to throw, 16 tests fail with `C.flame is not a function`.

**Extracted to `cli/lib/chalk-stub.js` rather than fixed twice.** The identical bug existed in both files; patching one copy would have left the other broken.

**The factory list is enumerated empirically, not from memory.** chalk 6 has **nine** factories — the plan I started from listed six, missing `underlineHex`, `underlineRgb` and `underlineAnsi256`, which chalk added in the 6.0 major. A list that omits them reintroduces the bug for precisely those names. The regeneration command is in the module header.

Two traps a naive stub falls into, both covered by tests:

| Trap | Symptom | Guard |
| --- | --- | --- |
| stub is a thenable | `await chalk` hangs forever — the runtime calls `.then` and waits for a callback that never fires (reproduced: Node exits 13, `Detected unsettled top-level await`) | `then` returns `undefined`; the test races it so a regression fails instead of hanging the suite |
| `chalk.level` is a stub | truthy, so `canRenderPixelArt()`'s `level >= 1` gate opens with no colour behind it | `level` returns `0` |

## #457 — dead code that read like a condition

`check: (dir) => existsSync(resolve(dir, '.agents')) || true` is unconditionally true, so the `existsSync` never mattered.

Resolved by reading rather than guessing. The evidence says **intentional**:

- `cli/adapters/universal.js:22-24` — `async detect(projectDir) { return true; }`, unconditionally
- the rule's own comment — `// Universal (always check project-level)`
- the adapter header — `.agents/skills/` is "the de facto cross-client interoperability path"

The adapter and the detector already agreed that universal always applies; only the detector expressed it as `x || true`, which is indistinguishable from a debugging leftover. Now `check: () => true` with the reasoning. Same behaviour, no dead branch.

The unreachability comment in `index.js` (added by #439) is updated to cite the constant rather than the `|| true`.

## Verification

103 → 111 tests. Both new blocks mutation-checked with the tool from #461:

```
$ npm run mutation-check -- --file cli/lib/chalk-stub.js --replace "  'hex',"::"" --test 'npm run test:cli'
MUTANT KILLED by 1 failing test(s) — the check can fail.

$ npm run mutation-check -- --file cli/lib/detector.js \
    --replace "check: () => true"::"check: (dir) => existsSync(resolve(dir, '.agents'))" --test 'npm run test:cli'
MUTANT KILLED by 1 failing test(s) — the check can fail.
```

The second mutation is literally the old code, so that test is proven to detect the regression it exists for.

The detector block includes a **control** asserting that a framework whose marker is absent is *not* detected. Without it, a detector returning every rule would satisfy the universal assertion while being completely broken.

## Found while fixing this, filed separately

**#464** — `skills/design-cli-output/SKILL.md:58` teaches the exact broken idiom, mirrored into 10 locales. The CLI bug was not a slip; it was the repo's own documented pattern applied correctly. Not folded in here because it is 11 files and a translation decision.

Also noted, not fixed: `audit` in a project with no `.agents/` still prints `WARN No skills installed in .agents/skills/`. That is the honest output of the always-on decision — universal is eligible and empty — and silencing it would change audit semantics for every adapter with the same shape. Say if you want an issue for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZUt4LTGxoyUXPfe7BjRpJ
