### PR TITLE
feat(i18n): enforce the keep-code-in-English rule with a default-deny fence-parity gate

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -2,9 +2,9 @@ name: Validate Skills
 on:
   push:
     branches: [main]
-    paths: ['skills/**', 'i18n/**/skills/**', 'scripts/audit-skill-sections.js', '.github/workflows/validate-skills.yml']
+    paths: ['skills/**', 'i18n/**', 'agents/**', 'teams/**', 'guides/**', 'scripts/**', 'package.json', 'package-lock.json', '.github/workflows/validate-skills.yml']
   pull_request:
-    paths: ['skills/**', 'i18n/**/skills/**', 'scripts/audit-skill-sections.js', '.github/workflows/validate-skills.yml']
+    paths: ['skills/**', 'i18n/**', 'agents/**', 'teams/**', 'guides/**', 'scripts/**', 'package.json', 'package-lock.json', '.github/workflows/validate-skills.yml']
   workflow_dispatch:
 
 permissions:
@@ -138,11 +138,13 @@ jobs:
       #
       # Ships WARN-ONLY, unlike the frontmatter gate above, and the difference is
       # the corpus state at introduction. #371 could ship blocking because a
-      # 39-file catch-up in the same PR left it clean. This one lands on 1,220
-      # violations across 327 files, and the repair splits into reviewable
-      # batches — 1,014 mechanical, 206 in 46 files that are content forks
-      # needing re-translation, some of it regulated (#478). A blocking gate here
-      # would fail every build until the last batch merges.
+      # 39-file catch-up in the same PR left it clean. This one lands on 1,307
+      # violations across 338 files (1,220 in skills, 87 in the agents/teams/
+      # guides mirrors), and the repair splits into reviewable batches — 1,014
+      # mechanical, 206 in 46 files that are content forks needing
+      # re-translation, some of it regulated (#478), 87 in mirrors the normalizer
+      # does not yet cover. A blocking gate here would fail every build until the
+      # last batch merges.
       #
       # Warn is a temporary state with a named exit: #477 flips this to blocking
       # in the PR that clears the final batch, and the red-to-green transition is

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -133,3 +133,26 @@ jobs:
       # heuristic warn-only A9. Local `npm run validate:i18n-parity` matches.
       - name: Check i18n frontmatter parity
         run: node scripts/check-i18n-frontmatter-parity.js
+
+      # Keep-code-in-English fence parity (#472).
+      #
+      # Ships WARN-ONLY, unlike the frontmatter gate above, and the difference is
+      # the corpus state at introduction. #371 could ship blocking because a
+      # 39-file catch-up in the same PR left it clean. This one lands on 1,220
+      # violations across 327 files, and the repair splits into reviewable
+      # batches — 1,014 mechanical, 206 in 46 files that are content forks
+      # needing re-translation, some of it regulated (#478). A blocking gate here
+      # would fail every build until the last batch merges.
+      #
+      # Warn is a temporary state with a named exit: #477 flips this to blocking
+      # in the PR that clears the final batch, and the red-to-green transition is
+      # the proof the gate can fail. The day-one red output is recorded in the
+      # PR that introduced this step, per CLAUDE.md § Proving a Gate Can Fail.
+      #
+      # The gate needs full history — it accepts a translated fence body that
+      # matches ANY revision of its English source, which is what makes it immune
+      # to the staleness confound. `fetch-depth: 0` above is therefore
+      # load-bearing here too, and the script hard-exits on a shallow clone
+      # rather than passing vacuously (#279/#362).
+      - name: Check i18n code-fence parity (warn only until #477)
+        run: node scripts/check-i18n-fence-parity.js --warn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,9 +230,14 @@ lists code blocks under "What always survives"; compression is licensed for
 prose only.
 
 ```bash
-npm run validate:i18n-fences     # check (blocking in CI)
-npm run normalize:i18n-fences    # restore English fence bodies
+npm run validate:i18n-fences                    # whole corpus
+node scripts/check-i18n-fence-parity.js \
+  --locale de --id create-r-package             # just the file you touched
+npm run normalize:i18n-fences                   # restore English fence bodies
 ```
+
+Runs **warn-only** in CI until the 1,307-violation backlog clears (#477), then
+flips to blocking. Warn is a temporary state with a named exit, not the design.
 
 ### Translation Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,39 @@ i18n/
 - Every translated file has frontmatter fields: `locale`, `source_locale`, `source_commit`, `translator`, `translation_date`
 - Translated SKILL.md files must stay under 500 lines
 
+#### Which code fences are frozen
+
+"Code blocks stay in English" was stated in four places and violated 1,220 times,
+so it is now mechanical. A fenced block in any translated file is **frozen**
+unless its info-string tag is exactly `text`, `markdown`, or `md`. Frozen means
+the body must be byte-identical to a fence body appearing in *some* revision of
+the paired English file.
+
+The exemption list is **closed and default-deny**: an untagged fence, or any tag
+not on that list — including tags nobody has used yet — is frozen on arrival.
+Adding a tag to the list requires naming which machine consumes that fence. An
+allowlist of "code" tags would leave `logql`, `bibtex`, `jsonl`, `traceql` and
+`powershell` unguarded, and would let the scope be edited by retagging a
+```` ```yaml ```` fence to ```` ```text ````.
+
+Frozen covers everything inside the delimiters: comments, docstrings, string
+literals, YAML values, placeholder tokens. Translate the prose *around* the
+fence. If a comment carries the only statement of an instruction, lift it into
+the step's prose rather than translating it in place.
+
+`text` and `markdown` are exempt because they carry reference tables, decision
+flows and report templates a human reads or fills in — a German reviewer should
+be able to emit a German report.
+
+This applies at every compression level. `guides/caveman-spellbook.md` already
+lists code blocks under "What always survives"; compression is licensed for
+prose only.
+
+```bash
+npm run validate:i18n-fences     # check (blocking in CI)
+npm run normalize:i18n-fences    # restore English fence bodies
+```
+
 ### Translation Workflow
 
 ```bash

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -34,6 +34,34 @@ i18n/
 | **Teams** | description, Purpose, Coordination Pattern prose, Usage Scenarios | name (=ID), lead, members[].id, coordination type, CONFIG block |
 | **Guides** | title, description, all prose sections, troubleshooting | code blocks, command examples, file paths, YAML config examples |
 
+### Code fences: which are frozen
+
+"Code blocks" above is enforced, not advisory (#472). A fenced block is **frozen**
+unless its info-string tag is exactly `text`, `markdown`, or `md`. A frozen fence
+body must be byte-identical to a fence body appearing in *some* revision of the
+paired English file — any revision ever committed, so a faithful translation of an
+older English source still passes and staleness stays
+`check-translation-freshness.js`'s problem.
+
+The exemption list is closed and **default-deny**. Untagged fences are frozen. Any
+tag not named above — `logql`, `bibtex`, `powershell`, or one invented next year —
+is frozen on arrival. Adding a tag requires a PR naming which machine consumes
+that fence.
+
+Frozen covers everything between the delimiters: comments, docstrings, string
+literals, YAML values, placeholders. Translate the prose around the fence. When a
+comment carries the only statement of an instruction, lift it into the prose
+instead of translating it in place.
+
+`text` and `markdown` stay localisable because they carry tables, decision flows
+and report templates meant to be read or filled in by a person in their own
+language.
+
+```bash
+npm run validate:i18n-fences     # check — blocking in CI
+npm run normalize:i18n-fences    # restore English fence bodies from source_commit
+```
+
 ## Translation Frontmatter
 
 Every translated file includes these fields in its YAML frontmatter:

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -58,9 +58,13 @@ and report templates meant to be read or filled in by a person in their own
 language.
 
 ```bash
-npm run validate:i18n-fences     # check — blocking in CI
-npm run normalize:i18n-fences    # restore English fence bodies from source_commit
+npm run validate:i18n-fences                    # whole corpus
+node scripts/check-i18n-fence-parity.js \
+  --locale de --id create-r-package             # just the file you touched
+npm run normalize:i18n-fences                   # restore English bodies from source_commit
 ```
+
+Runs **warn-only** in CI until the backlog clears (#477), then flips to blocking.
 
 ## Translation Frontmatter
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "validate:integrity": "bash scripts/validate-integrity.sh",
     "validate:translations": "node scripts/check-translation-freshness.js",
     "validate:i18n-parity": "node scripts/check-i18n-frontmatter-parity.js",
+    "validate:i18n-fences": "node scripts/check-i18n-fence-parity.js",
+    "normalize:i18n-fences": "node scripts/normalize-i18n-fences.js",
     "validate:content-style": "node scripts/check-content-style.js --all",
     "validate:line-endings": "node scripts/check-line-endings.js",
     "validate:skill-sections": "node scripts/audit-skill-sections.js --missing",

--- a/scripts/bulk-scaffold-caveman.sh
+++ b/scripts/bulk-scaffold-caveman.sh
@@ -41,8 +41,16 @@ for locale in "${LOCALES[@]}"; do
     fi
 
     mkdir -p "$target_dir"
+    # Inject ONLY inside the YAML frontmatter block. The unscoped `/^name:/`
+    # this replaces fired on every column-0 `name:` in the file, including
+    # inside ```yaml fences — a skill documenting a GitHub Actions workflow got
+    # `locale:`/`translator:` spliced into the workflow a reader is told to copy.
+    # 55 such injections across 38 files reached main before anything compared
+    # translated fences against English (#475, found via #472).
     awk -v locale="$locale" -v commit="$SOURCE_COMMIT" -v date="$TODAY" '
-      /^name:/ {
+      NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; print; next }
+      in_fm && /^---[[:space:]]*$/   { in_fm = 0; print; next }
+      in_fm && /^name:/ {
         print
         print "locale: " locale
         print "source_locale: en"

--- a/scripts/bulk-scaffold-caveman.sh
+++ b/scripts/bulk-scaffold-caveman.sh
@@ -45,7 +45,7 @@ for locale in "${LOCALES[@]}"; do
     # this replaces fired on every column-0 `name:` in the file, including
     # inside ```yaml fences — a skill documenting a GitHub Actions workflow got
     # `locale:`/`translator:` spliced into the workflow a reader is told to copy.
-    # 55 such injections across 38 files reached main before anything compared
+    # 64 such injections across 44 files reached main before anything compared
     # translated fences against English (#475, found via #472).
     awk -v locale="$locale" -v commit="$SOURCE_COMMIT" -v date="$TODAY" '
       NR == 1 && /^---[[:space:]]*$/ { in_fm = 1; print; next }

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * check-i18n-fence-parity.js
+ *
+ * Enforces the keep-code-in-English rule for fenced code blocks in translated
+ * skills. `CLAUDE.md` § Translation Rules and `i18n/README.md` both declare code
+ * blocks keep-in-English, and `skills/translate-content/SKILL.md` step 5.3 even
+ * instructs the translator to "diff the fenced blocks" — but nothing mechanical
+ * checked it, and the corpus drifted (#472).
+ *
+ * That the rule was stated four times and still violated is the point: every
+ * i18n commit in this repo postdates the commit that introduced step 5.3
+ * (77006e7a, 2026-03-13), so every violation was produced under a procedure
+ * that told the agent to verify exactly this. Prose does not enforce.
+ *
+ * ## What counts as a violation
+ *
+ * A fence body in a translated SKILL.md is a violation when it appears in NO
+ * revision of that skill's English SKILL.md, ever.
+ *
+ * That basis is chosen to be immune to the two confounds that make the naive
+ * comparison unusable:
+ *
+ *   - **Staleness.** 2,545 translations are stale repo-wide. A stale
+ *     translation's fence legitimately matches an OLDER English source and
+ *     diverges from HEAD without anybody having translated anything. Comparing
+ *     against HEAD alone would report those as violations.
+ *   - **`source_commit` bumps.** `evolve-skill` bumps `source_commit` without
+ *     retranslating (#405), so the frontmatter's claimed basis can sit ahead of
+ *     the real one. Anchoring to `source_commit` inherits that lie.
+ *
+ * Searching the whole history of the English file dodges both: staleness can
+ * only ever make a fence match an *earlier* English revision, never a revision
+ * that does not exist. So anything this reports was written by a human or an
+ * agent and never existed in English. Measured false-positive rate on the
+ * corpus at introduction: 2 whitespace-only and 2 cross-skill artifacts out of
+ * 1,934 — 0.2%.
+ *
+ * Consequence, stated deliberately: a fence matching an OLD English revision
+ * passes. That is staleness, which is `check-translation-freshness.js`'s job,
+ * not this gate's.
+ *
+ * ## Why not the CJK discriminator
+ *
+ * #472 proposed flagging fences containing CJK characters absent from English.
+ * That is sound but sees only 410 of 1,198 executable-tag violations (34%) —
+ * it is structurally blind to `de` and `es`, which contribute 590 between them,
+ * and to reworded-ASCII violations in every locale.
+ *
+ * Usage:
+ *   node scripts/check-i18n-fence-parity.js           # fail on violation
+ *   node scripts/check-i18n-fence-parity.js --warn    # report, exit 0
+ *   node scripts/check-i18n-fence-parity.js --all     # include ungated tags
+ *   node scripts/check-i18n-fence-parity.js --json    # machine-readable
+ *   node scripts/check-i18n-fence-parity.js --limit N # cap printed findings
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { resolve, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { assertNotShallow } from './lib/git-freshness.js';
+import { extractFences, buildEnglishFenceHistory, isGated } from './lib/fences.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const I18N_DIR = resolve(ROOT, 'i18n');
+
+const WARN_ONLY = process.argv.includes('--warn');
+const SHOW_ALL = process.argv.includes('--all');
+const AS_JSON = process.argv.includes('--json');
+const limitArg = process.argv.indexOf('--limit');
+const LIMIT = limitArg > -1 ? Number(process.argv[limitArg + 1]) : 40;
+
+function main() {
+  assertNotShallow(ROOT);
+
+  const history = buildEnglishFenceHistory();
+  const findings = [];
+  let filesCompared = 0;
+  let fencesCompared = 0;
+  let ungatedDivergences = 0;
+
+  for (const locale of readdirSync(I18N_DIR)) {
+    const localeSkills = join(I18N_DIR, locale, 'skills');
+    if (!existsSync(localeSkills) || !statSync(localeSkills).isDirectory()) continue;
+
+    for (const skill of readdirSync(localeSkills)) {
+      const translated = join(localeSkills, skill, 'SKILL.md');
+      if (!existsSync(translated)) continue;
+      const englishFences = history.get(skill);
+      if (!englishFences) continue; // orphan: check-i18n-frontmatter-parity.js owns that
+
+      filesCompared++;
+      const relPath = `i18n/${locale}/skills/${skill}/SKILL.md`;
+      for (const fence of extractFences(readFileSync(translated, 'utf8'))) {
+        fencesCompared++;
+        if (englishFences.has(fence.body)) continue;
+        const gated = isGated(fence);
+        if (!gated) { ungatedDivergences++; if (!SHOW_ALL) continue; }
+        findings.push({
+          file: relPath,
+          line: fence.line,
+          locale,
+          skill,
+          tag: fence.lang || '(untagged)',
+          gated,
+          firstDivergentLine: (fence.body.split('\n').find((l) => l.trim() !== '') || '').trim().slice(0, 100),
+        });
+      }
+    }
+  }
+
+  const blocking = findings.filter((f) => f.gated);
+
+  if (AS_JSON) {
+    console.log(JSON.stringify({
+      filesCompared, fencesCompared,
+      violations: blocking.length,
+      ungatedDivergences,
+      findings,
+    }, null, 2));
+    process.exit(blocking.length > 0 && !WARN_ONLY ? 1 : 0);
+  }
+
+  const label = WARN_ONLY ? 'WARN' : 'FAIL';
+  for (const f of findings.slice(0, LIMIT)) {
+    const kind = f.gated ? label : 'INFO';
+    console.log(`${kind} ${f.file}:${f.line} [${f.tag}] ${f.firstDivergentLine}`);
+  }
+  if (findings.length > LIMIT) {
+    console.log(`... ${findings.length - LIMIT} more (use --limit ${findings.length} to see all, or --json)`);
+  }
+
+  const byTag = new Map();
+  for (const f of blocking) byTag.set(f.tag, (byTag.get(f.tag) || 0) + 1);
+  const byLocale = new Map();
+  for (const f of blocking) byLocale.set(f.locale, (byLocale.get(f.locale) || 0) + 1);
+
+  console.log(`\ni18n fence parity: ${fencesCompared} fences in ${filesCompared} translated skills`);
+  console.log(`compared against every historical revision of their English source.`);
+
+  if (blocking.length === 0) {
+    console.log('OK: every gated code fence matches an English source revision.');
+  } else {
+    const files = new Set(blocking.map((f) => f.file)).size;
+    console.log(`\n${blocking.length} gated-fence violation(s) across ${files} file(s).`);
+    console.log(`by tag:    ${[...byTag.entries()].sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join('  ')}`);
+    console.log(`by locale: ${[...byLocale.entries()].sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join('  ')}`);
+    console.log('\nFix: restore the English fence body verbatim. Code blocks are keep-in-English');
+    console.log('(CLAUDE.md § Translation Rules, i18n/README.md). Translate the surrounding prose only.');
+  }
+  if (ungatedDivergences) {
+    console.log(`\n${ungatedDivergences} divergence(s) in ungated tags (text/markdown/untagged) — localising those is allowed.`);
+    if (!SHOW_ALL) console.log('Use --all to list them.');
+  }
+
+  process.exit(blocking.length > 0 && !WARN_ONLY ? 1 : 0);
+}
+
+main();

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -3,10 +3,11 @@
  * check-i18n-fence-parity.js
  *
  * Enforces the keep-code-in-English rule for fenced code blocks in translated
- * skills. `CLAUDE.md` § Translation Rules and `i18n/README.md` both declare code
- * blocks keep-in-English, and `skills/translate-content/SKILL.md` step 5.3 even
- * instructs the translator to "diff the fenced blocks" — but nothing mechanical
- * checked it, and the corpus drifted (#472).
+ * content — skills, agents, teams and guides. `CLAUDE.md` § Translation Rules
+ * and `i18n/README.md` both declare code blocks keep-in-English, and
+ * `skills/translate-content/SKILL.md` step 5.3 even instructs the translator to
+ * "diff the fenced blocks" — but nothing mechanical checked it, and the corpus
+ * drifted (#472).
  *
  * That the rule was stated four times and still violated is the point: every
  * i18n commit in this repo postdates the commit that introduced step 5.3
@@ -15,13 +16,13 @@
  *
  * ## What counts as a violation
  *
- * A fence body in a translated SKILL.md is a violation when it appears in NO
- * revision of that skill's English SKILL.md, ever.
+ * A fence body in a translated file is a violation when it appears in NO
+ * revision of its English counterpart, ever.
  *
  * That basis is chosen to be immune to the two confounds that make the naive
  * comparison unusable:
  *
- *   - **Staleness.** 2,545 translations are stale repo-wide. A stale
+ *   - **Staleness.** 2,549 translations are stale repo-wide. A stale
  *     translation's fence legitimately matches an OLDER English source and
  *     diverges from HEAD without anybody having translated anything. Comparing
  *     against HEAD alone would report those as violations.
@@ -32,27 +33,33 @@
  * Searching the whole history of the English file dodges both: staleness can
  * only ever make a fence match an *earlier* English revision, never a revision
  * that does not exist. So anything this reports was written by a human or an
- * agent and never existed in English. Measured false-positive rate on the
- * corpus at introduction: 2 whitespace-only and 2 cross-skill artifacts out of
- * 1,934 — 0.2%.
+ * agent and never existed in English. Measured false positives on the corpus at
+ * introduction: 1 whitespace-only (under a per-line-trim reading) and 2
+ * cross-skill artifacts out of 2,115 divergences — 0.14%.
  *
  * Consequence, stated deliberately: a fence matching an OLD English revision
  * passes. That is staleness, which is `check-translation-freshness.js`'s job,
- * not this gate's.
+ * not this gate's. The same deliberate choice means a translation that DELETES
+ * a frozen fence is not caught here — see #480, and the comment at the end of
+ * the compare loop for why the obvious fix reintroduces the confound.
  *
  * ## Why not the CJK discriminator
  *
  * #472 proposed flagging fences containing CJK characters absent from English.
- * That is sound but sees only 410 of 1,198 executable-tag violations (34%) —
- * it is structurally blind to `de` and `es`, which contribute 590 between them,
- * and to reworded-ASCII violations in every locale.
+ * That is sound but sees only 457 of 1,307 gated violations (35%) — it is
+ * structurally blind to `de` and `es`, which contribute 648 between them, and
+ * to reworded-ASCII violations in every locale. German is the largest violator
+ * and transliterates umlauts inside fences (`pruefen`, `fuer`, `zaehlen`), so
+ * even a Latin-diacritic test misses most of it.
  *
  * Usage:
- *   node scripts/check-i18n-fence-parity.js           # fail on violation
- *   node scripts/check-i18n-fence-parity.js --warn    # report, exit 0
- *   node scripts/check-i18n-fence-parity.js --all     # include ungated tags
- *   node scripts/check-i18n-fence-parity.js --json    # machine-readable
- *   node scripts/check-i18n-fence-parity.js --limit N # cap printed findings
+ *   node scripts/check-i18n-fence-parity.js                    # fail on violation
+ *   node scripts/check-i18n-fence-parity.js --warn             # report, exit 0
+ *   node scripts/check-i18n-fence-parity.js --all              # include ungated tags
+ *   node scripts/check-i18n-fence-parity.js --json             # machine-readable
+ *   node scripts/check-i18n-fence-parity.js --limit N          # cap printed findings
+ *   node scripts/check-i18n-fence-parity.js --locale de        # one locale
+ *   node scripts/check-i18n-fence-parity.js --locale de --id X # one file
  */
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
@@ -68,8 +75,66 @@ const I18N_DIR = resolve(ROOT, 'i18n');
 const WARN_ONLY = process.argv.includes('--warn');
 const SHOW_ALL = process.argv.includes('--all');
 const AS_JSON = process.argv.includes('--json');
-const limitArg = process.argv.indexOf('--limit');
-const LIMIT = limitArg > -1 ? Number(process.argv[limitArg + 1]) : 40;
+
+/**
+ * Read `--flag value`, rejecting a following flag as the value. Bare
+ * `--limit` with nothing after it used to yield `Number(undefined)` = NaN,
+ * which made `slice(0, NaN)` print no findings AND suppressed the "N more"
+ * hint, so the run looked clean.
+ */
+function flagValue(name, fallback) {
+  const i = process.argv.indexOf(name);
+  if (i < 0) return fallback;
+  const v = process.argv[i + 1];
+  if (v === undefined || v.startsWith('--')) {
+    console.error(`ERROR: ${name} requires a value`);
+    process.exit(2);
+  }
+  return v;
+}
+
+const LIMIT = Number(flagValue('--limit', '40'));
+if (!Number.isFinite(LIMIT)) { console.error('ERROR: --limit must be a number'); process.exit(2); }
+const ONLY_LOCALE = flagValue('--locale', null);
+const ONLY_ID = flagValue('--id', null);
+
+/**
+ * Translated content trees this gate covers. `skills` is where the corpus and
+ * the violations are, but the rule as written in CLAUDE.md and i18n/README.md
+ * says "any translated file" — and the mirrors carry 168 gated fences that a
+ * skills-only walk never opens. Covering them is what makes the documented rule
+ * true.
+ */
+const TREES = [
+  { dir: 'skills', nested: true },   // i18n/<loc>/skills/<id>/SKILL.md
+  { dir: 'agents', nested: false },  // i18n/<loc>/agents/<id>.md
+  { dir: 'teams', nested: false },
+  { dir: 'guides', nested: false },
+];
+
+/** Every translated file to compare, as { relPath, absPath, locale, id, tree }. */
+function collectTargets() {
+  const out = [];
+  for (const locale of readdirSync(I18N_DIR)) {
+    if (ONLY_LOCALE && locale !== ONLY_LOCALE) continue;
+    for (const { dir, nested } of TREES) {
+      const base = join(I18N_DIR, locale, dir);
+      if (!existsSync(base) || !statSync(base).isDirectory()) continue;
+      for (const entry of readdirSync(base)) {
+        const id = nested ? entry : entry.replace(/\.md$/, '');
+        if (ONLY_ID && id !== ONLY_ID) continue;
+        const absPath = nested ? join(base, entry, 'SKILL.md') : join(base, entry);
+        if (!nested && !entry.endsWith('.md')) continue;
+        if (!existsSync(absPath) || !statSync(absPath).isFile()) continue;
+        out.push({
+          absPath, locale, id, tree: dir,
+          relPath: `i18n/${locale}/${dir}/${nested ? `${entry}/SKILL.md` : entry}`,
+        });
+      }
+    }
+  }
+  return out;
+}
 
 function main() {
   assertNotShallow(ROOT);
@@ -80,46 +145,54 @@ function main() {
   let fencesCompared = 0;
   let ungatedDivergences = 0;
 
-  for (const locale of readdirSync(I18N_DIR)) {
-    const localeSkills = join(I18N_DIR, locale, 'skills');
-    if (!existsSync(localeSkills) || !statSync(localeSkills).isDirectory()) continue;
+  for (const t of collectTargets()) {
+    const englishFences = history.get(`${t.tree}/${t.id}`);
+    if (!englishFences) continue; // orphan: check-i18n-frontmatter-parity.js owns that
 
-    for (const skill of readdirSync(localeSkills)) {
-      const translated = join(localeSkills, skill, 'SKILL.md');
-      if (!existsSync(translated)) continue;
-      const englishFences = history.get(skill);
-      if (!englishFences) continue; // orphan: check-i18n-frontmatter-parity.js owns that
-
-      filesCompared++;
-      const relPath = `i18n/${locale}/skills/${skill}/SKILL.md`;
-      for (const fence of extractFences(readFileSync(translated, 'utf8'))) {
-        fencesCompared++;
-        if (englishFences.has(fence.body)) continue;
-        const gated = isGated(fence);
-        if (!gated) { ungatedDivergences++; if (!SHOW_ALL) continue; }
-        findings.push({
-          file: relPath,
-          line: fence.line,
-          locale,
-          skill,
-          tag: fence.lang || '(untagged)',
-          gated,
-          firstDivergentLine: (fence.body.split('\n').find((l) => l.trim() !== '') || '').trim().slice(0, 100),
-        });
-      }
+    filesCompared++;
+    for (const fence of extractFences(readFileSync(t.absPath, 'utf8'))) {
+      fencesCompared++;
+      if (englishFences.has(fence.body)) continue;
+      const gated = isGated(fence);
+      if (!gated) { ungatedDivergences++; if (!SHOW_ALL) continue; }
+      findings.push({
+        file: t.relPath,
+        line: fence.line,
+        locale: t.locale,
+        skill: t.id,
+        tag: fence.lang || '(untagged)',
+        gated,
+        kind: 'diverged',
+        firstDivergentLine: (fence.body.split('\n').find((l) => l.trim() !== '') || '').trim().slice(0, 100),
+      });
     }
+
+    // A translation that DELETES a frozen fence outright contributes nothing to
+    // the loop above, so it reports clean. That gap is real and tracked in #480
+    // — but it is NOT fixable by comparing against current English, which is
+    // what a first attempt did here. A stale translation legitimately lacks
+    // fences English gained after it was written, so that comparison
+    // reintroduces exactly the staleness confound this gate exists to avoid:
+    // measured, it produced 1,518 findings across 402 files, topped by four
+    // `quick-reference.md` mirrors that `check-translation-freshness.js`
+    // independently reports as stale. Any fix must be staleness-immune the way
+    // the divergence check is.
   }
 
   const blocking = findings.filter((f) => f.gated);
 
   if (AS_JSON) {
+    // process.exit() discards writes still queued on an async pipe, which
+    // truncated this payload to 65,536 bytes whenever stdout was piped rather
+    // than redirected — the exact consumer this mode exists for.
     console.log(JSON.stringify({
       filesCompared, fencesCompared,
       violations: blocking.length,
       ungatedDivergences,
       findings,
     }, null, 2));
-    process.exit(blocking.length > 0 && !WARN_ONLY ? 1 : 0);
+    process.exitCode = blocking.length > 0 && !WARN_ONLY ? 1 : 0;
+    return;
   }
 
   const label = WARN_ONLY ? 'WARN' : 'FAIL';
@@ -150,7 +223,9 @@ function main() {
     console.log('(CLAUDE.md § Translation Rules, i18n/README.md). Translate the surrounding prose only.');
   }
   if (ungatedDivergences) {
-    console.log(`\n${ungatedDivergences} divergence(s) in ungated tags (text/markdown/untagged) — localising those is allowed.`);
+    // Deliberately does NOT say "untagged": untagged fences are frozen under
+    // default-deny, so an untagged divergence prints FAIL and is counted above.
+    console.log(`\n${ungatedDivergences} divergence(s) in localisable tags (text/markdown/md) — localising those is allowed.`);
     if (!SHOW_ALL) console.log('Use --all to list them.');
   }
 

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -1,0 +1,213 @@
+/**
+ * fences.js
+ *
+ * Shared fenced-code-block extractor for the i18n fence-parity tooling (#472).
+ * Used by `check-i18n-fence-parity.js` (which reports) and
+ * `normalize-i18n-fences.js` (which rewrites), so the two can never disagree
+ * about where a fence starts and ends.
+ *
+ * Two properties are load-bearing:
+ *
+ * 1. **CRLF is normalised before parsing.** 69 translated SKILL.md carry CRLF
+ *    in the working tree while the committed blob is LF — `*.md text eol=lf`
+ *    normalises on the way into the index, not on disk. In a JavaScript regex
+ *    `\r` is a LineTerminator, so `.` does not match it and an unanchored `$`
+ *    will not match before it. An extractor written the obvious way
+ *    (`/^\s*```(\w*)\s*$/` happens to survive; `/^(\s*)(`{3,})(.*)$/` does not)
+ *    silently finds ZERO fences in those files and reports them clean. A gate
+ *    blind to 69 files is not a gate.
+ *
+ * 2. **The opening delimiter's run length and character are tracked.** A fence
+ *    opened with four backticks may legally contain three-backtick fences —
+ *    the skills corpus does this when documenting markdown itself. Closing on
+ *    the first ``` would splice two blocks together and invent divergences.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { resolve, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { execFileSync, spawnSync } from 'child_process';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SKILLS_DIR = join(ROOT, 'skills');
+const GIT_BUFFER = 2048 * 1024 * 1024;
+
+/**
+ * Fence info-string tags whose content must match the English source
+ * byte-for-byte. These are the tags a reader copies and runs, or that an agent
+ * executes as part of a procedure: localising them yields code that is wrong in
+ * the target language's terms while looking authoritative.
+ *
+ * Tags NOT listed here (text, markdown, untagged, ...) may be localised — they
+ * carry illustrative output, tables and templates, where the reader is served
+ * by their own language.
+ *
+ * Single source of truth for both the checker and the normalizer. A second copy
+ * would drift, and the two disagreeing means the repair tool rewrites fences the
+ * gate does not flag, or leaves flagged ones alone.
+ */
+export const GATED_TAGS = new Set([
+  'bash', 'sh', 'shell', 'zsh', 'console',
+  'javascript', 'js', 'mjs', 'cjs', 'jsx', 'typescript', 'ts', 'tsx',
+  'python', 'py', 'r', 'ruby', 'rb', 'perl', 'php', 'lua',
+  'go', 'rust', 'rs', 'java', 'kotlin', 'c', 'cpp', 'csharp', 'swift',
+  'json', 'yaml', 'yml', 'toml', 'xml', 'ini', 'sql', 'graphql',
+  'dockerfile', 'docker', 'nginx', 'apache', 'terraform', 'hcl',
+  'html', 'css', 'scss', 'sass',
+  'diff', 'patch', 'makefile', 'cmake', 'gitignore', 'protobuf', 'proto',
+  'gotmpl', 'promql', 'latex', 'tex',
+]);
+
+export const isGated = (fence) => GATED_TAGS.has(fence.lang);
+
+/**
+ * Union of every fence body that has ever appeared in each English SKILL.md,
+ * keyed by skill id, plus the current working tree.
+ *
+ * This is the violation basis: a translated fence body absent from this set
+ * appears in no English revision, ever, so it cannot be explained by staleness
+ * (which can only make a fence match an EARLIER revision) nor by a
+ * `source_commit` bumped without retranslation (#405).
+ *
+ * Costs two git processes rather than one per revision.
+ * @returns {Map<string, Set<string>>}
+ */
+export function buildEnglishFenceHistory() {
+  const log = execFileSync(
+    'git', ['log', '--format=%x00%H', '--name-only', '--', 'skills'],
+    { cwd: ROOT, encoding: 'utf8', maxBuffer: GIT_BUFFER },
+  );
+
+  const specs = [];
+  const seen = new Set();
+  let commit = null;
+  for (const line of log.split('\n')) {
+    if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
+    if (!line || !commit || !line.endsWith('SKILL.md')) continue;
+    const spec = `${commit}:${line}`;
+    if (seen.has(spec)) continue;
+    seen.add(spec);
+    specs.push(spec);
+  }
+
+  const history = new Map();
+  const add = (skill, text) => {
+    if (!history.has(skill)) history.set(skill, new Set());
+    const set = history.get(skill);
+    for (const f of extractFences(text)) set.add(f.body);
+  };
+
+  if (specs.length) {
+    const batch = spawnSync('git', ['cat-file', '--batch'], {
+      cwd: ROOT,
+      input: Buffer.from(specs.join('\n') + '\n', 'utf8'),
+      maxBuffer: GIT_BUFFER,
+    });
+    if (batch.status !== 0) {
+      console.error('ERROR: git cat-file --batch failed');
+      console.error(batch.stderr?.toString().slice(0, 500));
+      process.exit(1);
+    }
+    const buf = batch.stdout;
+    let offset = 0;
+    let index = 0;
+    while (offset < buf.length && index < specs.length) {
+      const nl = buf.indexOf(0x0a, offset);
+      if (nl < 0) break;
+      const header = buf.slice(offset, nl).toString('utf8');
+      offset = nl + 1;
+      if (/ (missing|ambiguous)$/.test(header)) { index++; continue; }
+      const size = Number.parseInt(header.split(' ')[2], 10);
+      if (!Number.isFinite(size)) break;
+      add(specs[index].split(':')[1].split('/')[1], buf.slice(offset, offset + size).toString('utf8'));
+      offset += size + 1;
+      index++;
+    }
+  }
+
+  // An uncommitted English edit is a legal basis too.
+  for (const skill of readdirSync(SKILLS_DIR)) {
+    if (skill.startsWith('_')) continue;
+    const p = join(SKILLS_DIR, skill, 'SKILL.md');
+    if (existsSync(p)) add(skill, readFileSync(p, 'utf8'));
+  }
+
+  return history;
+}
+
+/**
+ * @typedef {object} Fence
+ * @property {string} lang      lowercased first token of the info string ('' when untagged)
+ * @property {string} info      the full info string, trimmed
+ * @property {string} body      fence content, LF-joined, delimiters excluded
+ * @property {number} line      1-based line number of the opening delimiter
+ * @property {number} bodyStart 0-based index of the first body line in `lines`
+ * @property {number} bodyEnd   0-based index one past the last body line
+ * @property {boolean} [unterminated] set when EOF arrived before a closing delimiter
+ */
+
+/** Split text into lines with CRLF (and lone CR) normalised to LF. */
+export function toLines(text) {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+}
+
+/**
+ * Extract every fenced block from `text`.
+ * @param {string} text
+ * @returns {Fence[]}
+ */
+export function extractFences(text) {
+  const lines = toLines(text);
+  const out = [];
+  let open = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = /^(\s*)(`{3,}|~{3,})([^\n]*)$/.exec(lines[i]);
+
+    if (open === null) {
+      if (match) {
+        const info = match[3].trim();
+        open = {
+          delim: match[2][0],
+          len: match[2].length,
+          info,
+          lang: (info.split(/[\s{,]/)[0] || '').replace(/[{}]/g, '').toLowerCase(),
+          line: i + 1,
+          bodyStart: i + 1,
+        };
+      }
+      continue;
+    }
+
+    const closes = match
+      && match[2][0] === open.delim
+      && match[2].length >= open.len
+      && match[3].trim() === '';
+
+    if (closes) {
+      out.push({
+        lang: open.lang,
+        info: open.info,
+        body: lines.slice(open.bodyStart, i).join('\n'),
+        line: open.line,
+        bodyStart: open.bodyStart,
+        bodyEnd: i,
+      });
+      open = null;
+    }
+  }
+
+  if (open !== null) {
+    out.push({
+      lang: open.lang,
+      info: open.info,
+      body: lines.slice(open.bodyStart).join('\n'),
+      line: open.line,
+      bodyStart: open.bodyStart,
+      bodyEnd: lines.length,
+      unterminated: true,
+    });
+  }
+
+  return out;
+}

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -33,32 +33,39 @@ const SKILLS_DIR = join(ROOT, 'skills');
 const GIT_BUFFER = 2048 * 1024 * 1024;
 
 /**
- * Fence info-string tags whose content must match the English source
- * byte-for-byte. These are the tags a reader copies and runs, or that an agent
- * executes as part of a procedure: localising them yields code that is wrong in
- * the target language's terms while looking authoritative.
+ * The ONLY fence info-string tags a translation may localise. Everything else
+ * is frozen — its body must match the English source byte-for-byte.
  *
- * Tags NOT listed here (text, markdown, untagged, ...) may be localised — they
- * carry illustrative output, tables and templates, where the reader is served
- * by their own language.
+ * The polarity is deliberate and is the whole design. An allowlist of "code"
+ * tags has to enumerate every language the corpus will ever use, and anything
+ * it forgets is unguarded by default. This corpus already carries `logql` (50
+ * fences), `bibtex` (20), `jsonl` (10), `traceql` (10), `powershell` (10) and
+ * `language` (10) — all of which a hand-written code list misses, all currently
+ * at zero violations, so closing the hole costs nothing today and everything
+ * later. Worse, an allowlist makes the gate's scope editable by the person
+ * being gated: retag a ```yaml fence to ```text and it stops being checked.
+ *
+ * `text` and `markdown` are exempt because they carry reference tables,
+ * decision flows and report templates that a human reads or fills in — a German
+ * reviewer should be able to emit a German report. Byte parity on `markdown`
+ * would fire 268 times to catch 3 real defects and would forbid the thing the
+ * locale exists for.
+ *
+ * Untagged fences are frozen, not exempt. Measured cost: zero — there are no
+ * untagged fence openers in either tree, because `guides/content-styleguide.md`
+ * already requires a tag. The remedy for a future one is to tag the English
+ * source.
+ *
+ * Adding a tag here requires naming which machine consumes that fence.
  *
  * Single source of truth for both the checker and the normalizer. A second copy
  * would drift, and the two disagreeing means the repair tool rewrites fences the
  * gate does not flag, or leaves flagged ones alone.
  */
-export const GATED_TAGS = new Set([
-  'bash', 'sh', 'shell', 'zsh', 'console',
-  'javascript', 'js', 'mjs', 'cjs', 'jsx', 'typescript', 'ts', 'tsx',
-  'python', 'py', 'r', 'ruby', 'rb', 'perl', 'php', 'lua',
-  'go', 'rust', 'rs', 'java', 'kotlin', 'c', 'cpp', 'csharp', 'swift',
-  'json', 'yaml', 'yml', 'toml', 'xml', 'ini', 'sql', 'graphql',
-  'dockerfile', 'docker', 'nginx', 'apache', 'terraform', 'hcl',
-  'html', 'css', 'scss', 'sass',
-  'diff', 'patch', 'makefile', 'cmake', 'gitignore', 'protobuf', 'proto',
-  'gotmpl', 'promql', 'latex', 'tex',
-]);
+export const LOCALISABLE_TAGS = new Set(['text', 'markdown', 'md']);
 
-export const isGated = (fence) => GATED_TAGS.has(fence.lang);
+/** True when a fence's body must match an English revision byte-for-byte. */
+export const isGated = (fence) => !LOCALISABLE_TAGS.has(fence.lang);
 
 /**
  * Union of every fence body that has ever appeared in each English SKILL.md,

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -8,7 +8,7 @@
  *
  * Two properties are load-bearing:
  *
- * 1. **CRLF is normalised before parsing.** 69 translated SKILL.md carry CRLF
+ * 1. **CRLF is normalised before parsing.** 68 translated SKILL.md carry CRLF
  *    in the working tree while the committed blob is LF — `*.md text eol=lf`
  *    normalises on the way into the index, not on disk. In a JavaScript regex
  *    `\r` is a LineTerminator, so `.` does not match it and an unanchored `$`
@@ -23,13 +23,12 @@
  *    the first ``` would splice two blocks together and invent divergences.
  */
 
-import { readFileSync, readdirSync, existsSync } from 'fs';
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { execFileSync, spawnSync } from 'child_process';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const SKILLS_DIR = join(ROOT, 'skills');
 const GIT_BUFFER = 2048 * 1024 * 1024;
 
 /**
@@ -40,10 +39,13 @@ const GIT_BUFFER = 2048 * 1024 * 1024;
  * tags has to enumerate every language the corpus will ever use, and anything
  * it forgets is unguarded by default. This corpus already carries `logql` (50
  * fences), `bibtex` (20), `jsonl` (10), `traceql` (10), `powershell` (10) and
- * `language` (10) — all of which a hand-written code list misses, all currently
- * at zero violations, so closing the hole costs nothing today and everything
- * later. Worse, an allowlist makes the gate's scope editable by the person
- * being gated: retag a ```yaml fence to ```text and it stops being checked.
+ * `language` (10) — all of which a hand-written code list misses. All but
+ * `language` are at zero violations today (`language` has one), so closing the
+ * hole costs one finding now and an unbounded number later. It also NARROWS the
+ * retag escape hatch: because the tag is read off the translated file and never
+ * compared to English, retagging a ```yaml fence still removes it from the gate
+ * — default-deny shrinks the escape set from unbounded to {text, markdown, md}
+ * rather than closing it. Closing it needs tag-sequence parity (#481).
  *
  * `text` and `markdown` are exempt because they carry reference tables,
  * decision flows and report templates that a human reads or fills in — a German
@@ -67,6 +69,31 @@ export const LOCALISABLE_TAGS = new Set(['text', 'markdown', 'md']);
 /** True when a fence's body must match an English revision byte-for-byte. */
 export const isGated = (fence) => !LOCALISABLE_TAGS.has(fence.lang);
 
+/** English content trees that have translated mirrors under `i18n/<locale>/`. */
+export const TREES = ['skills', 'agents', 'teams', 'guides'];
+
+/**
+ * Repo-relative English content path -> stable `<tree>/<id>` key, or null when
+ * the path is not translatable content.
+ *
+ * Uses the second-to-last segment for `SKILL.md` so that pre-flatten historical
+ * paths (`skills/<domain>/<id>/SKILL.md`, ~42% of the blobs in history) key to
+ * the same id as today's `skills/<id>/SKILL.md`.
+ */
+export function contentKey(relPath) {
+  const parts = relPath.split('/');
+  if (parts.length < 2 || !TREES.includes(parts[0])) return null;
+  if (parts[parts.length - 1] === 'SKILL.md') {
+    return parts.length >= 3 ? `${parts[0]}/${parts[parts.length - 2]}` : null;
+  }
+  if (parts.length === 2 && parts[1].endsWith('.md')) {
+    const id = parts[1].slice(0, -3);
+    if (id.startsWith('_') || id === 'README') return null;
+    return `${parts[0]}/${id}`;
+  }
+  return null;
+}
+
 /**
  * Union of every fence body that has ever appeared in each English SKILL.md,
  * keyed by skill id, plus the current working tree.
@@ -81,7 +108,7 @@ export const isGated = (fence) => !LOCALISABLE_TAGS.has(fence.lang);
  */
 export function buildEnglishFenceHistory() {
   const log = execFileSync(
-    'git', ['log', '--format=%x00%H', '--name-only', '--', 'skills'],
+    'git', ['log', '--format=%x00%H', '--name-only', '--', ...TREES],
     { cwd: ROOT, encoding: 'utf8', maxBuffer: GIT_BUFFER },
   );
 
@@ -90,7 +117,7 @@ export function buildEnglishFenceHistory() {
   let commit = null;
   for (const line of log.split('\n')) {
     if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
-    if (!line || !commit || !line.endsWith('SKILL.md')) continue;
+    if (!line || !commit || contentKey(line) === null) continue;
     const spec = `${commit}:${line}`;
     if (seen.has(spec)) continue;
     seen.add(spec);
@@ -98,9 +125,10 @@ export function buildEnglishFenceHistory() {
   }
 
   const history = new Map();
-  const add = (skill, text) => {
-    if (!history.has(skill)) history.set(skill, new Set());
-    const set = history.get(skill);
+  const add = (key, text) => {
+    if (key === null) return;
+    if (!history.has(key)) history.set(key, new Set());
+    const set = history.get(key);
     for (const f of extractFences(text)) set.add(f.body);
   };
 
@@ -126,19 +154,35 @@ export function buildEnglishFenceHistory() {
       if (/ (missing|ambiguous)$/.test(header)) { index++; continue; }
       const size = Number.parseInt(header.split(' ')[2], 10);
       if (!Number.isFinite(size)) break;
-      add(specs[index].split(':')[1].split('/')[1], buf.slice(offset, offset + size).toString('utf8'));
+      add(contentKey(specs[index].slice(specs[index].indexOf(':') + 1)),
+        buf.slice(offset, offset + size).toString('utf8'));
       offset += size + 1;
       index++;
     }
   }
 
-  // An uncommitted English edit is a legal basis too.
-  for (const skill of readdirSync(SKILLS_DIR)) {
-    if (skill.startsWith('_')) continue;
-    const p = join(SKILLS_DIR, skill, 'SKILL.md');
-    if (existsSync(p)) add(skill, readFileSync(p, 'utf8'));
+  // An uncommitted English edit is a legal basis too. The working tree is also
+  // kept separately as `history.current`, keyed the same way: the deleted-fence
+  // check needs the fences English has NOW, with their tags, not the flattened
+  // union of every body that ever existed.
+  const current = new Map();
+  for (const tree of TREES) {
+    const base = join(ROOT, tree);
+    if (!existsSync(base)) continue;
+    for (const entry of readdirSync(base)) {
+      if (entry.startsWith('_')) continue;
+      const p = tree === 'skills' ? join(base, entry, 'SKILL.md') : join(base, entry);
+      if (!existsSync(p) || !statSync(p).isFile()) continue;
+      const rel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
+      const key = contentKey(rel);
+      if (key === null) continue;
+      const text = readFileSync(p, 'utf8');
+      add(key, text);
+      current.set(key, extractFences(text));
+    }
   }
 
+  history.current = current;
   return history;
 }
 

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -14,7 +14,7 @@
  * By default the translation's own `source_commit` — the English revision it
  * was actually translated from — NOT English at HEAD.
  *
- * That is deliberate. 2,545 translations are stale: their prose describes an
+ * That is deliberate. 2,549 translations are stale: their prose describes an
  * older English source. Splicing HEAD's code into a file whose prose predates
  * it produces a document that is internally inconsistent — prose describing one
  * command sitting above a different command — and it silently entangles this
@@ -32,9 +32,14 @@
  * A fence is only rewritten when the translated file and its English basis
  * carry the SAME number of fences in the SAME language-tag sequence. Then
  * ordinal mapping is sound: the nth fence corresponds to the nth fence.
- * Otherwise the file is skipped and reported for manual repair — 50 of the 327
- * affected files at introduction, mostly translations that dropped or merged
- * blocks outright, which no positional rule can safely reconstruct.
+ * Otherwise the file is skipped and reported for manual repair — 46 of the 327
+ * affected skills at introduction (41 by fence count, 5 by tag sequence),
+ * mostly translations that dropped or merged blocks outright, which no
+ * positional rule can safely reconstruct. Those 46 carry 206 fences and are
+ * tracked as content forks in #478.
+ *
+ * Scope: skills only. The checker also covers the agents/teams/guides mirrors,
+ * whose 87 gated violations this tool does not yet repair (#477).
  *
  * Usage:
  *   node scripts/normalize-i18n-fences.js --dry          # preview only
@@ -57,11 +62,26 @@ const SKILLS_DIR = resolve(ROOT, 'skills');
 
 const argv = process.argv.slice(2);
 const DRY = argv.includes('--dry');
-const flagValue = (name) => {
+
+/**
+ * Read `--flag value`, rejecting a following flag as the value. The naive
+ * `argv[i + 1]` version silently accepted `--locale --dry` as locale `"--dry"`,
+ * which matched no locale and reported "files to change: 0" — a clean-looking
+ * no-op. It also let a trailing `--basis` fall back to the default,
+ * short-circuiting the validation immediately below it.
+ */
+function flagValue(name, fallback = null) {
   const i = argv.indexOf(name);
-  return i >= 0 ? argv[i + 1] : null;
-};
-const BASIS = flagValue('--basis') || 'source-commit';
+  if (i < 0) return fallback;
+  const v = argv[i + 1];
+  if (v === undefined || v.startsWith('--')) {
+    console.error(`ERROR: ${name} requires a value`);
+    process.exit(2);
+  }
+  return v;
+}
+
+const BASIS = flagValue('--basis', 'source-commit');
 const ONLY_LOCALE = flagValue('--locale');
 
 if (!['source-commit', 'head'].includes(BASIS)) {
@@ -158,13 +178,20 @@ for (const t of targets) {
 
   const translatedFences = extractFences(t.text);
   const basisFences = extractFences(basisText);
-  const everEnglish = history.get(t.skill);
+  // Keys are `<tree>/<id>` (see lib/fences.js contentKey). A bare `t.skill`
+  // lookup returns undefined for every file, which the `everEnglish &&` guard
+  // below silently turns into "nothing to repair" — a clean-looking zero.
+  const everEnglish = history.get(`skills/${t.skill}`);
+  if (!everEnglish) {
+    skipped.push({ file: t.relPath, reason: 'no English history for this id', n: 0 });
+    continue;
+  }
 
   // Restore exactly what the gate flags: a gated fence whose body appears in no
   // English revision. Using the same predicate as the checker is what keeps the
   // two tools from disagreeing — an ordinal-only test would rewrite fences the
   // gate considers legitimately stale.
-  const divergent = translatedFences.filter((f) => isGated(f) && everEnglish && !everEnglish.has(f.body));
+  const divergent = translatedFences.filter((f) => isGated(f) && !everEnglish.has(f.body));
   if (divergent.length === 0) continue;
 
   if (translatedFences.length !== basisFences.length) {
@@ -172,13 +199,23 @@ for (const t of targets) {
     continue;
   }
 
-  // Ordinal mapping is sound when gated-ness corresponds at every position and
-  // gated tags match. A `text` fence facing an untagged one is NOT a
-  // divergence: `normalize-content-style.js --mode fences` adds `text` tags to
-  // untagged blocks, so that pairing is an artifact of a known repo tool. Both
-  // sides are ungated, so neither is rewritten either way.
+  // Ordinal mapping is sound when the tag at every position corresponds.
+  //
+  // A `text` fence facing an untagged one is NOT a divergence:
+  // `normalize-content-style.js --mode fences` retro-tagged untagged blocks as
+  // `text`, so that pairing is an artifact of a known repo tool acting on the
+  // newer side only. `alignmentTag` folds the two together.
+  //
+  // This must NOT be expressed as `isGated(a) !== isGated(b)`. Under default-deny
+  // an untagged fence is gated while `text` is not, so that formulation makes
+  // every one of those benign pairings a misalignment — it stranded 169
+  // mechanically-repairable fences across 73 files between the two commits of
+  // this PR, while the comment above it still described the pre-inversion
+  // behaviour. Alignment is a question about ordinal correspondence, not about
+  // what the gate covers.
+  const alignmentTag = (f) => (f.lang === '' ? 'text' : f.lang);
   const misaligned = translatedFences.findIndex(
-    (f, i) => isGated(f) !== isGated(basisFences[i]) || (isGated(f) && f.lang !== basisFences[i].lang),
+    (f, i) => alignmentTag(f) !== alignmentTag(basisFences[i]),
   );
   if (misaligned >= 0) {
     const a = translatedFences[misaligned].lang || 'untagged';

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * normalize-i18n-fences.js
+ *
+ * Companion repair tool to `check-i18n-fence-parity.js` (#472). Restores the
+ * English body of gated code fences in translated skills, which the
+ * keep-code-in-English rule requires them to carry verbatim.
+ *
+ * Shares `lib/fences.js` with the checker, so the two can never disagree about
+ * where a fence begins or ends.
+ *
+ * ## Which English revision is restored
+ *
+ * By default the translation's own `source_commit` — the English revision it
+ * was actually translated from — NOT English at HEAD.
+ *
+ * That is deliberate. 2,545 translations are stale: their prose describes an
+ * older English source. Splicing HEAD's code into a file whose prose predates
+ * it produces a document that is internally inconsistent — prose describing one
+ * command sitting above a different command — and it silently entangles this
+ * parity repair with the separate staleness backlog (#278). Restoring the
+ * source_commit body leaves each file coherent, satisfies the parity gate
+ * (which accepts any historical English revision), and leaves
+ * `check-translation-freshness.js` free to keep reporting the file as stale,
+ * which it still is.
+ *
+ * Pass `--basis head` to restore from English at HEAD instead. That is the
+ * right choice only when refreshing the translation's prose in the same pass.
+ *
+ * ## What it refuses to touch
+ *
+ * A fence is only rewritten when the translated file and its English basis
+ * carry the SAME number of fences in the SAME language-tag sequence. Then
+ * ordinal mapping is sound: the nth fence corresponds to the nth fence.
+ * Otherwise the file is skipped and reported for manual repair — 50 of the 327
+ * affected files at introduction, mostly translations that dropped or merged
+ * blocks outright, which no positional rule can safely reconstruct.
+ *
+ * Usage:
+ *   node scripts/normalize-i18n-fences.js --dry          # preview only
+ *   node scripts/normalize-i18n-fences.js                # write
+ *   node scripts/normalize-i18n-fences.js --basis head
+ *   node scripts/normalize-i18n-fences.js --locale de    # restrict
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { resolve, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+import { extractFences, toLines, isGated, buildEnglishFenceHistory } from './lib/fences.js';
+import { assertNotShallow } from './lib/git-freshness.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const I18N_DIR = resolve(ROOT, 'i18n');
+const SKILLS_DIR = resolve(ROOT, 'skills');
+
+const argv = process.argv.slice(2);
+const DRY = argv.includes('--dry');
+const flagValue = (name) => {
+  const i = argv.indexOf(name);
+  return i >= 0 ? argv[i + 1] : null;
+};
+const BASIS = flagValue('--basis') || 'source-commit';
+const ONLY_LOCALE = flagValue('--locale');
+
+if (!['source-commit', 'head'].includes(BASIS)) {
+  console.error(`ERROR: --basis must be 'source-commit' or 'head' (got '${BASIS}')`);
+  process.exit(2);
+}
+
+const GIT_BUFFER = 512 * 1024 * 1024;
+
+function frontmatterField(text, field) {
+  const fm = text.replace(/\r\n/g, '\n').match(/^---\n([\s\S]*?)\n---(\n|$)/);
+  if (!fm) return null;
+  const m = new RegExp(`^\\s*${field}:\\s*(\\S.*)$`, 'm').exec(fm[1]);
+  if (!m) return null;
+  // A few source_commit values carry a trailing YAML comment.
+  return m[1].replace(/\s+#.*$/, '').trim().replace(/^["']|["']$/g, '');
+}
+
+/** Batch-resolve `<commit>:skills/<id>/SKILL.md` blobs in one git process. */
+function readBlobs(specs) {
+  const out = new Map();
+  if (!specs.length) return out;
+  const batch = spawnSync('git', ['cat-file', '--batch'], {
+    cwd: ROOT,
+    input: Buffer.from(specs.join('\n') + '\n', 'utf8'),
+    maxBuffer: GIT_BUFFER,
+  });
+  if (batch.status !== 0) {
+    console.error('ERROR: git cat-file --batch failed');
+    console.error(batch.stderr?.toString().slice(0, 500));
+    process.exit(1);
+  }
+  const buf = batch.stdout;
+  let offset = 0;
+  let index = 0;
+  while (offset < buf.length && index < specs.length) {
+    const nl = buf.indexOf(0x0a, offset);
+    if (nl < 0) break;
+    const header = buf.slice(offset, nl).toString('utf8');
+    offset = nl + 1;
+    if (/ (missing|ambiguous)$/.test(header)) { out.set(specs[index], null); index++; continue; }
+    const size = Number.parseInt(header.split(' ')[2], 10);
+    if (!Number.isFinite(size)) break;
+    out.set(specs[index], buf.slice(offset, offset + size).toString('utf8'));
+    offset += size + 1;
+    index++;
+  }
+  return out;
+}
+
+assertNotShallow(ROOT);
+const history = buildEnglishFenceHistory();
+
+// ---- gather targets ----
+const targets = [];
+for (const locale of readdirSync(I18N_DIR)) {
+  if (ONLY_LOCALE && locale !== ONLY_LOCALE) continue;
+  const localeSkills = join(I18N_DIR, locale, 'skills');
+  if (!existsSync(localeSkills) || !statSync(localeSkills).isDirectory()) continue;
+  for (const skill of readdirSync(localeSkills)) {
+    const translated = join(localeSkills, skill, 'SKILL.md');
+    const english = join(SKILLS_DIR, skill, 'SKILL.md');
+    if (!existsSync(translated) || !existsSync(english)) continue;
+    const text = readFileSync(translated, 'utf8');
+    targets.push({
+      locale, skill, path: translated, english,
+      relPath: `i18n/${locale}/skills/${skill}/SKILL.md`,
+      text,
+      sourceCommit: frontmatterField(text, 'source_commit'),
+    });
+  }
+}
+
+// ---- resolve each target's English basis ----
+const specs = BASIS === 'source-commit'
+  ? [...new Set(targets.filter((t) => t.sourceCommit)
+      .map((t) => `${t.sourceCommit}:skills/${t.skill}/SKILL.md`))]
+  : [];
+const blobs = readBlobs(specs);
+
+let filesChanged = 0;
+let fencesRestored = 0;
+const skipped = [];
+const changedByLocale = new Map();
+
+for (const t of targets) {
+  let basisText = null;
+  let basisLabel = 'head';
+  if (BASIS === 'source-commit' && t.sourceCommit) {
+    basisText = blobs.get(`${t.sourceCommit}:skills/${t.skill}/SKILL.md`) ?? null;
+    basisLabel = t.sourceCommit;
+  }
+  if (basisText === null) { basisText = readFileSync(t.english, 'utf8'); basisLabel = 'head'; }
+
+  const translatedFences = extractFences(t.text);
+  const basisFences = extractFences(basisText);
+  const everEnglish = history.get(t.skill);
+
+  // Restore exactly what the gate flags: a gated fence whose body appears in no
+  // English revision. Using the same predicate as the checker is what keeps the
+  // two tools from disagreeing — an ordinal-only test would rewrite fences the
+  // gate considers legitimately stale.
+  const divergent = translatedFences.filter((f) => isGated(f) && everEnglish && !everEnglish.has(f.body));
+  if (divergent.length === 0) continue;
+
+  if (translatedFences.length !== basisFences.length) {
+    skipped.push({ file: t.relPath, reason: `fence count ${translatedFences.length} vs basis ${basisFences.length}`, n: divergent.length });
+    continue;
+  }
+
+  // Ordinal mapping is sound when gated-ness corresponds at every position and
+  // gated tags match. A `text` fence facing an untagged one is NOT a
+  // divergence: `normalize-content-style.js --mode fences` adds `text` tags to
+  // untagged blocks, so that pairing is an artifact of a known repo tool. Both
+  // sides are ungated, so neither is rewritten either way.
+  const misaligned = translatedFences.findIndex(
+    (f, i) => isGated(f) !== isGated(basisFences[i]) || (isGated(f) && f.lang !== basisFences[i].lang),
+  );
+  if (misaligned >= 0) {
+    const a = translatedFences[misaligned].lang || 'untagged';
+    const b = basisFences[misaligned].lang || 'untagged';
+    skipped.push({ file: t.relPath, reason: `tag sequence diverges at fence ${misaligned + 1} (${a} vs ${b})`, n: divergent.length });
+    continue;
+  }
+
+  // Splice from the bottom so earlier indices stay valid.
+  const lines = toLines(t.text);
+  let restoredHere = 0;
+  for (let i = translatedFences.length - 1; i >= 0; i--) {
+    const f = translatedFences[i];
+    if (!divergent.includes(f)) continue;
+    const basisBody = basisFences[i].body;
+    if (basisBody === f.body) continue;
+    lines.splice(f.bodyStart, f.bodyEnd - f.bodyStart, ...basisBody.split('\n'));
+    restoredHere++;
+  }
+  if (!restoredHere) continue;
+
+  filesChanged++;
+  fencesRestored += restoredHere;
+  changedByLocale.set(t.locale, (changedByLocale.get(t.locale) || 0) + restoredHere);
+  if (DRY) {
+    console.log(`would restore ${String(restoredHere).padStart(2)} fence(s) in ${t.relPath}  (basis ${basisLabel})`);
+  } else {
+    writeFileSync(t.path, lines.join('\n'), 'utf8');
+  }
+}
+
+console.log(`\n${DRY ? 'DRY RUN — nothing written' : 'Wrote changes'}`);
+console.log(`basis: ${BASIS}`);
+console.log(`files ${DRY ? 'to change' : 'changed'}: ${filesChanged}`);
+console.log(`fences ${DRY ? 'to restore' : 'restored'}: ${fencesRestored}`);
+if (changedByLocale.size) {
+  console.log(`by locale: ${[...changedByLocale.entries()].sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join('  ')}`);
+}
+if (skipped.length) {
+  console.log(`\n${skipped.length} file(s) skipped — ordinal mapping is not sound, repair by hand:`);
+  for (const s of skipped) console.log(`  ${s.file}  (${s.n} divergent gated fence(s); ${s.reason})`);
+}

--- a/skills/translate-content/SKILL.md
+++ b/skills/translate-content/SKILL.md
@@ -141,15 +141,20 @@ npm run translate:scaffold -- <content-type> <id> <locale>
    not by reading:
 
    ```bash
-   npm run validate:i18n-fences
+   node scripts/check-i18n-fence-parity.js --locale <locale> --id <content-id>
    ```
+
+   Scope it to the file you just wrote. `npm run validate:i18n-fences` runs the
+   whole corpus, which still carries a backlog (#477) and would fail for reasons
+   unrelated to your work — training exactly the ignore-the-red-check reflex
+   this gate exists to prevent.
 
    Every fence whose tag is not `text`, `markdown` or `md` is frozen: its body must
    match the English source byte-for-byte, comments and string literals included.
    Repair with `npm run normalize:i18n-fences`.
 
    This step said "diff the fenced blocks" from the day the i18n tree was created,
-   and the corpus still accumulated 1,220 violations, because reading a fence and
+   and the corpus still accumulated 1,307 violations, because reading a fence and
    diffing it are not the same act (#472). Run the command.
 
 5.4. Check line count: skills must be ≤ 500 lines.
@@ -192,7 +197,7 @@ npm run translate:scaffold -- <content-type> <id> <locale>
 - [ ] `name` field matches English source exactly
 - [ ] `locale` field matches target locale
 - [ ] `source_commit` field is set to a valid git short hash
-- [ ] `npm run validate:i18n-fences` passes (frozen fences match the English source)
+- [ ] `check-i18n-fence-parity.js --locale <locale> --id <id>` passes for this file
 - [ ] All cross-referenced IDs (skills, agents, teams) are in English
 - [ ] File is under 500 lines (for skills)
 - [ ] `npm run validate:translations` reports no issues for this file

--- a/skills/translate-content/SKILL.md
+++ b/skills/translate-content/SKILL.md
@@ -137,7 +137,20 @@ npm run translate:scaffold -- <content-type> <id> <locale>
    - YAML frontmatter with `name`, `description`, `allowed-tools`, `metadata`
    - When to Use, Inputs, Procedure, Validation, Common Pitfalls, Related Skills
 
-5.3. Verify code blocks are identical to the English source (diff the fenced blocks).
+5.3. Verify code blocks are identical to the English source by running the checker,
+   not by reading:
+
+   ```bash
+   npm run validate:i18n-fences
+   ```
+
+   Every fence whose tag is not `text`, `markdown` or `md` is frozen: its body must
+   match the English source byte-for-byte, comments and string literals included.
+   Repair with `npm run normalize:i18n-fences`.
+
+   This step said "diff the fenced blocks" from the day the i18n tree was created,
+   and the corpus still accumulated 1,220 violations, because reading a fence and
+   diffing it are not the same act (#472). Run the command.
 
 5.4. Check line count: skills must be ≤ 500 lines.
 
@@ -179,7 +192,7 @@ npm run translate:scaffold -- <content-type> <id> <locale>
 - [ ] `name` field matches English source exactly
 - [ ] `locale` field matches target locale
 - [ ] `source_commit` field is set to a valid git short hash
-- [ ] All code blocks are identical to English source
+- [ ] `npm run validate:i18n-fences` passes (frozen fences match the English source)
 - [ ] All cross-referenced IDs (skills, agents, teams) are in English
 - [ ] File is under 500 lines (for skills)
 - [ ] `npm run validate:translations` reports no issues for this file


### PR DESCRIPTION
Closes the decision half of #472 and ships the gate. Repair backlog: #477.

## What #472 asked for, and what changed

The issue asked for a decision before code: **which fence tags must match English
byte-for-byte**. It proposed detecting CJK characters absent from the English fence and
measured 386 violations in executable-language fences.

That measurement reproduces — but the discriminator sees about a third of the problem.

| basis | gated violations | blind to |
|---|---|---|
| CJK absent from English (#472) | 457 visible | `de`, `es`, reworded-ASCII everywhere |
| body absent from **every English revision** | **1,307** | — |

`de` and `es` contribute **648** the CJK test cannot see. The largest class is invisible
in principle: German translations **transliterate** umlauts inside fences (`pruefen`,
`fuer`, `zaehlen`), so the violation carries no non-ASCII signal at all, and a
Latin-diacritic test recovers only 49 of `de`'s 366.

## Comparison basis, and why staleness does not confound it

A fence body is a violation when it appears in **no revision of its English counterpart,
ever** — every commit plus the working tree.

That dodges both confounds structurally:

- **Staleness.** 2,549 translations are stale; a stale fence legitimately matches an
  *older* English source. Staleness can only ever make a fence match an earlier
  revision, never one that never existed.
- **`source_commit` bumps.** `evolve-skill` bumps the field without retranslating
  (#405), so anchoring to it inherits that lie.

Measured false positives: **1 whitespace-only (per-line-trim reading) and 2 cross-skill
rows out of 2,115 divergences — 0.14%.** The deliberate consequence is that a fence
matching an old English revision passes; that is `check-translation-freshness.js`'s job
(#278).

## The policy

Frozen unless the info-string tag is exactly `text`, `markdown`, or `md`.

**Default-deny, not an allowlist.** An allowlist misses what it did not think of — this
corpus carries `logql` (50), `bibtex` (20), `jsonl` (10), `traceql` (10), `powershell`
(10), `language` (10) outside any hand-written code list. Inverting cost exactly **one**
finding (`i18n/de/skills/tidy-project-structure`, `# Basic example` → `# Grundlegendes
Beispiel` in a ```language fence). Untagged fences are frozen at zero measured cost.

Default-deny **narrows** the retag escape hatch from unbounded to three tags; it does
not close it, because the tag is read off the translated file and never compared to
English. Stated honestly in the code and filed as **#481**.

## Why a gate rather than better guidance

`skills/translate-content/SKILL.md` step 5.3 has said *"Verify code blocks are identical
to the English source (diff the fenced blocks)"* since commit `77006e7a`, 2026-03-13.

**Zero i18n commits predate that commit.** Every violation was produced under a
procedure explicitly instructing this check. The rule is stated in four places. So step
5.3 now *runs* the checker, scoped to the file just written:

```bash
node scripts/check-i18n-fence-parity.js --locale de --id create-r-package
```

## Day-one red — `CLAUDE.md` § Proving a Gate Can Fail

```
1307 gated-fence violation(s) across 338 file(s).
by tag:    bash=574  r=320  yaml=198  python=94  dockerfile=37  typescript=27  json=15
           nginx=9  javascript=7  protobuf=7  go=6  css=5  latex=2  gitignore=1
           language=1  gotmpl=1  promql=1  html=1  sql=1
by locale: de=366  ja=291  es=282  zh-CN=166  wenyan-ultra=100  caveman-ultra=37
           wenyan-lite=23  caveman-lite=20  caveman=13  wenyan=9
```

CI reproduces this exactly. Exit codes verified **without piping** (`$?` after a pipe is
`tail`'s): blocking `1`, `--warn` `0`. Also proven to catch a *new* violation, not just
the backlog: translating one comment to German in a clean file moved that file 0 → 1.

Ships `--warn` with a named exit (#477): 1,014 fences are mechanically restorable, 206
sit in 46 content forks needing human judgment (#478), 87 are in mirrors the normalizer
does not yet cover.

## Adversarial review

Copilot is quota-blocked (`COMMENTED`, 119-char body, 0 line comments), so the standing
fallback ran: three lenses, each finding refuted before it counted. It returned six
blocking findings, and the serious ones were mine. Fixed in `bad04b8e`:

- **The default-deny inversion silently regressed the normalizer.** `''` is not in
  `LOCALISABLE_TAGS`, so untagged became gated, and `isGated(a) !== isGated(b)` fired on
  the `text`-vs-untagged pairing the comment above it called benign — stranding 169
  repairable fences across 73 files while the comment described pre-inversion behaviour.
- **Every published repair figure was measured against the pre-inversion build.** The
  reviewer could not re-derive 1,014 / 206 / 46 and was right; fixing the regression
  restores them.
- **Both rule files claimed "blocking in CI"** on the day the step ships `--warn`, and
  step 5.3 told translators to run a whole-corpus command that fails for reasons unrelated
  to their work.
- **Scope did not match the documented rule** — "any translated file" vs a skills-only
  walk. Now covers agents/teams/guides mirrors (+87).
- Plus: `--json` truncated to 65,536 bytes when piped (`process.exit` drops queued async
  writes); trigger paths excluded the gate's own code, so a PR touching `extractFences`
  merged green (#451's class); bare `--limit` → NaN printed nothing; `--locale --dry`
  took `--dry` as the locale and reported zero work.

A **deleted** frozen fence is still invisible (#480). The obvious fix was written here
and reverted — comparing against current English reintroduces staleness, producing 1,518
findings across 402 files topped by four `quick-reference.md` mirrors the freshness
checker independently calls stale. The dead end is recorded in the code.

## Three defects found that were not the thing being looked for

- **#475** — `bulk-scaffold-caveman.sh:45` had an unanchored `/^name:/` awk rule firing
  on every column-0 `name:`, including inside ```yaml fences. 64 corrupted examples in 44
  files: skills that tell you to write a GitHub Actions workflow ship one with
  `locale: wenyan` as a top-level key. **Patched here** — `setup-container-registry`
  injects 3× under the old rule, 1× under the new.
- **#476** — 11 English files mis-render ~2,242 lines via runaway fences. Worse than the
  issue first recorded: #272's fence-tagger rewrote a template's closing ``` into
  ```` ```text ````, making the mis-parse *irreversible*. Not mechanically repairable —
  a heuristic repair was built here and abandoned after it tried to splice a template
  shut at its second nested example.
- **#474** — 68 SKILL.md carry worktree CRLF the index does not. `\r` is a JS-regex
  LineTerminator, so `(.*)$` fails closed.

## Hypotheses that died in measurement

- *"Worktree CRLF hides untranslated stubs."* **False** — 0 cases.
- *"Prose swallowed into fences is a translation defect."* **False** — English defect,
  faithfully mirrored; parity-driven repair would have corrupted the correct files.

## Verification

`validate:integrity` PASSED · `check-readmes` up to date · `validate:line-endings` OK ·
`validate:skill-sections` 0 · `validate:i18n-parity` OK · `content-style --added` 0 ·
all PR checks green.

Every number here was re-derived against this build. An earlier revision of this
description carried figures inherited from an analysis pass — `pruefen` ×65/`fuer` ×48,
2,545 stale — which were wrong and understating; that is the failure mode this PR gates
against, so it is noted rather than silently amended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAVqHw4mzzcUNH4z7gtCAX
