### PR TITLE
fix(skills): correct the chalk no-color fallback design-cli-output teaches (#464)

### DIFF
--- a/cli/lib/chalk-stub.js
+++ b/cli/lib/chalk-stub.js
@@ -22,7 +22,13 @@
  *
  *   node -e "import('chalk').then(m=>{const c=m.default;for(const n of
  *     Object.getOwnPropertyNames(Object.getPrototypeOf(c)))
- *     {try{if(typeof c[n]('#fff')==='function')console.log(n)}catch{}}})"
+ *     {if(n==='constructor')continue;
+ *      try{if(typeof c[n]('#fff')==='function')console.log(n)}catch{}}})"
+ *
+ * The `constructor` skip is load-bearing: that property is `createChalk`, and
+ * `createChalk('#fff')` returns a function, so without the skip the probe reports
+ * a tenth name that is not a factory. Diff the output against this set; do not
+ * paste it in. Against chalk 6.0.0 the corrected probe prints exactly these nine.
  */
 const CHALK_FACTORIES = new Set([
   'ansi256',

--- a/i18n/caveman-lite/skills/design-cli-output/SKILL.md
+++ b/i18n/caveman-lite/skills/design-cli-output/SKILL.md
@@ -2,7 +2,7 @@
 name: design-cli-output
 locale: caveman-lite
 source_locale: en
-source_commit: 23c3299b
+source_commit: 2630b6e9
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-07-30"
 description: >

--- a/i18n/caveman-lite/skills/design-cli-output/SKILL.md
+++ b/i18n/caveman-lite/skills/design-cli-output/SKILL.md
@@ -316,7 +316,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 Check for:

--- a/i18n/caveman-lite/skills/design-cli-output/SKILL.md
+++ b/i18n/caveman-lite/skills/design-cli-output/SKILL.md
@@ -2,9 +2,9 @@
 name: design-cli-output
 locale: caveman-lite
 source_locale: en
-source_commit: 82c77053
+source_commit: 23c3299b
 translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-23"
+translation_date: "2026-07-30"
 description: >
   Design terminal output for a CLI tool with chalk colors, Unicode glyphs,
   multiple verbosity levels (human, verbose, quiet, JSON), and consistent
@@ -53,15 +53,56 @@ Design consistent, multi-level terminal output for a command-line tool.
 
 ### Step 1: Define the Color Palette
 
-Use chalk to create a named palette object:
+Use chalk to create a named palette object.
+
+**Load chalk behind a no-color fallback.** The fallback has to stand in for every
+call shape the palette uses, which is more than passing strings through:
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+Four invariants, each of which a shorter stub gets wrong:
+
+1. **The proxy target is callable** — `(text) => text`, not `{}`. Chaining
+   (`chalk.bold.cyan('x')`) needs every hop to be both indexable and callable.
+2. **Factories return a function.** `new Proxy({}, { get: () => (s) => s })`
+   satisfies the direct styles and breaks the factories: `chalk.hex('#FF6B35')`
+   is then the *string* `'#FF6B35'`, and calling it throws
+   `TypeError: ... is not a function`. Palettes are built at module load, so that
+   fallback takes the tool down at import time — in precisely the situation where
+   degrading to plain text was the point.
+3. **`then` is `undefined`.** A stub that answers every property with a function
+   makes `await chalk` hang forever: the runtime calls `.then` and waits for a
+   callback nobody invokes. Node reports `Detected unsettled top-level await` and
+   exits 13.
+4. **`level` is a number.** Capability gates read `chalk.level >= 1`; a truthy
+   stub opens them with no color support behind them.
+
+Build the palette from whichever object survived that import.
 
 **Standard palette** (transactional output):
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -86,14 +127,34 @@ const C = {
 ```
 
 Palette design rules:
-- Always provide a no-color fallback (the Proxy pattern above)
+- Always provide a no-color fallback, and check it against the call shapes the
+  palette uses — the warm palette above is almost entirely factories
 - Use hex colors for custom palettes (`chalk.hex('#FF6B35')`)
 - Keep the fail/error color red regardless of palette theme
 - Name palette entries by semantic role, not visual appearance
+- Share one stub across modules instead of rebuilding it at each import site,
+  or the same defect has to be found and fixed in every copy
 
-**Got:** A palette object with named entries and a no-color fallback.
+**Got:** A palette object with named entries, and a fallback that has been
+executed rather than merely written.
 
-**If fail:** If chalk is unavailable (piped output, CI), the Proxy fallback returns strings unchanged. Test with `NO_COLOR=1` environment variable.
+**If fail:** Exercise the fallback path directly; the palette is the wrong
+place to discover it is broken. With the stub in scope:
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` does not cover this. It exercises a *working* chalk that chooses
+not to emit escapes; the fallback exercises a chalk that failed to import. The
+two paths share no code. See
+[Extended Examples](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback)
+for the annotated production stub, a reproduction of the defect, and a runnable
+version of the checks above.
 
 ### Step 2: Choose Status Indicators
 
@@ -252,6 +313,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 Check for:
@@ -260,14 +325,22 @@ Check for:
 - JSON is valid (pipe to `jq .` to verify)
 - Unicode glyphs render in the target terminals
 - Column alignment holds with varying content widths
+- The no-color fallback answers every call shape the palette uses, asserted in
+  the suite rather than demonstrated once by hand
 
-**Got:** Output is correct in all five contexts.
+**Got:** Output is correct in all six contexts.
 
-**If fail:** If ANSI codes leak, ensure chalk respects `NO_COLOR`. If Unicode breaks, provide an ASCII fallback mode.
+**If fail:** If ANSI codes leak, ensure chalk respects `NO_COLOR`. If Unicode
+breaks, provide an ASCII fallback mode. A green suite says nothing about color
+either way: test runners pipe stdout, which puts `chalk.level` at 0, so colored
+and uncolored output are byte-identical and the assertions hold with color
+entirely broken. Proving color works needs `FORCE_COLOR=3` and an assertion on
+an escape sequence.
 
 ## Validation
 
-- [ ] Color palette has a no-color fallback
+- [ ] Color palette has a no-color fallback, and the fallback has been run:
+      direct style, factory, chain, `level === 0`, and `await` all checked
 - [ ] Status indicators work in both color and no-color modes
 - [ ] All four verbosity levels produce useful output
 - [ ] JSON output is valid and parseable by `jq`
@@ -277,6 +350,7 @@ Check for:
 
 ## Pitfalls
 
+- **A no-color fallback that only handles direct styles**: `new Proxy({}, { get: () => (s) => s })` reads as complete and does cover `chalk.dim` and `chalk.red`, but every factory then returns a string the caller immediately tries to call. Because palettes are built at module load, the `TypeError` lands at import time — the fallback fails hardest in the one case it exists for. Step 1 lists the four invariants a stub has to satisfy.
 - **Mixing human text with JSON**: In `--json` mode, output only valid JSON. A single stray line (like "DRY RUN") breaks JSON parsers. If the command must show both, separate them clearly or suppress the human text in JSON mode.
 - **Hardcoded column widths**: Content length varies. Use `Math.max(...items.map(i => i.id.length))` to compute padding dynamically.
 - **Color without meaning**: If color is the only way to distinguish success from failure, colorblind users and piped output lose information. Always pair color with a text indicator (`+`, `OK`, `ERR`).

--- a/i18n/caveman-lite/translation_status.yml
+++ b/i18n/caveman-lite/translation_status.yml
@@ -1,11 +1,11 @@
 locale: caveman-lite
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 352
     total: 369
     pct: 95.4
-    stale: 310
+    stale: 309
     stubs: 0
   agents:
     translated: 0
@@ -29,5 +29,5 @@ coverage:
     translated: 352
     total: 500
     pct: 70.4
-    stale: 310
+    stale: 309
     stubs: 0

--- a/i18n/caveman-ultra/skills/design-cli-output/SKILL.md
+++ b/i18n/caveman-ultra/skills/design-cli-output/SKILL.md
@@ -2,9 +2,9 @@
 name: design-cli-output
 locale: caveman-ultra
 source_locale: en
-source_commit: 82c77053
+source_commit: 23c3299b
 translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
+translation_date: "2026-07-30"
 description: >
   Design terminal output for a CLI tool with chalk colors, Unicode glyphs,
   multiple verbosity levels (human, verbose, quiet, JSON), and consistent
@@ -53,15 +53,45 @@ Consistent multi-level terminal output for CLI.
 
 ### Step 1: Color palette
 
-chalk → named palette:
+chalk → named palette.
+
+**Load chalk behind no-color fallback.** Fallback must stand in for every call shape palette uses — more than passing strings thru:
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+4 invariants, shorter stub gets each wrong:
+
+1. **Proxy target callable** — `(text) => text`, not `{}`. Chain (`chalk.bold.cyan('x')`) → every hop indexable + callable.
+2. **Factories return fn.** `new Proxy({}, { get: () => (s) => s })` OK for direct styles, breaks factories: `chalk.hex('#FF6B35')` = *string* `'#FF6B35'`, call it → `TypeError: ... is not a function`. Palettes built at module load → that fallback kills tool at import time — exactly where degrading to plain text was the point.
+3. **`then` = `undefined`.** Stub answering every prop w/ fn → `await chalk` hangs forever: runtime calls `.then`, waits for callback nobody fires. Node: `Detected unsettled top-level await`, exit 13.
+4. **`level` = number.** Capability gates read `chalk.level >= 1`; truthy stub opens them w/ no color behind.
+
+Build palette from whichever obj survived that import.
 
 **Standard** (transactional):
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -86,14 +116,25 @@ const C = {
 ```
 
 Rules:
-- No-color fallback (Proxy pattern)
+- Always no-color fallback + check it vs call shapes palette really uses — warm palette above near-all factories
 - Hex for custom (`chalk.hex('#FF6B35')`)
 - Fail/err → red regardless
 - Name by semantic role not visual
+- Share 1 stub across modules, no rebuild per import site → else same defect hunted + fixed in every copy
 
-→ Palette obj w/ named entries + no-color fallback.
+→ Palette obj w/ named entries + fallback that ran, not merely written.
 
-If err: chalk unavailable (piped, CI) → Proxy returns strings unchanged. Test `NO_COLOR=1`.
+If err: Exercise fallback path direct; palette = wrong place to find it broken. Stub in scope:
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` no cover this. It runs *working* chalk choosing no escapes; fallback runs chalk that failed import. 2 paths share no code. See [More Ex](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback) → annotated prod stub, defect repro, runnable ver of checks above.
 
 ### Step 2: Status indicators
 
@@ -250,6 +291,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 Check:
@@ -258,14 +303,15 @@ Check:
 - JSON valid (`jq .`)
 - Unicode in target terminals
 - Col align w/ varying widths
+- No-color fallback answers every call shape palette uses, asserted in suite not hand-demoed once
 
-→ Output correct in all 5 contexts.
+→ Output correct in all 6 contexts.
 
-If err: ANSI leaks → chalk respects `NO_COLOR`. Unicode breaks → ASCII fallback.
+If err: ANSI leaks → chalk respects `NO_COLOR`. Unicode breaks → ASCII fallback. Green suite says nothing about color either way: test runners pipe stdout → `chalk.level` 0 → colored + uncolored out byte-identical, assertions hold w/ color fully broken. Prove color works → `FORCE_COLOR=3` + assert on escape seq.
 
 ## Check
 
-- [ ] Palette has no-color fallback
+- [ ] Palette has no-color fallback + fallback ran: direct style, factory, chain, `level === 0`, `await` all checked
 - [ ] Status indicators work color + no-color
 - [ ] All 4 verbosity levels useful
 - [ ] JSON valid + `jq`-parseable
@@ -275,6 +321,7 @@ If err: ANSI leaks → chalk respects `NO_COLOR`. Unicode breaks → ASCII fallb
 
 ## Traps
 
+- **No-color fallback covering direct styles only**: `new Proxy({}, { get: () => (s) => s })` reads complete, does cover `chalk.dim` + `chalk.red`, but every factory then returns string caller immediately tries to call. Palettes built at module load → `TypeError` lands at import time — fallback fails hardest in the 1 case it exists for. Step 1 lists 4 invariants stub must satisfy.
 - **Mix human + JSON**: `--json` only valid JSON. Stray line ("DRY RUN") breaks parsers. Suppress human in JSON mode.
 - **Hardcoded col widths**: Varies. `Math.max(...items.map(i => i.id.length))` dyn.
 - **Color w/o meaning**: Color-only → colorblind + piped lose info. Pair w/ text (`+`, `OK`, `ERR`).

--- a/i18n/caveman-ultra/skills/design-cli-output/SKILL.md
+++ b/i18n/caveman-ultra/skills/design-cli-output/SKILL.md
@@ -2,7 +2,7 @@
 name: design-cli-output
 locale: caveman-ultra
 source_locale: en
-source_commit: 23c3299b
+source_commit: 2630b6e9
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-07-30"
 description: >

--- a/i18n/caveman-ultra/skills/design-cli-output/SKILL.md
+++ b/i18n/caveman-ultra/skills/design-cli-output/SKILL.md
@@ -294,7 +294,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 Check:

--- a/i18n/caveman-ultra/translation_status.yml
+++ b/i18n/caveman-ultra/translation_status.yml
@@ -1,11 +1,11 @@
 locale: caveman-ultra
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 352
     total: 369
     pct: 95.4
-    stale: 310
+    stale: 309
     stubs: 0
   agents:
     translated: 0
@@ -29,5 +29,5 @@ coverage:
     translated: 352
     total: 500
     pct: 70.4
-    stale: 310
+    stale: 309
     stubs: 0

--- a/i18n/caveman/skills/design-cli-output/SKILL.md
+++ b/i18n/caveman/skills/design-cli-output/SKILL.md
@@ -2,7 +2,7 @@
 name: design-cli-output
 locale: caveman
 source_locale: en
-source_commit: 23c3299b
+source_commit: 2630b6e9
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-07-30"
 description: >

--- a/i18n/caveman/skills/design-cli-output/SKILL.md
+++ b/i18n/caveman/skills/design-cli-output/SKILL.md
@@ -2,9 +2,9 @@
 name: design-cli-output
 locale: caveman
 source_locale: en
-source_commit: 82c77053
+source_commit: 23c3299b
 translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-24"
+translation_date: "2026-07-30"
 description: >
   Design terminal output for a CLI tool with chalk colors, Unicode glyphs,
   multiple verbosity levels (human, verbose, quiet, JSON), and consistent
@@ -55,13 +55,53 @@ Consistent, multi-level terminal output for a command-line tool.
 
 Use chalk. Make named palette object.
 
+**Load chalk behind no-color fallback.** Fallback must stand in for every call
+shape palette uses — more than passing strings through:
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+Four invariants. Shorter stub gets each one wrong:
+
+1. **Proxy target callable** — `(text) => text`, not `{}`. Chaining
+   (`chalk.bold.cyan('x')`) needs every hop both indexable + callable.
+2. **Factories return function.** `new Proxy({}, { get: () => (s) => s })`
+   satisfies direct styles, breaks factories: `chalk.hex('#FF6B35')` is then
+   *string* `'#FF6B35'`, and calling it throws
+   `TypeError: ... is not a function`. Palettes built at module load, so that
+   fallback takes tool down at import time — exactly where degrading to plain
+   text was point.
+3. **`then` is `undefined`.** Stub answering every property with function makes
+   `await chalk` hang forever: runtime calls `.then`, waits for callback nobody
+   invokes. Node reports `Detected unsettled top-level await`, exits 13.
+4. **`level` is number.** Capability gates read `chalk.level >= 1`; truthy stub
+   opens them with no color support behind.
+
+Build palette from whichever object survived that import.
+
 **Standard palette** (transactional output):
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -86,14 +126,33 @@ const C = {
 ```
 
 Palette rules:
-- Always provide no-color fallback (Proxy pattern above)
+- Always provide no-color fallback, and check it against call shapes palette
+  actually uses — warm palette above almost all factories
 - Use hex colors for custom palettes (`chalk.hex('#FF6B35')`)
 - Keep fail/error red no matter the theme
 - Name palette by semantic role, not visual
+- Share one stub across modules, not rebuild at each import site — else same
+  defect must be found + fixed in every copy
 
-**Got:** Palette object. Named entries. No-color fallback.
+**Got:** Palette object. Named entries. Fallback executed, not merely written.
 
-**If fail:** Chalk unavailable (piped, CI)? Proxy fallback returns strings unchanged. Test: `NO_COLOR=1` env var.
+**If fail:** Exercise fallback path directly; palette is wrong place to discover
+it broken. With stub in scope:
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` does not cover this. It exercises *working* chalk that chooses not
+to emit escapes; fallback exercises chalk that failed to import. Two paths share
+no code. See
+[Extended Examples](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback)
+for annotated production stub, reproduction of defect, runnable version of checks
+above.
 
 ### Step 2: Pick Status Indicators
 
@@ -252,6 +311,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 Check:
@@ -260,14 +323,21 @@ Check:
 - JSON valid (pipe to `jq .`)
 - Unicode glyphs render in target terminals
 - Column alignment holds with varying content widths
+- No-color fallback answers every call shape palette uses, asserted in suite,
+  not demonstrated once by hand
 
-**Got:** Output correct in all 5 contexts.
+**Got:** Output correct in all 6 contexts.
 
-**If fail:** ANSI codes leak? Ensure chalk respects `NO_COLOR`. Unicode breaks? Provide ASCII fallback mode.
+**If fail:** ANSI codes leak? Ensure chalk respects `NO_COLOR`. Unicode breaks?
+Provide ASCII fallback mode. Note green suite says nothing about color either
+way: test runners pipe stdout, which puts `chalk.level` at 0, so colored +
+uncolored output byte-identical — assertions hold with color entirely broken.
+Proving color works needs `FORCE_COLOR=3` + assertion on escape sequence.
 
 ## Checks
 
-- [ ] Color palette has no-color fallback
+- [ ] Color palette has no-color fallback, and fallback has been run: direct
+      style, factory, chain, `level === 0`, `await` all checked
 - [ ] Status indicators work in both color + no-color modes
 - [ ] All 4 verbosity levels produce useful output
 - [ ] JSON output valid, parseable by `jq`
@@ -277,6 +347,7 @@ Check:
 
 ## Pitfalls
 
+- **No-color fallback that only handles direct styles**: `new Proxy({}, { get: () => (s) => s })` reads complete and does cover `chalk.dim` + `chalk.red`, but every factory then returns string caller immediately tries to call. Palettes built at module load, so `TypeError` lands at import time — fallback fails hardest in the one case it exists for. Step 1 lists four invariants stub must satisfy.
 - **Mixing human text with JSON**: In `--json` mode, only valid JSON. One stray line ("DRY RUN") breaks JSON parsers. If must show both, separate clearly or suppress human text in JSON mode.
 - **Hardcoded column widths**: Content length varies. Use `Math.max(...items.map(i => i.id.length))` for dynamic padding.
 - **Color without meaning**: Color only way to tell success from failure? Colorblind users + piped output lose info. Always pair color with text indicator (`+`, `OK`, `ERR`).

--- a/i18n/caveman/skills/design-cli-output/SKILL.md
+++ b/i18n/caveman/skills/design-cli-output/SKILL.md
@@ -314,7 +314,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 Check:

--- a/i18n/caveman/translation_status.yml
+++ b/i18n/caveman/translation_status.yml
@@ -1,11 +1,11 @@
 locale: caveman
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 352
     total: 369
     pct: 95.4
-    stale: 310
+    stale: 309
     stubs: 0
   agents:
     translated: 0
@@ -29,5 +29,5 @@ coverage:
     translated: 352
     total: 500
     pct: 70.4
-    stale: 310
+    stale: 309
     stubs: 0

--- a/i18n/de/skills/design-cli-output/SKILL.md
+++ b/i18n/de/skills/design-cli-output/SKILL.md
@@ -25,7 +25,7 @@ metadata:
     - unicode
   locale: de
   source_locale: en
-  source_commit: 23c3299b
+  source_commit: 2630b6e9
   translator: "Claude + human review"
   translation_date: "2026-07-30"
 ---

--- a/i18n/de/skills/design-cli-output/SKILL.md
+++ b/i18n/de/skills/design-cli-output/SKILL.md
@@ -25,9 +25,9 @@ metadata:
     - unicode
   locale: de
   source_locale: en
-  source_commit: 11edabf5
+  source_commit: 23c3299b
   translator: "Claude + human review"
-  translation_date: "2026-05-03"
+  translation_date: "2026-07-30"
 ---
 
 # CLI-Ausgabe entwerfen
@@ -53,15 +53,58 @@ Konsistente, mehrstufige Terminal-Ausgabe fuer ein Kommandozeilen-Tool entwerfen
 
 ### Schritt 1: Die Farbpalette definieren
 
-Chalk nutzen um ein benanntes Paletten-Objekt zu erstellen:
+Chalk nutzen um ein benanntes Paletten-Objekt zu erstellen.
+
+**Chalk hinter einem No-Color-Fallback laden.** Der Fallback muss fuer jede
+Aufruf-Form einstehen die die Palette nutzt, und das ist mehr als Strings
+durchzureichen:
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+Vier Invarianten, von denen jede ein kuerzerer Stub falsch macht:
+
+1. **Das Proxy-Target ist aufrufbar** — `(text) => text`, nicht `{}`. Verkettung
+   (`chalk.bold.cyan('x')`) braucht jeden Schritt sowohl indexierbar als auch
+   aufrufbar.
+2. **Factories geben eine Funktion zurueck.** `new Proxy({}, { get: () => (s) => s })`
+   erfuellt die direkten Styles und bricht die Factories: `chalk.hex('#FF6B35')`
+   ist dann der *String* `'#FF6B35'`, und ihn aufzurufen wirft
+   `TypeError: ... is not a function`. Paletten werden beim Modul-Load gebaut, also
+   nimmt dieser Fallback das Tool zur Import-Zeit herunter — genau in der Situation
+   in der das Degradieren auf Klartext der Zweck war.
+3. **`then` ist `undefined`.** Ein Stub der jede Property mit einer Funktion
+   beantwortet laesst `await chalk` fuer immer haengen: die Runtime ruft `.then`
+   und wartet auf einen Callback den niemand aufruft. Node meldet
+   `Detected unsettled top-level await` und beendet mit 13.
+4. **`level` ist eine Zahl.** Capability-Gates lesen `chalk.level >= 1`; ein
+   truthy Stub oeffnet sie ohne Farb-Unterstuetzung dahinter.
+
+Die Palette aus dem Objekt bauen das diesen Import ueberlebt hat.
 
 **Standard-Palette** (transaktionale Ausgabe):
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -86,14 +129,35 @@ const C = {
 ```
 
 Paletten-Design-Regeln:
-- Immer einen No-Color-Fallback bereitstellen (das Proxy-Muster oben)
+- Immer einen No-Color-Fallback bereitstellen, und ihn gegen die Aufruf-Formen
+  pruefen die die Palette tatsaechlich nutzt — die warme Palette oben besteht
+  fast vollstaendig aus Factories
 - Hex-Farben fuer benutzerdefinierte Paletten verwenden (`chalk.hex('#FF6B35')`)
 - Die Fail-/Error-Farbe rot halten unabhaengig vom Paletten-Thema
 - Paletten-Eintraege nach semantischer Rolle benennen, nicht visueller Erscheinung
+- Einen Stub ueber Module hinweg teilen statt ihn an jeder Import-Stelle neu zu
+  bauen, sonst muss derselbe Defekt in jeder Kopie gefunden und behoben werden
 
-**Erwartet:** Ein Paletten-Objekt mit benannten Eintraegen und einem No-Color-Fallback.
+**Erwartet:** Ein Paletten-Objekt mit benannten Eintraegen, und ein Fallback der
+ausgefuehrt und nicht bloss geschrieben wurde.
 
-**Bei Fehler:** Wenn chalk nicht verfuegbar ist (gepipte Ausgabe, CI), gibt der Proxy-Fallback Strings unveraendert zurueck. Mit `NO_COLOR=1`-Umgebungsvariable testen.
+**Bei Fehler:** Den Fallback-Pfad direkt ausueben; die Palette ist der falsche
+Ort um zu entdecken dass er kaputt ist. Mit dem Stub im Scope:
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` deckt das nicht ab. Es uebt ein *funktionierendes* chalk aus das
+sich entscheidet keine Escapes zu senden; der Fallback uebt ein chalk aus das
+nicht importiert werden konnte. Die zwei Pfade teilen keinen Code. Siehe
+[Erweiterte Beispiele](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback)
+fuer den annotierten Produktions-Stub, eine Reproduktion des Defekts und eine
+lauffaehige Version der obigen Pruefungen.
 
 ### Schritt 2: Status-Indikatoren waehlen
 
@@ -252,6 +316,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 Pruefen auf:
@@ -260,14 +328,23 @@ Pruefen auf:
 - JSON ist gueltig (an `jq .` pipen zur Verifikation)
 - Unicode-Glyphen rendern in den Ziel-Terminals
 - Spaltenausrichtung haelt mit variierenden Inhalts-Breiten
+- Der No-Color-Fallback beantwortet jede Aufruf-Form die die Palette nutzt,
+  zugesichert in der Suite statt einmal von Hand demonstriert
 
-**Erwartet:** Ausgabe ist in allen fuenf Kontexten korrekt.
+**Erwartet:** Ausgabe ist in allen sechs Kontexten korrekt.
 
-**Bei Fehler:** Wenn ANSI-Codes lecken, sicherstellen dass chalk `NO_COLOR` respektiert. Wenn Unicode bricht, einen ASCII-Fallback-Modus bereitstellen.
+**Bei Fehler:** Wenn ANSI-Codes lecken, sicherstellen dass chalk `NO_COLOR`
+respektiert. Wenn Unicode bricht, einen ASCII-Fallback-Modus bereitstellen. Zu
+beachten: eine gruene Suite sagt in keine Richtung etwas ueber Farbe aus —
+Test-Runner pipen stdout, was `chalk.level` auf 0 setzt, also sind gefaerbte und
+ungefaerbte Ausgabe byte-identisch und die Assertions halten mit vollstaendig
+kaputter Farbe. Zu beweisen dass Farbe funktioniert braucht `FORCE_COLOR=3` und
+eine Assertion auf einer Escape-Sequenz.
 
 ## Validierung
 
-- [ ] Farbpalette hat einen No-Color-Fallback
+- [ ] Farbpalette hat einen No-Color-Fallback, und der Fallback wurde ausgefuehrt:
+      direkter Style, Factory, Verkettung, `level === 0` und `await` alle geprueft
 - [ ] Status-Indikatoren funktionieren in beiden Farb- und No-Color-Modi
 - [ ] Alle vier Verbosity-Stufen produzieren nuetzliche Ausgabe
 - [ ] JSON-Ausgabe ist gueltig und durch `jq` parsebar
@@ -277,6 +354,7 @@ Pruefen auf:
 
 ## Haeufige Stolperfallen
 
+- **Ein No-Color-Fallback der nur direkte Styles behandelt**: `new Proxy({}, { get: () => (s) => s })` liest sich vollstaendig und deckt `chalk.dim` und `chalk.red` tatsaechlich ab, aber jede Factory gibt dann einen String zurueck den der Caller sofort aufzurufen versucht. Weil Paletten beim Modul-Load gebaut werden, landet der `TypeError` zur Import-Zeit — der Fallback versagt am haertesten in dem einen Fall fuer den er existiert. Schritt 1 listet die vier Invarianten die ein Stub erfuellen muss.
 - **Menschlichen Text mit JSON vermischen**: Im `--json`-Modus nur gueltiges JSON ausgeben. Eine einzelne verirrte Zeile (wie "DRY RUN") bricht JSON-Parser. Wenn der Befehl beides zeigen muss, sie klar trennen oder den menschlichen Text im JSON-Modus unterdruecken.
 - **Hartcodierte Spaltenbreiten**: Inhaltslaenge variiert. `Math.max(...items.map(i => i.id.length))` nutzen um Padding dynamisch zu berechnen.
 - **Farbe ohne Bedeutung**: Wenn Farbe der einzige Weg ist Erfolg von Versagen zu unterscheiden, verlieren farbenblinde Benutzer und gepipte Ausgabe Information. Farbe immer mit einem Text-Indikator paaren (`+`, `OK`, `ERR`).

--- a/i18n/de/skills/design-cli-output/SKILL.md
+++ b/i18n/de/skills/design-cli-output/SKILL.md
@@ -319,7 +319,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 Pruefen auf:

--- a/i18n/de/translation_status.yml
+++ b/i18n/de/translation_status.yml
@@ -1,11 +1,11 @@
 locale: de
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 355
     total: 369
     pct: 96.2
-    stale: 172
+    stale: 171
     stubs: 11
   agents:
     translated: 3
@@ -29,5 +29,5 @@ coverage:
     translated: 363
     total: 500
     pct: 72.6
-    stale: 179
+    stale: 178
     stubs: 20

--- a/i18n/es/skills/design-cli-output/SKILL.md
+++ b/i18n/es/skills/design-cli-output/SKILL.md
@@ -296,7 +296,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 Verificar:

--- a/i18n/es/skills/design-cli-output/SKILL.md
+++ b/i18n/es/skills/design-cli-output/SKILL.md
@@ -25,7 +25,7 @@ metadata:
     - unicode
   locale: es
   source_locale: en
-  source_commit: 23c3299b
+  source_commit: 2630b6e9
   translator: "Claude + human review"
   translation_date: "2026-07-30"
 ---

--- a/i18n/es/skills/design-cli-output/SKILL.md
+++ b/i18n/es/skills/design-cli-output/SKILL.md
@@ -25,9 +25,9 @@ metadata:
     - unicode
   locale: es
   source_locale: en
-  source_commit: 11edabf5
+  source_commit: 23c3299b
   translator: "Claude + human review"
-  translation_date: "2026-05-03"
+  translation_date: "2026-07-30"
 ---
 
 # Design CLI Output
@@ -53,15 +53,45 @@ Diseñar salida de terminal consistente y de múltiples niveles para una herrami
 
 ### Paso 1: Definir la Paleta de Colores
 
-Usar chalk para crear un objeto de paleta nombrado:
+Usar chalk para crear un objeto de paleta nombrado.
+
+**Cargar chalk detrás de un respaldo sin color.** El respaldo tiene que suplir cada forma de llamada que usa la paleta, lo cual es más que dejar pasar los strings sin cambios:
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+Cuatro invariantes, y un stub más corto se equivoca en cada una de ellas:
+
+1. **El target del Proxy es invocable** — `(text) => text`, no `{}`. El encadenamiento (`chalk.bold.cyan('x')`) necesita que cada salto sea a la vez indexable e invocable.
+2. **Las factories retornan una función.** `new Proxy({}, { get: () => (s) => s })` satisface los estilos directos y rompe las factories: `chalk.hex('#FF6B35')` es entonces el *string* `'#FF6B35'`, y llamarlo lanza `TypeError: ... is not a function`. Las paletas se construyen al cargar el módulo, así que ese respaldo tumba la herramienta en el momento del import — precisamente en la situación donde degradar a texto plano era el objetivo.
+3. **`then` es `undefined`.** Un stub que responde a cada propiedad con una función hace que `await chalk` se cuelgue para siempre: el runtime llama a `.then` y espera un callback que nadie invoca. Node reporta `Detected unsettled top-level await` y sale con 13.
+4. **`level` es un número.** Las comprobaciones de capacidad leen `chalk.level >= 1`; un stub truthy las abre sin soporte de color detrás.
+
+Construir la paleta a partir del objeto que haya sobrevivido a ese import.
 
 **Paleta estándar** (salida transaccional):
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -86,14 +116,25 @@ const C = {
 ```
 
 Reglas de diseño de paleta:
-- Siempre proveer un respaldo sin color (el patrón Proxy de arriba)
+- Siempre proveer un respaldo sin color, y comprobarlo contra las formas de llamada que la paleta realmente usa — la paleta cálida de arriba es casi por completo factories
 - Usar colores hex para paletas personalizadas (`chalk.hex('#FF6B35')`)
 - Mantener el color fail/error rojo independientemente del tema de la paleta
 - Nombrar entradas de paleta por rol semántico, no por apariencia visual
+- Compartir un solo stub entre módulos en lugar de reconstruirlo en cada sitio de import, o el mismo defecto tendrá que encontrarse y arreglarse en cada copia
 
-**Esperado:** Un objeto de paleta con entradas nombradas y un respaldo sin color.
+**Esperado:** Un objeto de paleta con entradas nombradas, y un respaldo que ha sido ejecutado en lugar de solamente escrito.
 
-**En caso de fallo:** Si chalk no está disponible (salida con pipe, CI), el respaldo Proxy retorna strings sin cambios. Probar con la variable de entorno `NO_COLOR=1`.
+**En caso de fallo:** Ejercitar la ruta del respaldo directamente; la paleta es el lugar equivocado para descubrir que está roto. Con el stub en alcance:
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` no cubre esto. Ejercita un chalk *funcional* que elige no emitir escapes; el respaldo ejercita un chalk que falló al importarse. Las dos rutas no comparten código. Ver [Ejemplos Extendidos](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback) para el stub de producción anotado, una reproducción del defecto, y una versión ejecutable de las comprobaciones de arriba.
 
 ### Paso 2: Elegir Indicadores de Estado
 
@@ -252,6 +293,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 Verificar:
@@ -260,14 +305,15 @@ Verificar:
 - El JSON es válido (pipe a `jq .` para verificar)
 - Los glyphs Unicode se renderizan en los terminales objetivo
 - La alineación de columnas se mantiene con anchos de contenido variables
+- El respaldo sin color responde a cada forma de llamada que usa la paleta, comprobado con aserciones en la suite en lugar de demostrado una vez a mano
 
-**Esperado:** La salida es correcta en los cinco contextos.
+**Esperado:** La salida es correcta en los seis contextos.
 
-**En caso de fallo:** Si los códigos ANSI se filtran, asegurar que chalk respeta `NO_COLOR`. Si Unicode se rompe, proveer un modo de respaldo ASCII.
+**En caso de fallo:** Si los códigos ANSI se filtran, asegurar que chalk respeta `NO_COLOR`. Si Unicode se rompe, proveer un modo de respaldo ASCII. Notar que una suite verde no dice nada sobre el color en ningún sentido: los test runners hacen pipe de stdout, lo que pone `chalk.level` en 0, así que la salida coloreada y la no coloreada son idénticas byte a byte y las aserciones se cumplen con el color completamente roto. Probar que el color funciona requiere `FORCE_COLOR=3` y una aserción sobre una secuencia de escape.
 
 ## Validación
 
-- [ ] La paleta de colores tiene un respaldo sin color
+- [ ] La paleta de colores tiene un respaldo sin color, y el respaldo se ha ejecutado: estilo directo, factory, cadena, `level === 0` y `await` todos comprobados
 - [ ] Los indicadores de estado funcionan en modos color y sin color
 - [ ] Los cuatro niveles de verbosidad producen salida útil
 - [ ] La salida JSON es válida y parseable por `jq`
@@ -277,6 +323,7 @@ Verificar:
 
 ## Errores Comunes
 
+- **Un respaldo sin color que solo maneja estilos directos**: `new Proxy({}, { get: () => (s) => s })` se lee como completo y sí cubre `chalk.dim` y `chalk.red`, pero entonces cada factory retorna un string que el llamador intenta llamar de inmediato. Como las paletas se construyen al cargar el módulo, el `TypeError` cae en el momento del import — el respaldo falla con más fuerza en el único caso para el que existe. El Paso 1 lista las cuatro invariantes que un stub tiene que satisfacer.
 - **Mezclar texto humano con JSON**: En modo `--json`, emitir solo JSON válido. Una sola línea perdida (como "DRY RUN") rompe los parseadores JSON. Si el comando debe mostrar ambos, separarlos claramente o suprimir el texto humano en modo JSON.
 - **Anchos de columna hardcodeados**: La longitud del contenido varía. Usar `Math.max(...items.map(i => i.id.length))` para calcular el padding dinámicamente.
 - **Color sin significado**: Si el color es la única forma de distinguir éxito de fallo, los usuarios daltónicos y la salida con pipe pierden información. Siempre emparejar el color con un indicador de texto (`+`, `OK`, `ERR`).

--- a/i18n/es/translation_status.yml
+++ b/i18n/es/translation_status.yml
@@ -1,11 +1,11 @@
 locale: es
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 355
     total: 369
     pct: 96.2
-    stale: 175
+    stale: 174
     stubs: 11
   agents:
     translated: 3
@@ -29,5 +29,5 @@ coverage:
     translated: 363
     total: 500
     pct: 72.6
-    stale: 182
+    stale: 181
     stubs: 20

--- a/i18n/ja/skills/design-cli-output/SKILL.md
+++ b/i18n/ja/skills/design-cli-output/SKILL.md
@@ -25,9 +25,9 @@ metadata:
     - unicode
   locale: ja
   source_locale: en
-  source_commit: 11edabf5
+  source_commit: 23c3299b
   translator: "Claude + human review"
-  translation_date: "2026-05-03"
+  translation_date: "2026-07-30"
 ---
 
 # Design CLI Output
@@ -53,15 +53,45 @@ metadata:
 
 ### ステップ1: カラーパレットを定義する
 
-chalk を使って名前付きパレットオブジェクトを作成する:
+chalk を使って名前付きパレットオブジェクトを作成する。
+
+**chalk を no-color フォールバックの背後でロードする。** フォールバックはパレットが使うすべての呼び出し形を代替しなければならず、それは文字列をそのまま通すことだけでは足りない:
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+4 つの不変条件。より短いスタブはそれぞれを取り違える:
+
+1. **Proxy のターゲットが呼び出し可能**: `{}` ではなく `(text) => text`。チェーン（`chalk.bold.cyan('x')`）はすべてのホップがインデックス可能かつ呼び出し可能であることを要求する。
+2. **ファクトリは関数を返す**: `new Proxy({}, { get: () => (s) => s })` は直接スタイルを満たしつつファクトリを壊す。`chalk.hex('#FF6B35')` はそのとき *文字列* `'#FF6B35'` であり、それを呼ぶと `TypeError: ... is not a function` を投げる。パレットはモジュールロード時に構築されるため、そのフォールバックはインポート時点でツールを落とす — プレーンテキストへの劣化こそが目的だったまさにその状況で。
+3. **`then` が `undefined`**: すべてのプロパティに関数を返すスタブは `await chalk` を永久にハングさせる。ランタイムが `.then` を呼び、誰も呼ばないコールバックを待つ。Node は `Detected unsettled top-level await` を報告して 13 で終了する。
+4. **`level` が数値**: 能力ゲートは `chalk.level >= 1` を読む。真値のスタブは背後にカラーサポートがないままそれを開けてしまう。
+
+そのインポートを生き延びたオブジェクトからパレットを構築する。
 
 **標準パレット**（トランザクション出力）:
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -86,14 +116,25 @@ const C = {
 ```
 
 パレット設計ルール:
-- 常に no-color フォールバックを提供する（上記 Proxy パターン）
+- 常に no-color フォールバックを提供し、パレットが実際に使う呼び出し形に対して検査する — 上の温かいパレットはほぼすべてファクトリである
 - カスタムパレットには hex カラーを使う（`chalk.hex('#FF6B35')`）
 - パレットテーマに関係なく fail/error カラーは赤を保つ
 - パレットエントリは見た目ではなく意味的役割で命名する
+- スタブは各インポート箇所で作り直すのではなくモジュール間で 1 つを共有する。さもなければ同じ欠陥をコピーごとに見つけて直すことになる
 
-**期待結果：** 名前付きエントリと no-color フォールバックを持つパレットオブジェクト。
+**期待結果：** 名前付きエントリを持つパレットオブジェクトと、単に書かれただけでなく実行されたフォールバック。
 
-**失敗時：** chalk が利用不能なら（パイプ出力、CI）、Proxy フォールバックは文字列を変えずに返す。`NO_COLOR=1` 環境変数でテストする。
+**失敗時：** フォールバックパスを直接実行する。壊れていることをパレットで発見するのは間違った場所である。スタブがスコープにある状態で:
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` はこれをカバーしない。それはエスケープを出さないことを選ぶ *動作している* chalk を実行するが、フォールバックはインポートに失敗した chalk を実行する。2 つのパスはコードを共有しない。注釈付きの本番スタブ、欠陥の再現、上記チェックの実行可能版は[拡張例](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback)を参照。
 
 ### ステップ2: ステータスインジケーターを選ぶ
 
@@ -252,6 +293,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 確認事項:
@@ -260,14 +305,15 @@ CI=true node cli/index.js audit
 - JSON が有効（`jq .` にパイプして検証）
 - ターゲットターミナルで Unicode グリフが描画される
 - 内容幅が変動してもカラム整列が保たれる
+- no-color フォールバックがパレットが使うすべての呼び出し形に応答し、手作業で一度示すのではなくスイートでアサートされている
 
-**期待結果：** 5 つの文脈すべてで出力が正しい。
+**期待結果：** 6 つの文脈すべてで出力が正しい。
 
-**失敗時：** ANSI コードが漏れたら chalk が `NO_COLOR` を尊重するか確認する。Unicode が壊れたら ASCII フォールバックモードを提供する。
+**失敗時：** ANSI コードが漏れたら chalk が `NO_COLOR` を尊重するか確認する。Unicode が壊れたら ASCII フォールバックモードを提供する。緑のスイートはカラーについてどちらの意味でも何も語らないことに注意: テストランナーは stdout をパイプするため `chalk.level` は 0 になり、カラー出力と非カラー出力はバイト単位で同一になって、カラーが完全に壊れていてもアサーションは通る。カラーが動作することを証明するには `FORCE_COLOR=3` とエスケープシーケンスに対するアサーションが必要である。
 
 ## バリデーション
 
-- [ ] カラーパレットに no-color フォールバックがある
+- [ ] カラーパレットに no-color フォールバックがあり、そのフォールバックが実行済み: 直接スタイル、ファクトリ、チェーン、`level === 0`、`await` をすべて確認
 - [ ] ステータスインジケーターがカラー・no-color 両モードで動く
 - [ ] 4 つの冗長度レベルすべてが有用な出力を生む
 - [ ] JSON 出力が有効で `jq` で解析可能
@@ -277,6 +323,7 @@ CI=true node cli/index.js audit
 
 ## よくある落とし穴
 
+- **直接スタイルしか扱わない no-color フォールバック**: `new Proxy({}, { get: () => (s) => s })` は完全なものに見え、`chalk.dim` と `chalk.red` は実際にカバーするが、そのときすべてのファクトリは呼び出し元が直後に呼ぼうとする文字列を返す。パレットはモジュールロード時に構築されるため、`TypeError` はインポート時点で発生する — フォールバックはそれが存在する唯一の場面で最も激しく失敗する。スタブが満たすべき 4 つの不変条件はステップ1に列挙されている。
 - **人間テキストと JSON を混ぜる**: `--json` モードでは有効 JSON のみを出力。一行でも混じる（「DRY RUN」など）と JSON パーサーが壊れる。コマンドが両方を表示しなければならないなら、明確に分離するか JSON モードで人間テキストを抑制する。
 - **ハードコードされたカラム幅**: 内容長は変動する。`Math.max(...items.map(i => i.id.length))` を使ってパディングを動的に計算する。
 - **意味のないカラー**: カラーが成功と失敗を区別する唯一の方法なら、色覚多様性ユーザーとパイプ出力は情報を失う。常にカラーをテキストインジケーター（`+`、`OK`、`ERR`）と組み合わせる。

--- a/i18n/ja/skills/design-cli-output/SKILL.md
+++ b/i18n/ja/skills/design-cli-output/SKILL.md
@@ -296,7 +296,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 確認事項:

--- a/i18n/ja/skills/design-cli-output/SKILL.md
+++ b/i18n/ja/skills/design-cli-output/SKILL.md
@@ -25,7 +25,7 @@ metadata:
     - unicode
   locale: ja
   source_locale: en
-  source_commit: 23c3299b
+  source_commit: 2630b6e9
   translator: "Claude + human review"
   translation_date: "2026-07-30"
 ---

--- a/i18n/ja/translation_status.yml
+++ b/i18n/ja/translation_status.yml
@@ -1,11 +1,11 @@
 locale: ja
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 355
     total: 369
     pct: 96.2
-    stale: 158
+    stale: 157
     stubs: 11
   agents:
     translated: 3
@@ -29,5 +29,5 @@ coverage:
     translated: 363
     total: 500
     pct: 72.6
-    stale: 165
+    stale: 164
     stubs: 20

--- a/i18n/wenyan-lite/skills/design-cli-output/SKILL.md
+++ b/i18n/wenyan-lite/skills/design-cli-output/SKILL.md
@@ -2,7 +2,7 @@
 name: design-cli-output
 locale: wenyan-lite
 source_locale: en
-source_commit: 23c3299b
+source_commit: 2630b6e9
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-07-30"
 description: >

--- a/i18n/wenyan-lite/skills/design-cli-output/SKILL.md
+++ b/i18n/wenyan-lite/skills/design-cli-output/SKILL.md
@@ -2,9 +2,9 @@
 name: design-cli-output
 locale: wenyan-lite
 source_locale: en
-source_commit: 82c77053
+source_commit: 23c3299b
 translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
+translation_date: "2026-07-30"
 description: >
   Design terminal output for a CLI tool with chalk colors, Unicode glyphs,
   multiple verbosity levels (human, verbose, quiet, JSON), and consistent
@@ -53,15 +53,45 @@ metadata:
 
 ### 步驟一：定色盤
 
-用 chalk 建命名色盤物件：
+用 chalk 建命名色盤物件。
+
+**載 chalk 於無色回退之後。** 回退須代色盤所用之每一呼叫形，非僅傳字串而已：
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+四不變式，短拙之替身各失其一：
+
+1. **代理之標的可呼叫**——`(text) => text`，非 `{}`。鏈式（`chalk.bold.cyan('x')`）須每一節既可索引亦可呼叫。
+2. **工廠須返函數。** `new Proxy({}, { get: () => (s) => s })` 足直接樣式而破工廠：`chalk.hex('#FF6B35')` 遂為*字串* `'#FF6B35'`，呼之則擲 `TypeError: ... is not a function`。色盤於模組載入時建，故此回退於 import 之際即斃其工具——正當降為純文字之所以存也。
+3. **`then` 須為 `undefined`。** 若替身以函數應每一屬性，則 `await chalk` 永懸：運行時呼 `.then` 而候一無人喚之回調。Node 報 `Detected unsettled top-level await`，出碼 13。
+4. **`level` 須為數。** 能力閘讀 `chalk.level >= 1`；真值替身啟之，而其後實無色可支。
+
+以此 import 後存留之物件建色盤。
 
 **標準色盤**（事務性輸出）：
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -86,14 +116,25 @@ const C = {
 ```
 
 色盤設計規則：
-- 恆提供無色回退（如上之 Proxy 模式）
+- 恆提供無色回退，且以色盤實用之呼叫形驗之——上之暖色盤幾盡為工廠
 - 自定色盤用 hex 色（`chalk.hex('#FF6B35')`）
 - 失敗/錯誤色保持紅色，不論色盤主題
 - 以語義角色命色盤項，非視覺外觀
+- 諸模組共一替身，勿於每一 import 處重建之，否則同一疾須於每一副本中尋而修之
 
-**預期：** 具命名項與無色回退之色盤物件。
+**預期：** 具命名項之色盤物件，且其回退已行之，非僅書之而已。
 
-**失敗時：** 若 chalk 不可用（piped 輸出、CI），Proxy 回退返字串不變。以 `NO_COLOR=1` 環境變數測之。
+**失敗時：** 直行回退之路；色盤非發覺其已破之所。替身在域中，則：
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` 不覆此事。彼行一*可用*之 chalk 而擇不發轉義；回退則行一 import 失敗之 chalk。二路無共用之碼。註釋詳備之生產替身、此疾之復現、及上諸檢之可運行本，見 [Extended Examples](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback)。
 
 ### 步驟二：擇狀態指示符
 
@@ -252,6 +293,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 檢之於：
@@ -260,14 +305,15 @@ CI=true node cli/index.js audit
 - JSON 有效（pipe 至 `jq .` 以驗）
 - Unicode 圖符於目標終端中渲染
 - 欄對齊於內容寬度變動時仍持
+- 無色回退應色盤所用之每一呼叫形，且斷言於測試套中，非手行一次以示之
 
-**預期：** 輸出於所有五情境中皆正確。
+**預期：** 輸出於所有六情境中皆正確。
 
-**失敗時：** 若 ANSI 碼漏，確 chalk 尊 `NO_COLOR`。若 Unicode 破，提供 ASCII 回退模式。
+**失敗時：** 若 ANSI 碼漏，確 chalk 尊 `NO_COLOR`。若 Unicode 破，提供 ASCII 回退模式。又須知：綠套於色一無所證。測試運行者 pipe stdout，使 `chalk.level` 為 0，故著色與無色之輸出逐位元相同，色雖全破而斷言猶立。欲證色可用，須 `FORCE_COLOR=3` 及對轉義序列之斷言。
 
 ## 驗證
 
-- [ ] 色盤有無色回退
+- [ ] 色盤有無色回退，且回退已行之：直接樣式、工廠、鏈、`level === 0`、`await` 皆已檢
 - [ ] 狀態指示符於色與無色模式皆運作
 - [ ] 所有四冗長度層級生有用輸出
 - [ ] JSON 輸出有效且 `jq` 可解析
@@ -277,6 +323,7 @@ CI=true node cli/index.js audit
 
 ## 常見陷阱
 
+- **僅理直接樣式之無色回退**：`new Proxy({}, { get: () => (s) => s })` 讀之如全，且誠覆 `chalk.dim` 與 `chalk.red`，然每一工廠遂返一字串，而呼叫者即欲呼之。色盤於模組載入時建，故 `TypeError` 落於 import 之際——回退於其所以存之唯一情境中敗得最重。步驟一列替身須滿之四不變式。
 - **於 JSON 中混人類文字**：於 `--json` 模式僅輸出有效 JSON。單一漏行（如「DRY RUN」）破 JSON 解析器。若指令須兩者皆示，明離之或於 JSON 模式中抑人類文字。
 - **硬編碼欄寬**：內容長度變。用 `Math.max(...items.map(i => i.id.length))` 動態算填充。
 - **無義之色**：若色為區成敗之唯一法，則色盲用戶與 piped 輸出失資訊。恆以文字指示符（`+`、`OK`、`ERR`）配色。

--- a/i18n/wenyan-lite/skills/design-cli-output/SKILL.md
+++ b/i18n/wenyan-lite/skills/design-cli-output/SKILL.md
@@ -296,7 +296,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 檢之於：

--- a/i18n/wenyan-lite/translation_status.yml
+++ b/i18n/wenyan-lite/translation_status.yml
@@ -1,11 +1,11 @@
 locale: wenyan-lite
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 352
     total: 369
     pct: 95.4
-    stale: 310
+    stale: 309
     stubs: 0
   agents:
     translated: 0
@@ -29,5 +29,5 @@ coverage:
     translated: 352
     total: 500
     pct: 70.4
-    stale: 310
+    stale: 309
     stubs: 0

--- a/i18n/wenyan-ultra/skills/design-cli-output/SKILL.md
+++ b/i18n/wenyan-ultra/skills/design-cli-output/SKILL.md
@@ -2,9 +2,9 @@
 name: design-cli-output
 locale: wenyan-ultra
 source_locale: en
-source_commit: 82c77053
+source_commit: 23c3299b
 translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
+translation_date: "2026-07-30"
 description: >
   Design terminal output for a CLI tool with chalk colors, Unicode glyphs,
   multiple verbosity levels (human, verbose, quiet, JSON), and consistent
@@ -53,15 +53,45 @@ metadata:
 
 ### 一：定色板
 
-以 chalk 建名板對象：
+以 chalk 建名板對象。
+
+**載 chalk 須置無色退於後。** 退須代板所用諸調用形，僅過字串不足：
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+四不變式，簡退各誤其一：
+
+1. **代理標的可調用**——`(text) => text`，非 `{}`。鏈式（`chalk.bold.cyan('x')`）每節須既可索又可調。
+2. **工廠返函。** `new Proxy({}, { get: () => (s) => s })` 足直式而壞工廠：`chalk.hex('#FF6B35')` 遂為*字串* `'#FF6B35'`，調之則擲 `TypeError: ... is not a function`。板於模組載時即建，故此退於引入之際即斃工具——正當本欲降為素文之境。
+3. **`then` 須 `undefined`。** 凡屬皆返函之退令 `await chalk` 永懸：運行時調 `.then` 而待無人喚之回調。Node 報 `Detected unsettled top-level await` 而以 13 退。
+4. **`level` 須數。** 能力閘讀 `chalk.level >= 1`；真值之退啟閘而其後實無色可支。
+
+以引入後倖存之對象建板。
 
 **標板**（事務輸出）：
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -86,14 +116,26 @@ const C = {
 ```
 
 色板設規：
-- 常供無色退（上 Proxy 模式）
+- 常供無色退，且以板實用之調用形驗之——上暖板幾盡工廠
 - 自定板用十六進（`chalk.hex('#FF6B35')`）
 - 失敗/錯色無論板主題守紅
 - 按語義角名非視外觀
+- 諸模組共一退，勿於各引入處重造，否則同瑕須逐處覓而修
 
-**得：** 板對象含名項+無色退。
+**得：** 板對象含名項，且退已行非僅書。
 
-**敗：** chalk 不可用（管輸、CI）→Proxy 退返字串不變。以 `NO_COLOR=1` 環境變量測。
+**敗：** 徑試退路；板非覺其壞之所。退在域中，則：
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` 不覆此。彼試*可用*之 chalk 而擇不發轉義；退則試引入敗之 chalk。二路無共碼。註解之生產退、瑕之複現、上諸查之可運行版，見
+[Extended Examples](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback)。
 
 ### 二：擇狀態指示符
 
@@ -252,6 +294,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 查：
@@ -260,14 +306,15 @@ CI=true node cli/index.js audit
 - JSON 有效（管至 `jq .` 驗）
 - 目標終端渲染 Unicode 符
 - 內容寬變時列對齊守
+- 無色退答板所用諸調用形，於測套斷言，非手示一回
 
-**得：** 五上下文輸出皆正。
+**得：** 六上下文輸出皆正。
 
-**敗：** ANSI 漏→確 chalk 尊 `NO_COLOR`。Unicode 壞→供 ASCII 退模。
+**敗：** ANSI 漏→確 chalk 尊 `NO_COLOR`。Unicode 壞→供 ASCII 退模。又：測套綠不言色之有無——測運行器管 stdout，`chalk.level` 遂為 0，著色與否輸出同位元，色全壞而斷言猶立。證色實工，須 `FORCE_COLOR=3` 並斷言於轉義序列。
 
 ## 驗
 
-- [ ] 色板有無色退
+- [ ] 色板有無色退，且退已行：直式、工廠、鏈、`level === 0`、`await` 皆查
 - [ ] 狀態指示符於色+無色模式皆工作
 - [ ] 四冗繁級生有用輸出
 - [ ] JSON 有效可為 `jq` 解
@@ -277,6 +324,7 @@ CI=true node cli/index.js audit
 
 ## 忌
 
+- **僅理直式之無色退**：`new Proxy({}, { get: () => (s) => s })` 讀之若全，誠覆 `chalk.dim` 與 `chalk.red`，然每工廠遂返字串，而調用者即欲調之。板於模組載時即建，故 `TypeError` 落於引入之際——退於其所以存在之唯一境敗得最烈。退須足之四不變式，列於步一。
 - **混人文於 JSON**：`--json` 模式僅輸出有效 JSON。單雜行（如「DRY RUN」）破 JSON 解析。若命令須示兩者→明分或於 JSON 模抑人文。
 - **硬編碼列寬**：內容長變。用 `Math.max(...items.map(i => i.id.length))` 動計填充。
 - **僅色傳義**：若色為唯一別成敗者→色盲用戶+管輸出失信息。常配色+文指示（`+`、`OK`、`ERR`）。

--- a/i18n/wenyan-ultra/skills/design-cli-output/SKILL.md
+++ b/i18n/wenyan-ultra/skills/design-cli-output/SKILL.md
@@ -2,7 +2,7 @@
 name: design-cli-output
 locale: wenyan-ultra
 source_locale: en
-source_commit: 23c3299b
+source_commit: 2630b6e9
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-07-30"
 description: >

--- a/i18n/wenyan-ultra/skills/design-cli-output/SKILL.md
+++ b/i18n/wenyan-ultra/skills/design-cli-output/SKILL.md
@@ -297,7 +297,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 查：

--- a/i18n/wenyan-ultra/translation_status.yml
+++ b/i18n/wenyan-ultra/translation_status.yml
@@ -1,11 +1,11 @@
 locale: wenyan-ultra
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 352
     total: 369
     pct: 95.4
-    stale: 307
+    stale: 306
     stubs: 0
   agents:
     translated: 0
@@ -29,5 +29,5 @@ coverage:
     translated: 352
     total: 500
     pct: 70.4
-    stale: 307
+    stale: 306
     stubs: 0

--- a/i18n/wenyan/skills/design-cli-output/SKILL.md
+++ b/i18n/wenyan/skills/design-cli-output/SKILL.md
@@ -2,7 +2,7 @@
 name: design-cli-output
 locale: wenyan
 source_locale: en
-source_commit: 23c3299b
+source_commit: 2630b6e9
 translator: "Julius Brussee homage — caveman"
 translation_date: "2026-07-30"
 description: >

--- a/i18n/wenyan/skills/design-cli-output/SKILL.md
+++ b/i18n/wenyan/skills/design-cli-output/SKILL.md
@@ -297,7 +297,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 察：

--- a/i18n/wenyan/skills/design-cli-output/SKILL.md
+++ b/i18n/wenyan/skills/design-cli-output/SKILL.md
@@ -2,9 +2,9 @@
 name: design-cli-output
 locale: wenyan
 source_locale: en
-source_commit: 82c77053
+source_commit: 23c3299b
 translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
+translation_date: "2026-07-30"
 description: >
   Design terminal output for a CLI tool with chalk colors, Unicode glyphs,
   multiple verbosity levels (human, verbose, quiet, JSON), and consistent
@@ -53,15 +53,45 @@ metadata:
 
 ### 第一步：定色板
 
-以 chalk 建名板物：
+以 chalk 建名板物。
+
+**載 chalk 於無色退路之後。** 退路須代板所用之諸呼形，非唯傳字符串而已：
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+四恒則，短樁各失其一：
+
+1. **`Proxy` 之標的可呼** — `(text) => text`，非 `{}`。連鎖（`chalk.bold.cyan('x')`）須每節皆可索且可呼。
+2. **廠函返函。** `new Proxy({}, { get: () => (s) => s })` 足直式而破廠函：`chalk.hex('#FF6B35')` 遂為*字符串* `'#FF6B35'`，呼之則擲 `TypeError: ... is not a function`。板建於模載之時，故此退路於入模之際即傾其具——正當以純文本降格為旨之境。
+3. **`then` 為 `undefined`。** 若樁以函答諸屬，則 `await chalk` 永懸：運行時呼 `.then` 而候無人施之回調。Node 報 `Detected unsettled top-level await` 而退 13。
+4. **`level` 為數。** 能力關讀 `chalk.level >= 1`；真值之樁啟之，而其後無色可用。
+
+以歷此入而存者建板。
 
 **標板**（交易輸出）：
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -86,14 +116,26 @@ const C = {
 ```
 
 板設之則：
-- 恒供無色退路（上之 Proxy 模式）
+- 恒供無色退路，且以板實用之諸呼形驗之——上之溫板幾盡廠函
 - 自定板用十六進色（`chalk.hex('#FF6B35')`）
 - fail/error 色無論板主題恒為紅
 - 以語義角命板項，非以視外觀
+- 諸模共一樁，勿於各入處重建，否則同疵須逐本尋而修
 
-**得：** 板物附名項及無色退路。
+**得：** 板物附名項，且其退路已執，非徒書之。
 
-**敗則：** 若 chalk 不可得（管輸出、CI），Proxy 退路返字符串不變。以 `NO_COLOR=1` 環境變量測。
+**敗則：** 直試退路之途；板非發其壞之所。樁在域中則：
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` 不覆此。彼試*可用*之 chalk 而擇不出逸碼；退路試入模已敗之 chalk。二途無共碼。全註之產樁、疵之重現、及上諸察之可執本，見
+[Extended Examples](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback)。
 
 ### 第二步：擇狀指
 
@@ -252,6 +294,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 察：
@@ -260,14 +306,15 @@ CI=true node cli/index.js audit
 - JSON 有效（管至 `jq .` 驗）
 - Unicode 字符於目標終端渲
 - 列齊於變寬內容守
+- 無色退路答板所用之諸呼形，且斷言於試集，非徒手示一回
 
-**得：** 五境輸出皆正。
+**得：** 六境輸出皆正。
 
-**敗則：** 若 ANSI 漏，確 chalk 守 `NO_COLOR`。若 Unicode 壞，供 ASCII 退模。
+**敗則：** 若 ANSI 漏，確 chalk 守 `NO_COLOR`。若 Unicode 壞，供 ASCII 退模。又須知綠試集於色無所證：試行者管 stdout，`chalk.level` 遂為 0，著色與未著色之輸出逐字節同，故色全壞而諸斷言猶立。證色可用須 `FORCE_COLOR=3` 及對逸碼之斷言。
 
 ## 驗
 
-- [ ] 色板有無色退路
+- [ ] 色板有無色退路，且退路已執：直式、廠函、連鎖、`level === 0`、`await` 皆察
 - [ ] 狀指於色與無色模皆可
 - [ ] 四冗贅級皆生有用輸出
 - [ ] JSON 輸出有效且 `jq` 可解
@@ -277,6 +324,7 @@ CI=true node cli/index.js audit
 
 ## 陷
 
+- **唯理直式之無色退路**：`new Proxy({}, { get: () => (s) => s })` 讀似完備，且誠覆 `chalk.dim` 與 `chalk.red`，然諸廠函遂返字符串，而呼者即刻呼之。板建於模載，故 `TypeError` 落於入模之時——退路正於其所以存之一境敗之最劇。第一步列樁須足之四恒則。
 - **混人文本與 JSON**：`--json` 模唯出有效 JSON。一孤行（如「DRY RUN」）破 JSON 解。若命令宜示二者，明分或於 JSON 模抑人文本。
 - **硬編列寬**：內容長變。以 `Math.max(...items.map(i => i.id.length))` 動算墊。
 - **色無義**：若色為別成敗唯徑，色盲用者與管輸失資。恒色配文指（`+`、`OK`、`ERR`）。

--- a/i18n/wenyan/translation_status.yml
+++ b/i18n/wenyan/translation_status.yml
@@ -1,11 +1,11 @@
 locale: wenyan
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 352
     total: 369
     pct: 95.4
-    stale: 310
+    stale: 309
     stubs: 0
   agents:
     translated: 0
@@ -29,5 +29,5 @@ coverage:
     translated: 352
     total: 500
     pct: 70.4
-    stale: 310
+    stale: 309
     stubs: 0

--- a/i18n/zh-CN/skills/design-cli-output/SKILL.md
+++ b/i18n/zh-CN/skills/design-cli-output/SKILL.md
@@ -22,9 +22,9 @@ metadata:
     - unicode
   locale: zh-CN
   source_locale: en
-  source_commit: 11edabf5
+  source_commit: 23c3299b
   translator: "Claude + human review"
-  translation_date: "2026-05-03"
+  translation_date: "2026-07-30"
 ---
 
 # 设计 CLI 输出
@@ -50,15 +50,45 @@ metadata:
 
 ### 第 1 步：定义配色板
 
-使用 chalk 创建命名的配色板对象：
+使用 chalk 创建命名的配色板对象。
+
+**加载 chalk 时带上无颜色后备。** 后备必须替代配色板所使用的每一种调用形态，而这不止于原样传回字符串：
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+四条不变量，更简短的 stub 每一条都会弄错：
+
+1. **Proxy 目标必须可调用** —— 是 `(text) => text`，不是 `{}`。链式调用（`chalk.bold.cyan('x')`）要求每一跳既可索引又可调用。
+2. **工厂函数必须返回函数。** `new Proxy({}, { get: () => (s) => s })` 满足直接样式却破坏工厂函数：此时 `chalk.hex('#FF6B35')` 是*字符串* `'#FF6B35'`，调用它会抛出 `TypeError: ... is not a function`。配色板在模块加载时构建，因此这种后备会在 import 时就让工具崩掉 —— 而这恰恰是本应降级为纯文本的场景。
+3. **`then` 必须是 `undefined`。** 若 stub 对每个属性都返回一个函数，`await chalk` 会永久挂起：运行时会调用 `.then`，然后等待一个无人触发的回调。Node 会报告 `Detected unsettled top-level await` 并以 13 退出。
+4. **`level` 必须是数字。** 能力开关读取 `chalk.level >= 1`；返回真值的 stub 会打开这些开关，而其背后并无颜色支持。
+
+用这次 import 之后存活下来的那个对象来构建配色板。
 
 **标准配色板**（事务性输出）：
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -83,14 +113,25 @@ const C = {
 ```
 
 配色板设计规则：
-- 始终提供无颜色后备（上面的 Proxy 模式）
+- 始终提供无颜色后备，并对照配色板实际使用的调用形态检查它 —— 上面的温暖配色板几乎全是工厂函数
 - 自定义配色板使用十六进制颜色（`chalk.hex('#FF6B35')`）
 - 无论配色板主题如何，fail/error 颜色保持红色
 - 按语义角色而非视觉外观命名配色板条目
+- 跨模块共用同一个 stub，而不是在每个 import 处各建一个，否则同一个缺陷得在每份副本里各找各修一遍
 
-**预期结果：** 一个带有命名条目和无颜色后备的配色板对象。
+**预期结果：** 一个带有命名条目的配色板对象，以及一个已被实际执行过、而非仅仅写出来的后备。
 
-**失败处理：** 若 chalk 不可用（管道输出、CI），Proxy 后备会原样返回字符串。使用 `NO_COLOR=1` 环境变量进行测试。
+**失败处理：** 直接演练后备路径；配色板不是发现它已损坏的合适位置。在 stub 处于作用域内时：
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` 覆盖不到这一点。它演练的是一个*可用的* chalk 选择不输出转义码；而后备演练的是一个 import 失败的 chalk。两条路径不共享任何代码。带注释的生产级 stub、该缺陷的复现，以及上述检查的可运行版本，请参阅[扩展示例](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback)。
 
 ### 第 2 步：选择状态指示器
 
@@ -249,6 +290,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 检查：
@@ -257,14 +302,15 @@ CI=true node cli/index.js audit
 - JSON 有效（管道到 `jq .` 验证）
 - Unicode 图形符号在目标终端中渲染
 - 列对齐在不同内容宽度下保持
+- 无颜色后备能应答配色板使用的每一种调用形态，且是在测试套件中断言的，而非手工演示一次
 
-**预期结果：** 输出在所有五种上下文中都正确。
+**预期结果：** 输出在所有六种上下文中都正确。
 
-**失败处理：** 若 ANSI 码泄漏，确保 chalk 尊重 `NO_COLOR`。若 Unicode 损坏，提供 ASCII 后备模式。
+**失败处理：** 若 ANSI 码泄漏，确保 chalk 尊重 `NO_COLOR`。若 Unicode 损坏，提供 ASCII 后备模式。注意：绿色的测试套件对颜色本身两个方向都什么也说明不了 —— 测试运行器会把 stdout 接入管道，这会让 `chalk.level` 变成 0，于是有颜色和无颜色的输出逐字节相同，即便颜色彻底坏掉断言依然通过。要证明颜色可用，需要 `FORCE_COLOR=3` 并对转义序列做断言。
 
 ## 验证清单
 
-- [ ] 配色板有无颜色后备
+- [ ] 配色板有无颜色后备，且该后备已实际运行过：直接样式、工厂函数、链式调用、`level === 0`、`await` 全部检查通过
 - [ ] 状态指示器在颜色和无颜色模式下都工作
 - [ ] 所有四个详细级别产出有用输出
 - [ ] JSON 输出有效且可被 `jq` 解析
@@ -274,6 +320,7 @@ CI=true node cli/index.js audit
 
 ## 常见问题
 
+- **只处理直接样式的无颜色后备**：`new Proxy({}, { get: () => (s) => s })` 读起来很完整，也确实覆盖了 `chalk.dim` 和 `chalk.red`，但此后每个工厂函数都返回一个字符串，而调用者紧接着就要去调用它。由于配色板在模块加载时构建，`TypeError` 会落在 import 时 —— 后备恰恰在它唯一存在意义的那个场景里败得最惨。第 1 步列出了 stub 必须满足的四条不变量。
 - **将人类文本与 JSON 混合**：在 `--json` 模式下，仅输出有效 JSON。一行散漫的文本（如 "DRY RUN"）会破坏 JSON 解析器。若命令必须显示两者，清晰分离或在 JSON 模式下抑制人类文本。
 - **硬编码列宽**：内容长度不同。使用 `Math.max(...items.map(i => i.id.length))` 动态计算填充。
 - **无意义的颜色**：若颜色是区分成功与失败的唯一方式，色盲用户和管道输出会丢失信息。始终将颜色与文本指示器配对（`+`、`OK`、`ERR`）。

--- a/i18n/zh-CN/skills/design-cli-output/SKILL.md
+++ b/i18n/zh-CN/skills/design-cli-output/SKILL.md
@@ -293,7 +293,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 检查：

--- a/i18n/zh-CN/skills/design-cli-output/SKILL.md
+++ b/i18n/zh-CN/skills/design-cli-output/SKILL.md
@@ -22,7 +22,7 @@ metadata:
     - unicode
   locale: zh-CN
   source_locale: en
-  source_commit: 23c3299b
+  source_commit: 2630b6e9
   translator: "Claude + human review"
   translation_date: "2026-07-30"
 ---

--- a/i18n/zh-CN/translation_status.yml
+++ b/i18n/zh-CN/translation_status.yml
@@ -1,11 +1,11 @@
 locale: zh-CN
-last_updated: '2026-07-24'
+last_updated: '2026-07-30'
 coverage:
   skills:
     translated: 355
     total: 369
     pct: 96.2
-    stale: 165
+    stale: 164
     stubs: 11
   agents:
     translated: 3
@@ -29,5 +29,5 @@ coverage:
     translated: 363
     total: 500
     pct: 72.6
-    stale: 172
+    stale: 171
     stubs: 20

--- a/skills/design-cli-output/SKILL.md
+++ b/skills/design-cli-output/SKILL.md
@@ -48,15 +48,56 @@ Design consistent, multi-level terminal output for a command-line tool.
 
 ### Step 1: Define the Color Palette
 
-Use chalk to create a named palette object:
+Use chalk to create a named palette object.
+
+**Load chalk behind a no-color fallback.** The fallback has to stand in for every
+call shape the palette uses, which is more than passing strings through:
+
+```javascript
+// A factory returns a *function*; a direct style returns a string. Enumerate
+// this list against the installed chalk, not from memory — chalk 6 added the
+// three underline* variants, and a list that omits them is wrong for those names.
+const FACTORIES = new Set(['ansi256', 'bgAnsi256', 'bgHex', 'bgRgb', 'hex',
+  'rgb', 'underlineAnsi256', 'underlineHex', 'underlineRgb']);
+
+function makeChalkStub() {
+  return new Proxy((text) => text, {
+    get(target, prop) {
+      if (prop === 'then') return undefined;   // must not be a thenable
+      if (prop === 'level') return 0;          // no color support, truthfully
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      return FACTORIES.has(prop) ? () => makeChalkStub() : makeChalkStub();
+    },
+  });
+}
+
+let chalk;
+try { chalk = (await import('chalk')).default; }
+catch { chalk = makeChalkStub(); }
+```
+
+Four invariants, each of which a shorter stub gets wrong:
+
+1. **The proxy target is callable** — `(text) => text`, not `{}`. Chaining
+   (`chalk.bold.cyan('x')`) needs every hop to be both indexable and callable.
+2. **Factories return a function.** `new Proxy({}, { get: () => (s) => s })`
+   satisfies the direct styles and breaks the factories: `chalk.hex('#FF6B35')`
+   is then the *string* `'#FF6B35'`, and calling it throws
+   `TypeError: ... is not a function`. Palettes are built at module load, so that
+   fallback takes the tool down at import time — in precisely the situation where
+   degrading to plain text was the point.
+3. **`then` is `undefined`.** A stub that answers every property with a function
+   makes `await chalk` hang forever: the runtime calls `.then` and waits for a
+   callback nobody invokes. Node reports `Detected unsettled top-level await` and
+   exits 13.
+4. **`level` is a number.** Capability gates read `chalk.level >= 1`; a truthy
+   stub opens them with no color support behind them.
+
+Build the palette from whichever object survived that import.
 
 **Standard palette** (transactional output):
 
 ```javascript
-let chalk;
-try { chalk = (await import('chalk')).default; }
-catch { chalk = new Proxy({}, { get: () => (s) => s }); }
-
 // Status colors
 const ok = chalk.green;       // success
 const fail = chalk.red;       // errors
@@ -81,14 +122,34 @@ const C = {
 ```
 
 Palette design rules:
-- Always provide a no-color fallback (the Proxy pattern above)
+- Always provide a no-color fallback, and check it against the call shapes the
+  palette actually uses — the warm palette above is almost entirely factories
 - Use hex colors for custom palettes (`chalk.hex('#FF6B35')`)
 - Keep the fail/error color red regardless of palette theme
 - Name palette entries by semantic role, not visual appearance
+- Share one stub across modules instead of rebuilding it at each import site,
+  or the same defect has to be found and fixed in every copy
 
-**Expected:** A palette object with named entries and a no-color fallback.
+**Expected:** A palette object with named entries, and a fallback that has been
+executed rather than merely written.
 
-**On failure:** If chalk is unavailable (piped output, CI), the Proxy fallback returns strings unchanged. Test with `NO_COLOR=1` environment variable.
+**On failure:** Exercise the fallback path directly; the palette is the wrong
+place to discover it is broken. With the stub in scope:
+
+```javascript
+console.assert(chalk.dim('x') === 'x');            // direct style
+console.assert(chalk.hex('#fff')('x') === 'x');    // factory — the usual defect
+console.assert(chalk.bold.cyan('x') === 'x');      // chain
+console.assert(chalk.level === 0);                 // capability gate stays shut
+await chalk;                                       // must not hang
+```
+
+`NO_COLOR=1` does not cover this. It exercises a *working* chalk that chooses
+not to emit escapes; the fallback exercises a chalk that failed to import. The
+two paths share no code. See
+[Extended Examples](references/EXAMPLES.md#step-1-the-no-color-chalk-fallback)
+for the annotated production stub, a reproduction of the defect, and a runnable
+version of the checks above.
 
 ### Step 2: Choose Status Indicators
 
@@ -247,6 +308,10 @@ node cli/index.js campfire --json | jq .
 
 # In CI (typically no TTY)
 CI=true node cli/index.js audit
+
+# The no-color fallback. A failed import cannot be provoked with an env var, so
+# assert on the stub itself in the suite rather than reaching it through the CLI.
+node --test cli/test/
 ```
 
 Check for:
@@ -255,14 +320,22 @@ Check for:
 - JSON is valid (pipe to `jq .` to verify)
 - Unicode glyphs render in the target terminals
 - Column alignment holds with varying content widths
+- The no-color fallback answers every call shape the palette uses, asserted in
+  the suite rather than demonstrated once by hand
 
-**Expected:** Output is correct in all five contexts.
+**Expected:** Output is correct in all six contexts.
 
-**On failure:** If ANSI codes leak, ensure chalk respects `NO_COLOR`. If Unicode breaks, provide an ASCII fallback mode.
+**On failure:** If ANSI codes leak, ensure chalk respects `NO_COLOR`. If Unicode
+breaks, provide an ASCII fallback mode. Note that a green suite says nothing
+about color either way: test runners pipe stdout, which puts `chalk.level` at 0,
+so colored and uncolored output are byte-identical and the assertions hold with
+color entirely broken. Proving color works needs `FORCE_COLOR=3` and an assertion
+on an escape sequence.
 
 ## Validation
 
-- [ ] Color palette has a no-color fallback
+- [ ] Color palette has a no-color fallback, and the fallback has been run:
+      direct style, factory, chain, `level === 0`, and `await` all checked
 - [ ] Status indicators work in both color and no-color modes
 - [ ] All four verbosity levels produce useful output
 - [ ] JSON output is valid and parseable by `jq`
@@ -272,6 +345,7 @@ Check for:
 
 ## Common Pitfalls
 
+- **A no-color fallback that only handles direct styles**: `new Proxy({}, { get: () => (s) => s })` reads as complete and does cover `chalk.dim` and `chalk.red`, but every factory then returns a string the caller immediately tries to call. Because palettes are built at module load, the `TypeError` lands at import time — the fallback fails hardest in the one case it exists for. Step 1 lists the four invariants a stub has to satisfy.
 - **Mixing human text with JSON**: In `--json` mode, output only valid JSON. A single stray line (like "DRY RUN") breaks JSON parsers. If the command must show both, separate them clearly or suppress the human text in JSON mode.
 - **Hardcoded column widths**: Content length varies. Use `Math.max(...items.map(i => i.id.length))` to compute padding dynamically.
 - **Color without meaning**: If color is the only way to distinguish success from failure, colorblind users and piped output lose information. Always pair color with a text indicator (`+`, `OK`, `ERR`).

--- a/skills/design-cli-output/SKILL.md
+++ b/skills/design-cli-output/SKILL.md
@@ -311,7 +311,8 @@ CI=true node cli/index.js audit
 
 # The no-color fallback. A failed import cannot be provoked with an env var, so
 # assert on the stub itself in the suite rather than reaching it through the CLI.
-node --test cli/test/
+# Pass a glob, not a directory: `node --test <dir>` stopped expanding at Node 22.
+node --test 'cli/test/*.test.js'
 ```
 
 Check for:

--- a/skills/design-cli-output/references/EXAMPLES.md
+++ b/skills/design-cli-output/references/EXAMPLES.md
@@ -1,0 +1,204 @@
+# Design CLI Output — Extended Examples
+
+Complete implementations for the patterns sketched in `SKILL.md`.
+
+## Step 1: The no-color chalk fallback
+
+### Why the short version fails
+
+The idiom below is the one to recognize and reject. It is compact, it reads as
+complete, and it is wrong:
+
+```javascript
+// broken.mjs — reproduces the defect. Run it: node broken.mjs
+const chalk = new Proxy({}, { get: () => (s) => s });
+
+console.log(chalk.dim('x'));         // 'x'       — direct styles are fine
+console.log(chalk.hex('#FF6B35'));   // '#FF6B35' — a string, not a function
+chalk.hex('#FF6B35')('flame');       // TypeError: chalk.hex(...) is not a function
+```
+
+Every property answers with `(s) => s`. That is right for a direct style, which
+takes text and returns text, and wrong for a factory, which takes a color and
+returns a styler. So `chalk.hex('#FF6B35')` yields the *string* `'#FF6B35'`, and
+the call that immediately follows it throws.
+
+Three properties separate a working stub from that one:
+
+**1. A factory has to return a function.** Warm palettes are built almost
+entirely from factories, and they are built at module load:
+
+```javascript
+const C = {
+  flame: chalk.hex('#FF6B35'),
+  amber: chalk.hex('#FFB347'),
+};
+```
+
+Those lines run during `import`. A stub that returns strings there throws before
+the program reaches `main()`, so the tool dies at startup in exactly the
+situation the fallback existed to survive — chalk missing or unimportable, where
+plain text was the whole point.
+
+**2. The stub must not be a thenable.** A proxy that answers *every* property
+with a function also answers `then` with a function. Any `await` on it — or any
+`Promise.resolve()` that wraps it — then hangs forever, because the runtime calls
+`.then(resolve, reject)` and waits for a callback that is never invoked:
+
+```javascript
+// hangs.mjs — do not expect this to exit.
+const chalk = new Proxy((t) => t, { get: () => (t) => t });
+await chalk;
+// Node: "Detected unsettled top-level await", exit code 13
+```
+
+Returning `undefined` for `then` is what makes the object safe to `await`.
+
+**3. `level` must be a number.** Chalk exposes `level` as an integer 0–3, and
+capability checks read it numerically:
+
+```javascript
+function canRenderPixelArt() {
+  return chalk.level >= 1;
+}
+```
+
+A stub that returns a function for `level` makes that comparison `false` by
+accident rather than by design (`function >= 1` is `NaN >= 1`), and any truthiness
+check on `chalk.level` opens the gate with no color support behind it. `0` is the
+truthful answer and keeps every such gate closed.
+
+### The production stub, annotated
+
+```javascript
+/**
+ * chalk-stub.js — the no-color fallback used when `import('chalk')` fails.
+ *
+ * Shared rather than duplicated. When two import sites each built their own
+ * fallback, the identical bug existed twice, and a fix applied to one copy left
+ * the other broken.
+ */
+
+/**
+ * chalk members that return a *function* rather than a styled string.
+ *
+ * Enumerate this against the installed chalk rather than from memory: chalk 6
+ * added the three `underline*` variants, and a list that omits them
+ * reintroduces the string-instead-of-function bug for exactly those names.
+ */
+const CHALK_FACTORIES = new Set([
+  'ansi256',
+  'bgAnsi256',
+  'bgHex',
+  'bgRgb',
+  'hex',
+  'rgb',
+  'underlineAnsi256',
+  'underlineHex',
+  'underlineRgb',
+]);
+
+/**
+ * A chalk-shaped object that applies no color.
+ *
+ * Supports the three call shapes a palette uses:
+ *   chalk.dim('x')            -> 'x'
+ *   chalk.hex('#FF6B35')('x') -> 'x'
+ *   chalk.bold.cyan('x')      -> 'x'
+ *
+ * @returns {any} a callable, chainable stub
+ */
+export function makeChalkStub() {
+  const identity = (text) => text;
+  return new Proxy(identity, {
+    get(target, prop) {
+      // Must not be a thenable, or `await chalk` never settles.
+      if (prop === 'then') return undefined;
+      // A stub means no color support, so 0 is the truthful answer and keeps
+      // `level >= 1` capability gates closed.
+      if (prop === 'level') return 0;
+      // Symbols (Symbol.toPrimitive, util.inspect.custom, ...) should behave as
+      // they would on a plain function rather than becoming more stubs.
+      if (typeof prop === 'symbol') return Reflect.get(target, prop);
+      // A factory must yield a function; a direct style must yield the string.
+      if (CHALK_FACTORIES.has(prop)) return () => makeChalkStub();
+      return makeChalkStub();
+    },
+  });
+}
+```
+
+The proxy target is `identity`, not `{}`. A callable target is what lets the stub
+be both indexed and invoked at every hop, which is what `chalk.bold.cyan('x')`
+requires.
+
+### Regenerating the factory list
+
+Do not maintain the set by hand across a chalk major. Ask the installed copy
+which of its members return a function:
+
+```bash
+node -e "import('chalk').then(m=>{const c=m.default;for(const n of
+  Object.getOwnPropertyNames(Object.getPrototypeOf(c)))
+  {if(n==='constructor')continue;
+   try{if(typeof c[n]('#fff')==='function')console.log(n)}catch{}}})"
+```
+
+Run it after every chalk upgrade and diff the output against `CHALK_FACTORIES`.
+Against chalk 6.0.0 it prints exactly the nine names above. The three
+`underline*` ones appeared this way in the 6.0 major; a set written from memory
+would have missed them.
+
+The `constructor` skip is load-bearing. `Object.getPrototypeOf(chalk).constructor`
+is `createChalk`, and `createChalk('#fff')` does return a function, so without the
+skip the probe reports a tenth name that is not a factory. A probe with a known
+false positive is still worth running — but paste its output through a diff, not
+straight into the set.
+
+### Runnable verification
+
+The fallback is the one path a normal test run cannot reach: an `import` failure
+cannot be provoked with an environment variable, and `NO_COLOR=1` exercises a
+*working* chalk that declines to emit escapes. Assert on the stub directly.
+
+```javascript
+// verify-chalk-stub.mjs — node verify-chalk-stub.mjs
+import assert from 'node:assert/strict';
+import { makeChalkStub } from './chalk-stub.js';
+
+const chalk = makeChalkStub();
+
+// Direct styles pass text through.
+assert.equal(chalk.dim('x'), 'x');
+assert.equal(chalk.red('x'), 'x');
+
+// Factories return a callable, not a string. This is the defect itself.
+assert.equal(typeof chalk.hex('#FF6B35'), 'function');
+assert.equal(chalk.hex('#FF6B35')('flame'), 'flame');
+assert.equal(chalk.bgHex('#FFB347')('bg'), 'bg');
+assert.equal(chalk.rgb(1, 2, 3)('x'), 'x');
+
+// The factories a given chalk major added most recently are the ones a
+// hand-written list omits.
+assert.equal(chalk.underlineHex('#fff')('x'), 'x');
+assert.equal(chalk.underlineRgb(1, 2, 3)('x'), 'x');
+assert.equal(chalk.underlineAnsi256(42)('x'), 'x');
+
+// Chains resolve at any depth.
+assert.equal(chalk.bold.cyan('x'), 'x');
+assert.equal(chalk.bold.underline.red('x'), 'x');
+
+// Capability gates stay closed, numerically.
+assert.equal(chalk.level, 0);
+assert.equal(chalk.level >= 1, false);
+
+// Awaiting the stub settles instead of hanging.
+assert.equal(await Promise.resolve(chalk), chalk);
+
+console.log('chalk stub OK');
+```
+
+A green CLI test suite is not a substitute for these assertions. Test runners
+pipe stdout, which puts `chalk.level` at 0, so colored and uncolored output are
+byte-identical — the suite passes with chalk entirely broken. If you need to
+prove color works at all, set `FORCE_COLOR=3` and assert on an escape sequence.


### PR DESCRIPTION
Closes #464.

`design-cli-output` taught the defect that #455 fixed. Step 1 documented

```js
catch { chalk = new Proxy({}, { get: () => (s) => s }); }
```

as the no-color fallback. Every property answers with `(s) => s`, which is right
for a direct style and wrong for a factory: `chalk.hex('#FF6B35')` evaluates to
the string `'#FF6B35'`, and the call that immediately follows it throws. So the
CLI bug was not a slip — it was the repo's own documented pattern, applied
correctly, and any agent following the skill wrote the same defect. Mirrored into
10 locales, it was taught eleven times.

## What changed

| Commit | |
|---|---|
| `23c3299b` | English `SKILL.md` corrected; new `references/EXAMPLES.md` |
| `9147b502` | the `constructor` false positive in the factory probe |
| `49dc5914` | all 10 locale mirrors |
| `2630b6e9` | **a broken command this PR itself introduced** — see below |
| `6bb2e1f5` | mirrors repointed at the corrected English source |

**English source.** The block is replaced with a working stub, and the four
invariants a stub has to satisfy are named: a callable proxy target, factories
that return functions, `then` undefined so `await chalk` settles, and a numeric
`level`. The skill stays self-contained rather than pointing at
`cli/lib/chalk-stub.js`, since it is guidance for building any CLI, not only this
one.

New `references/EXAMPLES.md` carries the annotated production stub, a runnable
reproduction of the defect, the factory-probe command, and the assertion set —
following the progressive-disclosure convention for blocks over 15 lines.

Step 6's "all five contexts" becomes six, since forcing the fallback path is now
listed. Its On-failure block records that a green suite proves nothing about color
either way: test runners pipe stdout, which puts `chalk.level` at 0, so colored
and uncolored output are byte-identical and every assertion holds with chalk fully
broken (#454).

**Locale mirrors.** All 10, prose translated, code untouched. Register preserved
per locale rather than normalised — the German mirror's ASCII transliteration of
umlauts, and the three compression tiers each of caveman and wenyan. Line counts
land between 335 and 369 against a 500 ceiling.

**A defect found in this PR's own work** (`9147b502`). The factory-regeneration
probe documented in `cli/lib/chalk-stub.js` reports **ten** names, not the nine in
`CHALK_FACTORIES`. `Object.getPrototypeOf(chalk).constructor` is `createChalk`,
and `createChalk('#fff')` returns a function, so it satisfies the probe's `typeof`
test. Regenerating the set and pasting the output adds a member that is not a
factory. Found by extracting the command from the file and running it rather than
reading it. Corrected in both places it appears, so the source and the skill that
mirrors it cannot drift.

## Correction: an earlier version of this PR shipped a command that never ran

The first version of this description claimed "every code block was executed
before committing." That was false, and the adversarial review caught it.

`node --test cli/test/`, added by this PR to Step 6 and mirrored into all 10
locales, exits 1 having executed none of the 111 tests:

```console
$ node --test cli/test/ ; echo "EXIT=$?"
Error: Cannot find module '/mnt/d/dev/p/agent-almanac/cli/test'
  code: 'MODULE_NOT_FOUND'
ℹ tests 1  ℹ pass 0  ℹ fail 1
EXIT=1
```

Node stopped expanding a directory positional at Node 22. On a minimal ESM
fixture: node@20 exits 0 with `pass 1`; node@22, node@24 and node@25 all exit 1
with `pass 0`. This package declares `engines: {"node": ">=22.12.0"}`, so the
command was broken on every version it supports and worked only below the declared
floor.

This is the defect class #464 is about, inside the fix for #464. The evidence
table below listed seven executed checks and none of them was that fence, and the
extract-and-run method that caught the `constructor` probe was available and I did
not apply it here. Fixed in `2630b6e9` with the glob form, and the check is now
mechanical rather than remembered — a script extracts the Step 6 fence from the
committed markdown and runs every line:

```
[ OK ] exit=0  node cli/index.js list --domains
[ OK ] exit=0  node cli/index.js list --domains | cat
[ OK ] exit=0  NO_COLOR=1 node cli/index.js list --domains
[ OK ] exit=0  node cli/index.js campfire --json | jq .
[ OK ] exit=0  CI=true node cli/index.js audit
[ OK ] exit=0  node --test 'cli/test/*.test.js'
```

## Acceptance criteria

- [x] `skills/design-cli-output/SKILL.md` no longer shows a fallback whose
      factories return strings
- [x] The 10 locale mirrors updated, with every code block left untranslated per
      the keep-in-English rule
- [x] The example is executable — `chalk.hex('#fff')('x') === 'x'` confirmed by
      running it

## Evidence

Run bare, exit codes read from `$?` directly, never through a pipe.

| Check | Result |
|---|---|
| Step 1 stub + its On-failure assertions | exit 0, including the AC's `chalk.hex('#fff')('x') === 'x'` |
| `broken.mjs` reproduction from EXAMPLES.md | prints `x`, then `#FF6B35`, then `TypeError: chalk.hex(...) is not a function`, exit 1 |
| `hangs.mjs` thenable demo from EXAMPLES.md | `Warning: Detected unsettled top-level await`, exit 13 |
| `verify-chalk-stub.mjs` against the real `cli/lib/chalk-stub.js` | exit 0 |
| factory probe, **extracted from the committed markdown** and executed | exactly the 9 names in `CHALK_FACTORIES`, diffed clean |
| same probe extracted from `chalk-stub.js`'s docstring | identical output; both docs agree |
| **all 6 commands in the Step 6 fence, extracted and executed** | every one exits 0 |
| `npm run test:cli` | 111/111, run serially with no agents in the tree |

Repo gates: `check-i18n-frontmatter-parity` 0 (3576 translated skills compared;
only `source_commit` and `translation_date` were touched), `audit-skill-sections`
0, `validate:line-endings` clean, `check-content-style --added` 0 blocking,
`check-translation-freshness` reports no `design-cli-output` entry stale against
`2630b6e9`. `build-data` regenerated: the only drift was its own `generated`
timestamp, so it is not committed.

Minor note on history: `6bb2e1f5`'s message says it regenerates
`translation_status.yml`. The regeneration was run and produced no diff — the
stale counts were already settled in `49dc5914` — so that commit contains only the
`source_commit` bump.

### The i18n gate was shown red before being trusted

A checker extracts every fenced block from each mirror and string-compares it
against the English set, then checks the line ceiling, `locale:`, `source_commit`,
`translation_date`, absence of CRLF, that no `references/` directory was created
under `i18n/`, and that the broken idiom appears exactly twice per file — matching
the two places English quotes it deliberately as the thing to reject.

Run against the mirrors in their **pre-fix** state it failed all ten, naming the
real defect rather than only the frontmatter fields:

```
[FAIL] de             290 lines   8 fences
         source_commit != 23c3299b
         2 fence(s) diverge from English
           diverging fence starts: "let chalk;"
         corrected stub fence absent or altered
         broken idiom appears 1x, English cites it 2x
GATE: FAIL
```

After the change, and again after the Step 6 fix, the same checker passes all ten
at 10 fences each. A green from a gate never observed failing is not evidence,
which is the lesson `CLAUDE.md` § *Proving a Gate Can Fail* exists to record.

## Review

Copilot was requested and is quota-blocked — `COMMENTED`, the 119-char quota body,
zero line comments. Verified, not assumed. Per repo practice an adversarial
substitute ran instead: three independent lenses (stub correctness, claim audit,
i18n fidelity), each finding refuted by separate verifiers prompted to reproduce
it. **1 survived of 11**, and it is the `node --test` defect corrected above. The
i18n lens returned clean after in-language comprehension reads of all ten mirrors.

## Filed, not fixed here

**#469** — locale mirrors' `references/EXAMPLES.md` links point at files that do
not exist: the path is relative and no i18n mirror has a `references/` directory.
Found because this PR adds the first `references/` to `design-cli-output` and had
to decide what its mirrors should link to. It follows the existing convention —
translated link text, English path and anchor — rather than diverging in one
skill, so it adds to that count deliberately. Two mirrors already reach back with
`../../../../skills/...`, which is precedent for the option the issue recommends.

**#471** — `cli/lib/chalk-stub.js` diverges from real chalk at `level: 0` in four
ways, worst being silent multi-argument truncation: `chalk.dim('Skills:', 369)`
gives `'Skills: 369'` from real chalk and `'Skills:'` from the stub. All four are
latent — swept 177 styler invocations in `cli/`, none triggers them — and all four
were reported by the review and then correctly **refuted as findings against this
PR**, being pre-existing behaviour shipped by #455 rather than introduced here.
Filed with the coupling noted: any fix has to land in the 11 documentation files
too, or source and guidance drift apart again.

Refs #455, #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Np1njXpzNXQ1mVWkesph3h
