### PR TITLE
feat(scripts): mechanize the repo-safety containment (#493)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,21 @@ Three traps it exists to catch, all of which have shipped here:
 
 The same asymmetry applies to the *subject* of a check: a green gate proves something about the gate, and an unexplained **stale generated file** proves something about the corpus. `check-readmes` going stale is how a stray fixture commit was caught after `git status` read clean — investigate such staleness before regenerating it away.
 
+## Guarding a Multi-Agent Run
+
+`git status` cannot see a subagent that **committed**. Bracket any fan-out with Bash access in this repo:
+
+```bash
+npm run guard:snapshot   # before
+npm run guard:verify     # after — exit 1 if anything moved; --release when done
+```
+
+It compares HEAD, branch, worktree status, **the content of every changed or untracked file**, and index flags. Content is load-bearing: overwriting a file that was already modified leaves its ` M path` status line byte-identical, and this repo is usually mid-edit. Index flags are included because `git update-index --skip-worktree` makes git report a modified file as clean from that point on, disarming every later check.
+
+It fails closed — a missing, unreadable, or foreign snapshot exits 2 rather than reporting success, and exit 2 must never be read as a pass. `snapshot` refuses to overwrite and `verify` keeps the snapshot unless `--release`, so a nested run cannot rebaseline the outer run's damage into a green. **Ignored paths are out of scope** (walking them means hashing `node_modules`), so a stray write to `CONTINUE_HERE.md` would not be seen (#493).
+
+Agents that may run shell commands should also carry the `REPO_SAFETY` preamble from `workflows/_template.mjs` — `mktemp -d` rather than a shared path, `cd "$DIR" || exit 1`, and a `git rev-parse --show-toplevel` assertion before anything destructive. The preamble is documentation; the guard is the control.
+
 ## Adding a New Skill
 
 1. Create `skills/<skill-name>/SKILL.md` following the format of existing skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,12 +107,13 @@ The same asymmetry applies to the *subject* of a check: a green gate proves some
 
 ```bash
 npm run guard:snapshot   # before
-npm run guard:verify     # after — exit 1 if anything moved; --release when done
+npm run guard:verify     # after — exit 1 if anything moved
+npm run guard:release    # when the run is genuinely over
 ```
 
 It compares HEAD, branch, worktree status, **the content of every changed or untracked file**, and index flags. Content is load-bearing: overwriting a file that was already modified leaves its ` M path` status line byte-identical, and this repo is usually mid-edit. Index flags are included because `git update-index --skip-worktree` makes git report a modified file as clean from that point on, disarming every later check.
 
-It fails closed — a missing, unreadable, or foreign snapshot exits 2 rather than reporting success, and exit 2 must never be read as a pass. `snapshot` refuses to overwrite and `verify` keeps the snapshot unless `--release`, so a nested run cannot rebaseline the outer run's damage into a green. **Ignored paths are out of scope** (walking them means hashing `node_modules`), so a stray write to `CONTINUE_HERE.md` would not be seen (#493).
+It fails closed — a missing, unreadable, or foreign snapshot exits 2 rather than reporting success, and exit 2 must never be read as a pass. `snapshot` refuses to overwrite and `verify` keeps the snapshot until `guard:release`, so a nested run cannot rebaseline the outer run's damage into a green. **Ignored paths are out of scope** (walking them means hashing `node_modules`), so a stray write to `CONTINUE_HERE.md` would not be seen (#493).
 
 Agents that may run shell commands should also carry the `REPO_SAFETY` preamble from `workflows/_template.mjs` — `mktemp -d` rather than a shared path, `cd "$DIR" || exit 1`, and a `git rev-parse --show-toplevel` assertion before anything destructive. The preamble is documentation; the guard is the control.
 

--- a/guides/creating-workflows.md
+++ b/guides/creating-workflows.md
@@ -191,7 +191,9 @@ nested run rebaseline the outer run's damage into a green.
 
 ### Contain the agents
 
-`workflows/_template.mjs` exports a `REPO_SAFETY` preamble; prepend it to the
+`workflows/_template.mjs` defines a `REPO_SAFETY` preamble — a plain `const`, not
+an export, since the documented wrap-then-check recipe rewrites only
+`export const meta` and any other top-level export breaks it. Prepend it to the
 prompt of **every** agent that may run shell commands, verifiers included — a
 verifier reproducing a finding is the agent most likely to build a fixture.
 Copying the template gets you this by default.

--- a/guides/creating-workflows.md
+++ b/guides/creating-workflows.md
@@ -186,7 +186,7 @@ covered.** Walking them would mean hashing `node_modules`. In this repo that
 means a stray write to `CONTINUE_HERE.md` would not be seen.
 
 `snapshot` refuses to overwrite an existing snapshot, and `verify` keeps it
-unless `--release`. Both exist because a single global slot otherwise lets a
+until `npm run guard:release`. Both exist because a single global slot otherwise lets a
 nested run rebaseline the outer run's damage into a green.
 
 ### Contain the agents
@@ -229,7 +229,7 @@ The Workflow **run model** is generally available on paid Claude Code plans (~v2
 | A mutating stage is rejected / misbehaves | Stage targets an advisory `agentType` but needs to write | Target an `implementing` agent type for any Write/Edit/Bash or `worktree` stage |
 | A "read-only" run left the repo changed | Agents inherit the repo as their cwd; the declared `intent` does not constrain Bash | Apply the containments in [Fanning Out Against a Live Repository](#fanning-out-against-a-live-repository) and bracket the run with `npm run guard:snapshot` / `guard:verify` |
 | `guard:verify` says "no snapshot" | The snapshot was released, or never taken | Re-snapshot and re-run. Never read exit 2 as a pass — it means the comparison did not happen |
-| `guard:snapshot` says one already exists | Another guarded run is open, or an earlier one was never released | Close it with `guard:verify --release`. Do not `--force` unless you know the other run is dead: re-arming rebaselines its damage |
+| `guard:snapshot` says one already exists | Another guarded run is open, or an earlier one was never released | Close it with `npm run guard:release`. Do not `--force` unless you know the other run is dead: re-arming rebaselines its damage |
 | `Date.now is not a function` | Used a forbidden non-deterministic call | Pass the value via `args`; vary by index/label instead |
 
 ## Related Resources

--- a/guides/creating-workflows.md
+++ b/guides/creating-workflows.md
@@ -153,7 +153,48 @@ and never created the directory. Its `cd "$1"` then failed, execution continued
 regardless, and `mkdir`, `cat >`, `git add -A` and `git commit` all landed on the
 real repository.
 
-Four containments, in order of how much they buy:
+### Bracket the run
+
+`repo-guard` is the mechanical half. Run it either side of any fan-out with Bash
+access:
+
+```bash
+npm run guard:snapshot   # before
+# ... the fan-out ...
+npm run guard:verify     # after
+```
+
+It compares HEAD, the current branch, the worktree status, **the content of every
+changed or untracked file**, and the index flags, exiting 1 with the difference
+printed if any moved. It fails closed: a missing, unreadable, or foreign snapshot
+exits 2 rather than reporting success, because a guard that answers "unchanged"
+when it could not look is worse than none.
+
+Two of those comparisons are subtler than they look, and both were added after
+the first version shipped without them:
+
+- **Content, not just status lines.** Overwriting a file that was *already*
+  modified leaves ` M CLAUDE.md` byte-identical before and after. Since this repo
+  is usually mid-edit, a line-only comparison misses the common case.
+- **HEAD.** The only check that catches an agent that **committed** — `git status`
+  reads clean once a stray write is committed, so every dirty-tree check passes.
+  Index flags matter for the same reason: `git update-index --skip-worktree`
+  makes git report a modified file as clean from that point on.
+
+Scope limit, stated so you do not over-trust it: **ignored paths are not
+covered.** Walking them would mean hashing `node_modules`. In this repo that
+means a stray write to `CONTINUE_HERE.md` would not be seen.
+
+`snapshot` refuses to overwrite an existing snapshot, and `verify` keeps it
+unless `--release`. Both exist because a single global slot otherwise lets a
+nested run rebaseline the outer run's damage into a green.
+
+### Contain the agents
+
+`workflows/_template.mjs` exports a `REPO_SAFETY` preamble; prepend it to the
+prompt of **every** agent that may run shell commands, verifiers included — a
+verifier reproducing a finding is the agent most likely to build a fixture.
+Copying the template gets you this by default.
 
 | Control | Catches |
 |---|---|
@@ -162,11 +203,8 @@ Four containments, in order of how much they buy:
 | `cd <dir> \|\| exit 1` in generated scripts | A failed `cd` silently redirecting relative paths at the repo |
 | `git rev-parse --show-toplevel` assertion before `git add -A` / `git commit` / any write flag | A destructive step aimed at the wrong tree |
 
-Then record `HEAD` before the run and compare after. That last check is the only
-one that catches an agent that **committed** — `git status` reads clean once a
-stray write has been committed, so every dirty-tree check passes.
-
-A prompt sentence is documentation, not a control. The prompt in that run named
+A prompt sentence is documentation, not a control — which is why the preamble is
+paired with the guard rather than trusted on its own. The prompt in that run named
 the directory, the tool, and the file to copy, and specificity did not help,
 because the failure was mechanical rather than a matter of the agent's compliance.
 
@@ -189,7 +227,9 @@ The Workflow **run model** is generally available on paid Claude Code plans (~v2
 | `meta must be a pure literal` | `meta` references a variable or call | Inline every value into the `export const meta` object literal |
 | Workflow not found by name | `meta.name` ≠ filename stem, or not installed in `.claude/workflows/` | Make the triple (filename ↔ sidecar `name:` ↔ `meta.name`) identical and install the file |
 | A mutating stage is rejected / misbehaves | Stage targets an advisory `agentType` but needs to write | Target an `implementing` agent type for any Write/Edit/Bash or `worktree` stage |
-| A "read-only" run left the repo changed | Agents inherit the repo as their cwd; the declared `intent` does not constrain Bash | Apply the containments in [Fanning Out Against a Live Repository](#fanning-out-against-a-live-repository); compare `HEAD` before and after |
+| A "read-only" run left the repo changed | Agents inherit the repo as their cwd; the declared `intent` does not constrain Bash | Apply the containments in [Fanning Out Against a Live Repository](#fanning-out-against-a-live-repository) and bracket the run with `npm run guard:snapshot` / `guard:verify` |
+| `guard:verify` says "no snapshot" | The snapshot was released, or never taken | Re-snapshot and re-run. Never read exit 2 as a pass — it means the comparison did not happen |
+| `guard:snapshot` says one already exists | Another guarded run is open, or an earlier one was never released | Close it with `guard:verify --release`. Do not `--force` unless you know the other run is dead: re-arming rebaselines its damage |
 | `Date.now is not a function` | Used a forbidden non-deterministic call | Pass the value via `args`; vary by index/label instead |
 
 ## Related Resources

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "validate:security": "node scripts/scan-skill-content.js",
     "guard:snapshot": "node scripts/repo-guard.js snapshot",
     "guard:verify": "node scripts/repo-guard.js verify",
+    "guard:release": "node scripts/repo-guard.js verify --release",
     "coverage:evals": "node scripts/eval-coverage.js",
     "mutation-check": "node scripts/mutation-check.js",
     "translation:status": "node scripts/generate-translation-status.js",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "validate:skill-sections": "node scripts/audit-skill-sections.js --missing",
     "validate:locales-json": "node scripts/validate-locales-json.js",
     "validate:security": "node scripts/scan-skill-content.js",
+    "guard:snapshot": "node scripts/repo-guard.js snapshot",
+    "guard:verify": "node scripts/repo-guard.js verify",
     "coverage:evals": "node scripts/eval-coverage.js",
     "mutation-check": "node scripts/mutation-check.js",
     "translation:status": "node scripts/generate-translation-status.js",

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -89,15 +89,19 @@ const SNAPSHOT_NAME = 'repo-guard.json';
 const FORMAT_VERSION = 2;
 /** Sentinel for a repository with no commits yet. */
 const UNBORN = '(unborn)';
+// Named in the npm form because `die()` appends this to every argument error,
+// and a usage block contradicting the rest of the tool's advice is how a caller
+// ends up running the one form that swallows its flags. Flags need `--` to cross
+// `npm run` at all.
 const USAGE = `Usage:
-  node scripts/repo-guard.js snapshot [--force] [--quiet]
-  node scripts/repo-guard.js verify   [--release] [--quiet]
+  npm run guard:snapshot              record HEAD, branch, status, contents, index flags
+  npm run guard:verify                compare the repository against that record
+  npm run guard:release               verify, then drop the snapshot if unchanged
 
-  snapshot   record HEAD, branch, status, file contents and index flags
-  --force    replace an existing snapshot (refused by default)
-  verify     compare the repository against that record
-  --release  delete the snapshot afterwards (kept by default)
-  --quiet    suppress the success line; differences always print`;
+  npm run guard:snapshot -- --force   replace an existing snapshot (refused by default)
+  npm run guard:verify   -- --quiet   suppress the success line; differences always print
+
+  (flags must follow \`--\`; npm swallows them otherwise)`;
 
 function die(message, code = 2) {
   console.error(`repo-guard: ${message}`);
@@ -324,7 +328,12 @@ if (contentChanged.length) {
 changed = reportList('index flags (skip-worktree / assume-unchanged)',
   before.indexFlags, after.indexFlags) || changed;
 
-if (argv.includes('--release')) {
+// Release only a CLEAN run. Dropping the baseline after a failure destroys the
+// evidence at the exact moment it is needed: you cannot re-verify after a
+// partial recovery, and the only way back is a fresh snapshot — which
+// rebaselines the damage as the new normal, the laundering hole the
+// refuse-to-overwrite rule exists to close.
+if (argv.includes('--release') && !changed) {
   try {
     unlinkSync(SNAPSHOT_PATH);
   } catch (error) {
@@ -351,6 +360,10 @@ if (changed) {
     // not be suggested when HEAD never moved.
     console.error('HEAD did not move, so this is a worktree change — inspect it before assuming');
     console.error('it was yours:  git diff  /  git status --porcelain -uall');
+  }
+  if (argv.includes('--release')) {
+    console.error('\nThe snapshot was KEPT despite --release, so you can re-verify after');
+    console.error('recovering. Re-snapshotting instead would rebaseline whatever changed.');
   }
   process.exit(1);
 }

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -74,6 +74,13 @@ import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 
 const SNAPSHOT_NAME = 'repo-guard.json';
+/**
+ * Bump whenever `captureState()` changes shape. A snapshot written by an older
+ * build cannot be compared against a newer capture — the first time that
+ * happened the guard said `snapshot is missing 'contents'`, which is accurate
+ * and useless. Refusing is right; naming the reason is what makes it actionable.
+ */
+const FORMAT_VERSION = 2;
 const USAGE = `Usage:
   node scripts/repo-guard.js snapshot [--force] [--quiet]
   node scripts/repo-guard.js verify   [--release] [--quiet]
@@ -206,7 +213,11 @@ if (command === 'snapshot') {
       'Finish that run with `repo-guard.js verify --release`, or pass --force.');
   }
   const state = captureState();
-  writeFileSync(SNAPSHOT_PATH, JSON.stringify({ ...state, takenAt: new Date().toISOString() }, null, 2) + '\n', 'utf8');
+  writeFileSync(
+    SNAPSHOT_PATH,
+    JSON.stringify({ formatVersion: FORMAT_VERSION, ...state, takenAt: new Date().toISOString() }, null, 2) + '\n',
+    'utf8',
+  );
   if (!QUIET) {
     console.log(`repo-guard: snapshot at ${state.head.slice(0, 8)} on ${state.branch}` +
       ` (${state.status.length} pending change(s), ${state.indexFlags.length} index flag(s))`);
@@ -226,6 +237,11 @@ try {
   before = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf8'));
 } catch (error) {
   die(`snapshot at ${SNAPSHOT_NAME} is unreadable: ${error.message}`);
+}
+if (before.formatVersion !== FORMAT_VERSION) {
+  die(`snapshot was written in format v${before.formatVersion ?? 1}, but this is v${FORMAT_VERSION}.\n` +
+    'It predates a change to what is recorded, so the comparison would be incomplete.\n' +
+    `Re-arm and re-run:  rm ${SNAPSHOT_PATH} && npm run guard:snapshot`);
 }
 for (const field of ['toplevel', 'head', 'branch', 'status', 'contents', 'indexFlags']) {
   if (before[field] === undefined) die(`snapshot is missing '${field}' — refusing to compare.`);

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -227,11 +227,19 @@ if (command === 'snapshot') {
       'Finish that run with `repo-guard.js verify --release`, or pass --force.');
   }
   const state = captureState();
-  writeFileSync(
-    SNAPSHOT_PATH,
-    JSON.stringify({ formatVersion: FORMAT_VERSION, ...state, takenAt: new Date().toISOString() }, null, 2) + '\n',
-    'utf8',
-  );
+  try {
+    writeFileSync(
+      SNAPSHOT_PATH,
+      JSON.stringify({ formatVersion: FORMAT_VERSION, ...state, takenAt: new Date().toISOString() }, null, 2) + '\n',
+      'utf8',
+    );
+  } catch (error) {
+    // An uncaught throw here exits 1, which in this tool's vocabulary means
+    // "the repository changed" — the fail-closed contract requires that an
+    // inability to record the baseline reads as uncertainty, not as a verdict.
+    die(`could not write the snapshot to ${SNAPSHOT_PATH}: ${error.message}\n` +
+      'The run is NOT guarded. Fix this before fanning out.');
+  }
   if (!QUIET) {
     console.log(`repo-guard: snapshot at ${state.head.slice(0, 8)} on ${state.branch}` +
       ` (${state.status.length} pending change(s), ${state.indexFlags.length} index flag(s))`);

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -144,27 +144,39 @@ const sha = (buffer) => createHash('sha256').update(buffer).digest('hex').slice(
  * entry, so a new file inside an already-untracked directory is caught too.
  */
 function captureState() {
-  const statusRaw = atRoot(['status', '--porcelain', '-uall']);
-  const status = statusRaw.split('\n').filter((line) => line.trim() !== '').sort();
+  // `-z` rather than line-splitting. Without it git applies `core.quotePath`,
+  // which C-quotes any path containing a byte >= 0x80 using OCTAL escapes —
+  // ` M "i18n/ja/\350\252\255\343\201\277.md"`. JSON has no octal escape, so
+  // parsing that back with JSON.parse threw, the path stayed quoted, the file
+  // was not found on disk, and it was skipped from the content map in silence.
+  // In a repository whose entire i18n tree is non-ASCII that is not an edge
+  // case: a clobbered `i18n/ja/読み.md` verified as "unchanged", exit 0.
+  // `-z` emits raw bytes with NUL separators and no quoting at all.
+  const parts = atRoot(['status', '--porcelain', '-uall', '-z']).split('\0');
+  const entries = [];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (!part) continue;
+    const code = part.slice(0, 2);
+    entries.push({ code, path: part.slice(3) });
+    // Under -z a rename or copy is TWO fields: the new path, then the original.
+    if (code[0] === 'R' || code[0] === 'C') i++;
+  }
+
+  const status = entries.map((e) => `${e.code} ${e.path}`).sort();
 
   const contents = {};
-  for (const line of status) {
-    // Porcelain v1: 2 status chars, a space, then the path. Renames use
-    // "old -> new"; the post-rename path is the one on disk.
-    let path = line.slice(3);
-    const arrow = path.indexOf(' -> ');
-    if (arrow >= 0) path = path.slice(arrow + 4);
-    if (path.startsWith('"') && path.endsWith('"')) {
-      try { path = JSON.parse(path); } catch { /* keep the quoted form */ }
-    }
+  for (const { path } of entries) {
     const abs = join(TOPLEVEL, path);
     try {
-      // Deleted paths have no content; the status line already records them.
-      if (!existsSync(abs) || !statSync(abs).isFile()) continue;
-      contents[path] = sha(readFileSync(abs));
+      // Every status-listed path gets an entry, including ones with no readable
+      // content. Skipping them instead would make a path that STOPS being a
+      // regular file — a file swapped for a symlink, say — vanish from the map
+      // while its status line stayed identical, and so go unreported.
+      if (!existsSync(abs)) contents[path] = '(absent)';
+      else if (!statSync(abs).isFile()) contents[path] = '(not-a-regular-file)';
+      else contents[path] = sha(readFileSync(abs));
     } catch (error) {
-      // Unreadable is a state too — record it rather than silently skipping,
-      // so a file becoming unreadable during a run still shows up.
       contents[path] = `unreadable:${error.code || 'error'}`;
     }
   }
@@ -275,11 +287,14 @@ if (before.branch !== after.branch) {
 
 changed = reportList('working tree', before.status, after.status) || changed;
 
-// Content comparison, restricted to paths present in both status lists — a path
-// that appeared or vanished is already reported above, and repeating it adds
-// noise without adding information.
-const contentChanged = Object.keys(after.contents)
-  .filter((path) => before.contents[path] !== undefined)
+// Compare the UNION of both content maps, not just the paths still present in
+// `after`. Iterating `after` alone made the vanishing direction unreachable: a
+// path dropped from the map — because it stopped being a regular file — was
+// never visited, and its status line had not moved either. Over-reporting a
+// path already named above is the safe direction; under-reporting is the bug
+// this whole tool exists to prevent.
+const watchedPaths = new Set([...Object.keys(before.contents), ...Object.keys(after.contents)]);
+const contentChanged = [...watchedPaths]
   .filter((path) => before.contents[path] !== after.contents[path])
   .sort();
 if (contentChanged.length) {

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -287,14 +287,16 @@ if (before.branch !== after.branch) {
 
 changed = reportList('working tree', before.status, after.status) || changed;
 
-// Compare the UNION of both content maps, not just the paths still present in
-// `after`. Iterating `after` alone made the vanishing direction unreachable: a
-// path dropped from the map — because it stopped being a regular file — was
-// never visited, and its status line had not moved either. Over-reporting a
-// path already named above is the safe direction; under-reporting is the bug
-// this whole tool exists to prevent.
-const watchedPaths = new Set([...Object.keys(before.contents), ...Object.keys(after.contents)]);
-const contentChanged = [...watchedPaths]
+// Iterating `after` is sufficient ONLY because every status-listed path now gets
+// an entry — including the `(absent)` and `(not-a-regular-file)` sentinels. The
+// sentinels are what make this safe: previously a path that stopped being a
+// regular file was skipped from the map entirely, so the comparison never
+// visited it while its status line stayed identical.
+//
+// A path in `before` but not in `after` cannot hide here: the key set of each
+// map is exactly its status list, so the path must also have left the status
+// list, which the working-tree diff above already reports.
+const contentChanged = Object.keys(after.contents)
   .filter((path) => before.contents[path] !== after.contents[path])
   .sort();
 if (contentChanged.length) {

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -2,8 +2,9 @@
 /**
  * repo-guard.js — prove a multi-agent run left the repository untouched.
  *
- *   node scripts/repo-guard.js snapshot   # before the fan-out
- *   node scripts/repo-guard.js verify     # after it returns
+ *   node scripts/repo-guard.js snapshot           # before the fan-out
+ *   node scripts/repo-guard.js verify             # after it returns
+ *   node scripts/repo-guard.js verify --release   # ... and drop the snapshot
  *
  * Exit 0 = the repository is exactly as it was. Exit 1 = it moved, with the
  * difference printed. Exit 2 = the question could not be answered honestly.
@@ -30,103 +31,158 @@
  * afterwards, and every dirty-tree check passes. In the real incident it was a
  * stale generated README that gave the write away, which is luck, not a control.
  *
- * So this compares four things, each corresponding to a way the incident hid:
+ * So this compares five things, each corresponding to a way a change can hide:
  *
- *   HEAD          a stray commit (the tree looks clean afterwards)
- *   branch        a checkout that moved the working branch
- *   status        stray writes and stray new files
- *   index flags   `git update-index --skip-worktree`, which the incident really
- *                 did run, and which makes git report a modified file as clean
- *                 from that point on — poisoning every later check
+ *   HEAD            a stray commit (the tree looks clean afterwards)
+ *   branch          a checkout that moved the working branch
+ *   status lines    files appearing, vanishing, or changing state
+ *   file contents   a stray write to a file that was ALREADY modified. Comparing
+ *                   status lines alone misses this entirely: ` M CLAUDE.md` reads
+ *                   identical before and after the overwrite. This repo is
+ *                   normally mid-edit, so that is the common case, not the
+ *                   exotic one.
+ *   index flags     `git update-index --skip-worktree`, which the incident really
+ *                   ran, and which makes git report a modified file as clean from
+ *                   then on — poisoning every later check
+ *
+ * ## What it does NOT cover
+ *
+ * Ignored paths. `git status --porcelain` omits them by design and walking them
+ * would mean hashing `node_modules`. A stray write to a gitignored file (in this
+ * repo, `CONTINUE_HERE.md`) is invisible here. Everything else under the working
+ * tree is compared by content.
  *
  * ## Failing closed
  *
  * A guard that answers "unchanged" when it could not look is worse than none.
- * Every uncertainty here exits 2, never 0: a missing or unreadable snapshot, a
- * snapshot taken in a different repository, a git invocation that fails, or an
- * unrecognised argument.
+ * Every uncertainty exits 2, never 0: a missing, unreadable, or foreign snapshot,
+ * a git invocation that fails, or an unrecognised argument.
+ *
+ * Two rules keep a second run from laundering the first run's damage into a
+ * green, which a single global snapshot slot otherwise invites:
+ *
+ *   - `snapshot` REFUSES to overwrite an existing snapshot (`--force` to
+ *     override). Re-arming mid-run would rebaseline the damage as the new normal.
+ *   - `verify` KEEPS the snapshot unless `--release`. Consuming it by default
+ *     silently disarms every later check — and a stale snapshot can only ever
+ *     over-report, never under-report, so keeping is the safe direction.
  */
 
-import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { readFileSync, writeFileSync, existsSync, unlinkSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 
-/**
- * The snapshot lives inside the git directory, not the working tree.
- *
- * The first version put it at the repo root, and a test caught two consequences:
- * it appeared in `git status` as an untracked file (so the guard had to special-
- * case its own artifact), and an agent running `git add -A` — precisely the
- * command from the incident — would have committed it. `.git/` is not part of
- * the working tree, so none of that can happen.
- */
 const SNAPSHOT_NAME = 'repo-guard.json';
 const USAGE = `Usage:
-  node scripts/repo-guard.js snapshot [--quiet]
-  node scripts/repo-guard.js verify   [--keep] [--quiet]
+  node scripts/repo-guard.js snapshot [--force] [--quiet]
+  node scripts/repo-guard.js verify   [--release] [--quiet]
 
-  snapshot  record HEAD, branch, worktree status and index flags
-  verify    compare the repository against that record (and delete it)
-  --keep    verify without deleting the snapshot (for repeated checks)
-  --quiet   suppress the success line; differences always print`;
+  snapshot   record HEAD, branch, status, file contents and index flags
+  --force    replace an existing snapshot (refused by default)
+  verify     compare the repository against that record
+  --release  delete the snapshot afterwards (kept by default)
+  --quiet    suppress the success line; differences always print`;
 
 function die(message, code = 2) {
   console.error(`repo-guard: ${message}`);
   process.exit(code);
 }
 
-// ── argument parsing: default-deny, because a silently ignored flag is how a
-// guard ends up not guarding what the caller believed it did.
+// ── arguments: default-deny, and per-command, so a flag that means nothing to
+// this subcommand is an error rather than a silently narrower check.
 const argv = process.argv.slice(2);
-const COMMANDS = new Set(['snapshot', 'verify']);
-const FLAGS = new Set(['--keep', '--quiet']);
+const FLAGS_FOR = { snapshot: ['--force', '--quiet'], verify: ['--release', '--quiet'] };
 
 const command = argv.find((a) => !a.startsWith('-'));
 if (!command) die(`no command given.\n${USAGE}`);
-if (!COMMANDS.has(command)) die(`unknown command '${command}'.\n${USAGE}`);
+if (!FLAGS_FOR[command]) die(`unknown command '${command}'.\n${USAGE}`);
 for (const arg of argv) {
   if (arg === command) continue;
-  if (!FLAGS.has(arg)) die(`unknown argument '${arg}'.\n${USAGE}`);
+  if (!FLAGS_FOR[command].includes(arg)) {
+    die(`unknown argument '${arg}' for '${command}'.\n${USAGE}`);
+  }
 }
-const KEEP = argv.includes('--keep');
 const QUIET = argv.includes('--quiet');
 
-/** Run git, or exit 2. A guard must never treat a failed probe as "nothing changed". */
-function git(args) {
-  const result = spawnSync('git', args, { encoding: 'utf8' });
+/**
+ * Run git from the repository ROOT, never the caller's cwd.
+ *
+ * `git ls-files` is cwd-scoped: run from a subdirectory it lists only that
+ * subtree, so a `skip-worktree` bit set elsewhere would be invisible and the
+ * guard would silently cover less than it claims.
+ */
+function git(args, { cwd = undefined, allowFailure = false } = {}) {
+  const result = spawnSync('git', args, { encoding: 'utf8', cwd, maxBuffer: 512 * 1024 * 1024 });
   if (result.error) die(`could not run git: ${result.error.message}`);
   if (result.status !== 0) {
+    if (allowFailure) return null;
     die(`git ${args.join(' ')} failed (exit ${result.status}): ${(result.stderr || '').trim()}`);
   }
   return result.stdout;
 }
 
 const TOPLEVEL = git(['rev-parse', '--show-toplevel']).trim();
-// `--absolute-git-dir` resolves correctly in a linked worktree, where `.git` is
-// a file pointing elsewhere rather than a directory.
-const SNAPSHOT_PATH = join(git(['rev-parse', '--absolute-git-dir']).trim(), SNAPSHOT_NAME);
+const GIT_DIR = git(['rev-parse', '--absolute-git-dir']).trim();
+const SNAPSHOT_PATH = join(GIT_DIR, SNAPSHOT_NAME);
+const atRoot = (args) => git(args, { cwd: TOPLEVEL });
 
-/** The repository's observable state. */
+const sha = (buffer) => createHash('sha256').update(buffer).digest('hex').slice(0, 16);
+
+/**
+ * Hash of every path git reports as changed or untracked.
+ *
+ * This is what makes a stray write to an already-dirty file visible. `-uall`
+ * lists untracked files individually rather than collapsing a directory to one
+ * entry, so a new file inside an already-untracked directory is caught too.
+ */
 function captureState() {
-  const status = git(['status', '--porcelain'])
-    .split('\n')
-    .filter((line) => line.trim() !== '')
-    .sort();
+  const statusRaw = atRoot(['status', '--porcelain', '-uall']);
+  const status = statusRaw.split('\n').filter((line) => line.trim() !== '').sort();
+
+  const contents = {};
+  for (const line of status) {
+    // Porcelain v1: 2 status chars, a space, then the path. Renames use
+    // "old -> new"; the post-rename path is the one on disk.
+    let path = line.slice(3);
+    const arrow = path.indexOf(' -> ');
+    if (arrow >= 0) path = path.slice(arrow + 4);
+    if (path.startsWith('"') && path.endsWith('"')) {
+      try { path = JSON.parse(path); } catch { /* keep the quoted form */ }
+    }
+    const abs = join(TOPLEVEL, path);
+    try {
+      // Deleted paths have no content; the status line already records them.
+      if (!existsSync(abs) || !statSync(abs).isFile()) continue;
+      contents[path] = sha(readFileSync(abs));
+    } catch (error) {
+      // Unreadable is a state too — record it rather than silently skipping,
+      // so a file becoming unreadable during a run still shows up.
+      contents[path] = `unreadable:${error.code || 'error'}`;
+    }
+  }
 
   // `git ls-files -v` marks anything not plainly cached with a tag other than
   // 'H'. 'S' is skip-worktree; a lowercase tag is assume-unchanged. Both make
   // git report a modified file as clean, so they must be part of the baseline —
   // otherwise setting one is itself an undetectable change.
-  const indexFlags = git(['ls-files', '-v'])
+  const indexFlags = atRoot(['ls-files', '-v'])
     .split('\n')
     .filter((line) => line && line[0] !== 'H')
     .sort();
 
+  // A repository with no commits yet has neither a resolvable HEAD nor an
+  // abbrev-ref for it. That is a legitimate state to snapshot, not an error —
+  // dying here would make the guard unusable on a fresh fixture.
+  const head = git(['rev-parse', 'HEAD'], { cwd: TOPLEVEL, allowFailure: true });
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: TOPLEVEL, allowFailure: true });
+
   return {
     toplevel: TOPLEVEL,
-    head: git(['rev-parse', 'HEAD']).trim(),
-    branch: git(['rev-parse', '--abbrev-ref', 'HEAD']).trim(),
+    head: head === null ? '(unborn)' : head.trim(),
+    branch: branch === null ? '(unborn)' : branch.trim(),
     status,
+    contents,
     indexFlags,
   };
 }
@@ -142,8 +198,15 @@ function reportList(label, before, after) {
 }
 
 if (command === 'snapshot') {
+  // Refusing to clobber is what stops a nested or concurrent run from
+  // rebaselining the outer run's damage as the new normal.
+  if (existsSync(SNAPSHOT_PATH) && !argv.includes('--force')) {
+    die(`a snapshot already exists at ${SNAPSHOT_NAME}.\n` +
+      'Another guarded run may be in progress — overwriting it would rebaseline its damage.\n' +
+      'Finish that run with `repo-guard.js verify --release`, or pass --force.');
+  }
   const state = captureState();
-  writeFileSync(SNAPSHOT_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  writeFileSync(SNAPSHOT_PATH, JSON.stringify({ ...state, takenAt: new Date().toISOString() }, null, 2) + '\n', 'utf8');
   if (!QUIET) {
     console.log(`repo-guard: snapshot at ${state.head.slice(0, 8)} on ${state.branch}` +
       ` (${state.status.length} pending change(s), ${state.indexFlags.length} index flag(s))`);
@@ -164,7 +227,7 @@ try {
 } catch (error) {
   die(`snapshot at ${SNAPSHOT_NAME} is unreadable: ${error.message}`);
 }
-for (const field of ['toplevel', 'head', 'branch', 'status', 'indexFlags']) {
+for (const field of ['toplevel', 'head', 'branch', 'status', 'contents', 'indexFlags']) {
   if (before[field] === undefined) die(`snapshot is missing '${field}' — refusing to compare.`);
 }
 if (before.toplevel !== TOPLEVEL) {
@@ -173,17 +236,19 @@ if (before.toplevel !== TOPLEVEL) {
 
 const after = captureState();
 let changed = false;
+let headMoved = false;
 
 if (before.head !== after.head) {
   changed = true;
+  headMoved = true;
   console.error(`\n  HEAD moved: ${before.head.slice(0, 8)} -> ${after.head.slice(0, 8)}`);
   // The commits themselves are the actionable part: this is the case `git
   // status` cannot see, because a committed stray write leaves a clean tree.
-  const range = spawnSync('git', ['log', '--format=  %h %an  %s', `${before.head}..${after.head}`],
-    { encoding: 'utf8' });
-  if (range.status === 0 && range.stdout.trim()) {
+  const range = git(['log', '--format=  %h %an  %s', `${before.head}..${after.head}`],
+    { cwd: TOPLEVEL, allowFailure: true });
+  if (range && range.trim()) {
     console.error('  commits added:');
-    console.error(range.stdout.trimEnd());
+    console.error(range.trimEnd());
   }
 }
 
@@ -193,18 +258,49 @@ if (before.branch !== after.branch) {
 }
 
 changed = reportList('working tree', before.status, after.status) || changed;
+
+// Content comparison, restricted to paths present in both status lists — a path
+// that appeared or vanished is already reported above, and repeating it adds
+// noise without adding information.
+const contentChanged = Object.keys(after.contents)
+  .filter((path) => before.contents[path] !== undefined)
+  .filter((path) => before.contents[path] !== after.contents[path])
+  .sort();
+if (contentChanged.length) {
+  changed = true;
+  console.error('\n  contents changed (file was already modified, so its status line did not move):');
+  for (const path of contentChanged) console.error(`    ~ ${path}`);
+}
+
 changed = reportList('index flags (skip-worktree / assume-unchanged)',
   before.indexFlags, after.indexFlags) || changed;
 
-if (!KEEP) unlinkSync(SNAPSHOT_PATH);
+if (argv.includes('--release')) {
+  try {
+    unlinkSync(SNAPSHOT_PATH);
+  } catch (error) {
+    // Do not let a cleanup failure masquerade as "the repository changed".
+    console.error(`repo-guard: warning — could not remove the snapshot: ${error.message}`);
+  }
+}
 
 if (changed) {
-  console.error(`\nrepo-guard: the repository CHANGED during the run.`);
-  console.error('Investigate before pushing. A stray commit is recoverable while unpushed:');
-  console.error(`  git log --oneline ${before.head.slice(0, 8)}..HEAD`);
-  console.error(`  git reset --mixed ${before.head.slice(0, 8)}   # keeps the files, drops the commit`);
+  console.error('\nrepo-guard: the repository CHANGED during the run.');
+  if (headMoved) {
+    console.error('Investigate before pushing. A stray commit is recoverable while unpushed:');
+    console.error(`  git log --oneline ${before.head.slice(0, 8)}..HEAD`);
+    console.error(`  git reset --mixed ${before.head.slice(0, 8)}   # keeps the files, drops the commit`);
+  } else {
+    // `git reset --mixed` would unstage the caller's own work here, so it must
+    // not be suggested when HEAD never moved.
+    console.error('HEAD did not move, so this is a worktree change — inspect it before assuming');
+    console.error('it was yours:  git diff  /  git status --porcelain -uall');
+  }
   process.exit(1);
 }
 
-if (!QUIET) console.log(`repo-guard: unchanged at ${after.head.slice(0, 8)} on ${after.branch}.`);
+if (!QUIET) {
+  const age = before.takenAt ? ` (snapshot taken ${before.takenAt})` : '';
+  console.log(`repo-guard: unchanged at ${after.head.slice(0, 8)} on ${after.branch}${age}.`);
+}
 process.exit(0);

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -81,6 +81,8 @@ const SNAPSHOT_NAME = 'repo-guard.json';
  * and useless. Refusing is right; naming the reason is what makes it actionable.
  */
 const FORMAT_VERSION = 2;
+/** Sentinel for a repository with no commits yet. */
+const UNBORN = '(unborn)';
 const USAGE = `Usage:
   node scripts/repo-guard.js snapshot [--force] [--quiet]
   node scripts/repo-guard.js verify   [--release] [--quiet]
@@ -198,8 +200,8 @@ function captureState() {
 
   return {
     toplevel: TOPLEVEL,
-    head: head === null ? '(unborn)' : head.trim(),
-    branch: branch === null ? '(unborn)' : branch.trim(),
+    head: head === null ? UNBORN : head.trim(),
+    branch: branch === null ? UNBORN : branch.trim(),
     status,
     contents,
     indexFlags,
@@ -319,7 +321,14 @@ if (argv.includes('--release')) {
 
 if (changed) {
   console.error('\nrepo-guard: the repository CHANGED during the run.');
-  if (headMoved) {
+  if (headMoved && before.head === UNBORN) {
+    // The baseline had no commits at all, so there is no revision to reset to —
+    // printing `git reset --mixed (unborn)` would be an invalid command offered
+    // at precisely the moment the caller is deciding what to trust.
+    console.error('The baseline had no commits, so every commit now present arrived during the run:');
+    console.error('  git log --oneline');
+    console.error('Inspect them before pushing; there is no earlier revision to reset to.');
+  } else if (headMoved) {
     console.error('Investigate before pushing. A stray commit is recoverable while unpushed:');
     console.error(`  git log --oneline ${before.head.slice(0, 8)}..HEAD`);
     console.error(`  git reset --mixed ${before.head.slice(0, 8)}   # keeps the files, drops the commit`);

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -2,9 +2,15 @@
 /**
  * repo-guard.js — prove a multi-agent run left the repository untouched.
  *
- *   node scripts/repo-guard.js snapshot           # before the fan-out
- *   node scripts/repo-guard.js verify             # after it returns
- *   node scripts/repo-guard.js verify --release   # ... and drop the snapshot
+ *   npm run guard:snapshot   # before the fan-out
+ *   npm run guard:verify    # after it returns
+ *   npm run guard:release   # ... and drop the snapshot
+ *
+ * The npm scripts are the supported entrypoint, and every message this tool
+ * prints names them rather than the raw `node scripts/repo-guard.js …` form:
+ * advice that is not copy-pasteable at the moment something broke is advice that
+ * does not get followed. (`--release` in particular cannot cross `npm run` —
+ * npm swallows it as its own config — which is why it has a script of its own.)
  *
  * Exit 0 = the repository is exactly as it was. Exit 1 = it moved, with the
  * difference printed. Exit 2 = the question could not be answered honestly.
@@ -224,7 +230,7 @@ if (command === 'snapshot') {
   if (existsSync(SNAPSHOT_PATH) && !argv.includes('--force')) {
     die(`a snapshot already exists at ${SNAPSHOT_NAME}.\n` +
       'Another guarded run may be in progress — overwriting it would rebaseline its damage.\n' +
-      'Finish that run with `repo-guard.js verify --release`, or pass --force.');
+      'Finish that run with `npm run guard:release`, or pass --force.');
   }
   const state = captureState();
   try {
@@ -250,7 +256,7 @@ if (command === 'snapshot') {
 // ── verify ───────────────────────────────────────────────────────────────────
 
 if (!existsSync(SNAPSHOT_PATH)) {
-  die(`no snapshot at ${SNAPSHOT_NAME}. Run \`repo-guard.js snapshot\` before the run.\n` +
+  die(`no snapshot at ${SNAPSHOT_NAME}. Run \`npm run guard:snapshot\` before the run.\n` +
     'Refusing to report "unchanged" for a comparison that never happened.');
 }
 
@@ -263,7 +269,7 @@ try {
 if (before.formatVersion !== FORMAT_VERSION) {
   die(`snapshot was written in format v${before.formatVersion ?? 1}, but this is v${FORMAT_VERSION}.\n` +
     'It predates a change to what is recorded, so the comparison would be incomplete.\n' +
-    `Re-arm and re-run:  rm ${SNAPSHOT_PATH} && npm run guard:snapshot`);
+    `Re-arm and re-run:  rm -f "${SNAPSHOT_PATH}" && npm run guard:snapshot`);
 }
 for (const field of ['toplevel', 'head', 'branch', 'status', 'contents', 'indexFlags']) {
   if (before[field] === undefined) die(`snapshot is missing '${field}' — refusing to compare.`);

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -86,7 +86,7 @@ const SNAPSHOT_NAME = 'repo-guard.json';
  * happened the guard said `snapshot is missing 'contents'`, which is accurate
  * and useless. Refusing is right; naming the reason is what makes it actionable.
  */
-const FORMAT_VERSION = 2;
+const FORMAT_VERSION = 3;
 /** Sentinel for a repository with no commits yet. */
 const UNBORN = '(unborn)';
 // Named in the npm form because `die()` appends this to every argument error,
@@ -99,7 +99,7 @@ const USAGE = `Usage:
   npm run guard:release               verify, then drop the snapshot if unchanged
 
   npm run guard:snapshot -- --force   replace an existing snapshot (refused by default)
-  npm run guard:verify   -- --quiet   suppress the success line; differences always print
+  npm run guard:snapshot -- --quiet   suppress the success line (also valid on verify)
 
   (flags must follow \`--\`; npm swallows them otherwise)`;
 
@@ -146,7 +146,10 @@ const GIT_DIR = git(['rev-parse', '--absolute-git-dir']).trim();
 const SNAPSHOT_PATH = join(GIT_DIR, SNAPSHOT_NAME);
 const atRoot = (args) => git(args, { cwd: TOPLEVEL });
 
-const sha = (buffer) => createHash('sha256').update(buffer).digest('hex').slice(0, 16);
+// Full digest. Truncating to 64 bits saved nothing that matters — only changed
+// and untracked paths are hashed, so the snapshot stays small either way — while
+// narrowing the margin on the one comparison the whole tool rests upon.
+const sha = (buffer) => createHash('sha256').update(buffer).digest('hex');
 
 /**
  * Hash of every path git reports as changed or untracked.

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * repo-guard.js — prove a multi-agent run left the repository untouched.
+ *
+ *   node scripts/repo-guard.js snapshot   # before the fan-out
+ *   node scripts/repo-guard.js verify     # after it returns
+ *
+ * Exit 0 = the repository is exactly as it was. Exit 1 = it moved, with the
+ * difference printed. Exit 2 = the question could not be answered honestly.
+ *
+ * ## Why this exists (#493)
+ *
+ * During an adversarial review of #486, a subagent wrote a test fixture into the
+ * working repository and committed it. It sat on the branch HEAD for ten minutes
+ * and would have gone out on the next push.
+ *
+ * The prompt had told it, specifically, to build fixtures under `/tmp`. It tried
+ * to. Two parallel agents had each written `$SCRATCH/fixture.sh` — the same path
+ * in the shared scratchpad — and the second clobbered the first, so the victim's
+ * `bash fixture.sh /tmp/nf-skipwt` ran a script that ignored its argument. The
+ * directory was never created, its `cd "$1"` failed, execution continued anyway,
+ * and every following relative path resolved against the repository.
+ *
+ * The lesson is that the containment cannot be a sentence in a prompt, because
+ * the agent complied with the sentence. It has to be a check that runs.
+ *
+ * ## Why `git status` is not that check
+ *
+ * `git status` cannot see an agent that COMMITTED — the tree reads clean
+ * afterwards, and every dirty-tree check passes. In the real incident it was a
+ * stale generated README that gave the write away, which is luck, not a control.
+ *
+ * So this compares four things, each corresponding to a way the incident hid:
+ *
+ *   HEAD          a stray commit (the tree looks clean afterwards)
+ *   branch        a checkout that moved the working branch
+ *   status        stray writes and stray new files
+ *   index flags   `git update-index --skip-worktree`, which the incident really
+ *                 did run, and which makes git report a modified file as clean
+ *                 from that point on — poisoning every later check
+ *
+ * ## Failing closed
+ *
+ * A guard that answers "unchanged" when it could not look is worse than none.
+ * Every uncertainty here exits 2, never 0: a missing or unreadable snapshot, a
+ * snapshot taken in a different repository, a git invocation that fails, or an
+ * unrecognised argument.
+ */
+
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+/**
+ * The snapshot lives inside the git directory, not the working tree.
+ *
+ * The first version put it at the repo root, and a test caught two consequences:
+ * it appeared in `git status` as an untracked file (so the guard had to special-
+ * case its own artifact), and an agent running `git add -A` — precisely the
+ * command from the incident — would have committed it. `.git/` is not part of
+ * the working tree, so none of that can happen.
+ */
+const SNAPSHOT_NAME = 'repo-guard.json';
+const USAGE = `Usage:
+  node scripts/repo-guard.js snapshot [--quiet]
+  node scripts/repo-guard.js verify   [--keep] [--quiet]
+
+  snapshot  record HEAD, branch, worktree status and index flags
+  verify    compare the repository against that record (and delete it)
+  --keep    verify without deleting the snapshot (for repeated checks)
+  --quiet   suppress the success line; differences always print`;
+
+function die(message, code = 2) {
+  console.error(`repo-guard: ${message}`);
+  process.exit(code);
+}
+
+// ── argument parsing: default-deny, because a silently ignored flag is how a
+// guard ends up not guarding what the caller believed it did.
+const argv = process.argv.slice(2);
+const COMMANDS = new Set(['snapshot', 'verify']);
+const FLAGS = new Set(['--keep', '--quiet']);
+
+const command = argv.find((a) => !a.startsWith('-'));
+if (!command) die(`no command given.\n${USAGE}`);
+if (!COMMANDS.has(command)) die(`unknown command '${command}'.\n${USAGE}`);
+for (const arg of argv) {
+  if (arg === command) continue;
+  if (!FLAGS.has(arg)) die(`unknown argument '${arg}'.\n${USAGE}`);
+}
+const KEEP = argv.includes('--keep');
+const QUIET = argv.includes('--quiet');
+
+/** Run git, or exit 2. A guard must never treat a failed probe as "nothing changed". */
+function git(args) {
+  const result = spawnSync('git', args, { encoding: 'utf8' });
+  if (result.error) die(`could not run git: ${result.error.message}`);
+  if (result.status !== 0) {
+    die(`git ${args.join(' ')} failed (exit ${result.status}): ${(result.stderr || '').trim()}`);
+  }
+  return result.stdout;
+}
+
+const TOPLEVEL = git(['rev-parse', '--show-toplevel']).trim();
+// `--absolute-git-dir` resolves correctly in a linked worktree, where `.git` is
+// a file pointing elsewhere rather than a directory.
+const SNAPSHOT_PATH = join(git(['rev-parse', '--absolute-git-dir']).trim(), SNAPSHOT_NAME);
+
+/** The repository's observable state. */
+function captureState() {
+  const status = git(['status', '--porcelain'])
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .sort();
+
+  // `git ls-files -v` marks anything not plainly cached with a tag other than
+  // 'H'. 'S' is skip-worktree; a lowercase tag is assume-unchanged. Both make
+  // git report a modified file as clean, so they must be part of the baseline —
+  // otherwise setting one is itself an undetectable change.
+  const indexFlags = git(['ls-files', '-v'])
+    .split('\n')
+    .filter((line) => line && line[0] !== 'H')
+    .sort();
+
+  return {
+    toplevel: TOPLEVEL,
+    head: git(['rev-parse', 'HEAD']).trim(),
+    branch: git(['rev-parse', '--abbrev-ref', 'HEAD']).trim(),
+    status,
+    indexFlags,
+  };
+}
+
+function reportList(label, before, after) {
+  const gone = before.filter((x) => !after.includes(x));
+  const added = after.filter((x) => !before.includes(x));
+  if (!gone.length && !added.length) return false;
+  console.error(`\n  ${label}:`);
+  for (const entry of added) console.error(`    + ${entry}`);
+  for (const entry of gone) console.error(`    - ${entry}`);
+  return true;
+}
+
+if (command === 'snapshot') {
+  const state = captureState();
+  writeFileSync(SNAPSHOT_PATH, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  if (!QUIET) {
+    console.log(`repo-guard: snapshot at ${state.head.slice(0, 8)} on ${state.branch}` +
+      ` (${state.status.length} pending change(s), ${state.indexFlags.length} index flag(s))`);
+  }
+  process.exit(0);
+}
+
+// ── verify ───────────────────────────────────────────────────────────────────
+
+if (!existsSync(SNAPSHOT_PATH)) {
+  die(`no snapshot at ${SNAPSHOT_NAME}. Run \`repo-guard.js snapshot\` before the run.\n` +
+    'Refusing to report "unchanged" for a comparison that never happened.');
+}
+
+let before;
+try {
+  before = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf8'));
+} catch (error) {
+  die(`snapshot at ${SNAPSHOT_NAME} is unreadable: ${error.message}`);
+}
+for (const field of ['toplevel', 'head', 'branch', 'status', 'indexFlags']) {
+  if (before[field] === undefined) die(`snapshot is missing '${field}' — refusing to compare.`);
+}
+if (before.toplevel !== TOPLEVEL) {
+  die(`snapshot was taken in ${before.toplevel}, but this is ${TOPLEVEL}.`);
+}
+
+const after = captureState();
+let changed = false;
+
+if (before.head !== after.head) {
+  changed = true;
+  console.error(`\n  HEAD moved: ${before.head.slice(0, 8)} -> ${after.head.slice(0, 8)}`);
+  // The commits themselves are the actionable part: this is the case `git
+  // status` cannot see, because a committed stray write leaves a clean tree.
+  const range = spawnSync('git', ['log', '--format=  %h %an  %s', `${before.head}..${after.head}`],
+    { encoding: 'utf8' });
+  if (range.status === 0 && range.stdout.trim()) {
+    console.error('  commits added:');
+    console.error(range.stdout.trimEnd());
+  }
+}
+
+if (before.branch !== after.branch) {
+  changed = true;
+  console.error(`\n  branch changed: ${before.branch} -> ${after.branch}`);
+}
+
+changed = reportList('working tree', before.status, after.status) || changed;
+changed = reportList('index flags (skip-worktree / assume-unchanged)',
+  before.indexFlags, after.indexFlags) || changed;
+
+if (!KEEP) unlinkSync(SNAPSHOT_PATH);
+
+if (changed) {
+  console.error(`\nrepo-guard: the repository CHANGED during the run.`);
+  console.error('Investigate before pushing. A stray commit is recoverable while unpushed:');
+  console.error(`  git log --oneline ${before.head.slice(0, 8)}..HEAD`);
+  console.error(`  git reset --mixed ${before.head.slice(0, 8)}   # keeps the files, drops the commit`);
+  process.exit(1);
+}
+
+if (!QUIET) console.log(`repo-guard: unchanged at ${after.head.slice(0, 8)} on ${after.branch}.`);
+process.exit(0);

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -61,17 +61,47 @@ test('verify passes when nothing happened', async (t) => {
   assert.match(r.stdout, /unchanged at/);
 });
 
-test('verify consumes the snapshot, so a second verify cannot pass on a stale one', async (t) => {
-  // Otherwise a snapshot left behind by an earlier run would answer a later
-  // question it never observed — a green that means nothing.
+test('verify KEEPS the snapshot, so a run cannot be silently disarmed', async (t) => {
+  // Consuming by default was the original design and it disarmed the guard the
+  // first time it was dogfooded: something ran verify mid-run, and the real
+  // check afterwards had nothing to compare against. A retained snapshot can
+  // only ever over-report, never under-report, so keeping is the safe direction.
   const dir = makeRepo(t);
   guard(dir, ['snapshot']);
-  assert.equal(guard(dir, ['verify']).status, 0);
 
+  assert.equal(guard(dir, ['verify']).status, 0);
   const second = guard(dir, ['verify']);
 
-  assert.equal(second.status, 2);
-  assert.match(second.stderr, /no snapshot/);
+  assert.equal(second.status, 0, 'the snapshot should still be there');
+  assert.match(second.stdout, /unchanged at/);
+});
+
+test('--release drops the snapshot when the run is genuinely over', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+
+  assert.equal(guard(dir, ['verify', '--release']).status, 0);
+
+  const after = guard(dir, ['verify']);
+  assert.equal(after.status, 2);
+  assert.match(after.stderr, /no snapshot/);
+});
+
+test('snapshot refuses to overwrite, so a nested run cannot rebaseline damage', async (t) => {
+  // The laundering path: run A arms, an agent strays, run B arms afresh — now
+  // the stray write is part of B's baseline and A's verify reports green.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  writeFileSync(join(dir, 'strayed.txt'), 'damage\n', 'utf8');
+
+  const second = guard(dir, ['snapshot']);
+
+  assert.equal(second.status, 2, 'a second snapshot must not silently replace the first');
+  assert.match(second.stderr, /already exists/);
+  // The original baseline must survive and still see the damage.
+  const v = guard(dir, ['verify']);
+  assert.equal(v.status, 1);
+  assert.match(v.stderr, /strayed\.txt/);
 });
 
 // ── the four mechanisms from the incident ───────────────────────────────────
@@ -95,6 +125,43 @@ test('detects a stray COMMIT — the case git status cannot see', async (t) => {
   assert.match(r.stderr, /HEAD moved/);
   assert.match(r.stderr, /de translation/, 'should name the stray commit');
   assert.match(r.stderr, /git reset --mixed/, 'should give the recovery command');
+});
+
+test('detects a stray write to an ALREADY-modified file', async (t) => {
+  // The blocking defect the first version shipped with. Comparing status LINES
+  // alone, ` M src/a.txt` reads identical before and after an overwrite, so the
+  // guard reported "unchanged" while the file had been rewritten. This repo is
+  // normally mid-edit, which makes it the common case rather than the exotic one.
+  const dir = makeRepo(t);
+  writeFileSync(join(dir, 'src', 'a.txt'), 'my own work in progress\n', 'utf8');
+  guard(dir, ['snapshot']);
+
+  const statusBefore = git(dir, ['status', '--porcelain']);
+  writeFileSync(join(dir, 'src', 'a.txt'), 'CLOBBERED BY A STRAY AGENT\n', 'utf8');
+  assert.equal(git(dir, ['status', '--porcelain']), statusBefore,
+    'precondition: the porcelain line is byte-identical before and after');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1, 'a status-line-only comparison would pass here');
+  assert.match(r.stderr, /contents changed/);
+  assert.match(r.stderr, /src\/a\.txt/);
+});
+
+test('detects a new file inside an already-untracked directory', async (t) => {
+  // `git status --porcelain` collapses an untracked directory to a single entry,
+  // so without -uall a file added inside it moves no line.
+  const dir = makeRepo(t);
+  mkdirSync(join(dir, 'scratch'), { recursive: true });
+  writeFileSync(join(dir, 'scratch', 'one.txt'), 'first\n', 'utf8');
+  guard(dir, ['snapshot']);
+
+  writeFileSync(join(dir, 'scratch', 'two.txt'), 'snuck in\n', 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /scratch\/two\.txt/);
 });
 
 test('detects a modified tracked file', async (t) => {
@@ -138,6 +205,40 @@ test('detects a skip-worktree bit — which makes git status LIE afterwards', as
   assert.equal(r.status, 1);
   assert.match(r.stderr, /index flags/);
   assert.match(r.stderr, /src\/a\.txt/);
+});
+
+test('detects a skip-worktree bit set from a SUBDIRECTORY', async (t) => {
+  // `git ls-files -v` is cwd-scoped: run from a subdirectory it lists only that
+  // subtree, so a bit set elsewhere would be invisible and the guard would cover
+  // less than it claims. Every git call therefore runs from the toplevel.
+  const dir = makeRepo(t);
+  mkdirSync(join(dir, 'other'), { recursive: true });
+  writeFileSync(join(dir, 'other', 'b.txt'), 'b\n', 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'add other']);
+  guard(dir, ['snapshot']);
+
+  git(dir, ['update-index', '--skip-worktree', 'src/a.txt']);
+
+  // Verify from a subdirectory that does NOT contain the flagged file.
+  const r = guard(join(dir, 'other'), ['verify']);
+
+  assert.equal(r.status, 1, 'cwd-scoped ls-files would miss this');
+  assert.match(r.stderr, /src\/a\.txt/);
+});
+
+test('recovery advice does not suggest a reset when HEAD never moved', async (t) => {
+  // `git reset --mixed` would unstage the caller's own work. Printing it for a
+  // pure worktree change is advice that destroys data.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  writeFileSync(join(dir, 'stray.txt'), 'x\n', 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.doesNotMatch(r.stderr, /git reset --mixed/);
+  assert.match(r.stderr, /HEAD did not move/);
 });
 
 test('detects a branch switch', async (t) => {
@@ -188,7 +289,7 @@ test('a snapshot from a different repository is an error', async (t) => {
 test('an unknown argument is an error, not a silently narrower check', async (t) => {
   const dir = makeRepo(t);
 
-  for (const args of [['snapshot', '--force'], ['verify', '--all'], ['inspect']]) {
+  for (const args of [['snapshot', '--release'], ['verify', '--force'], ['verify', '--all'], ['inspect']]) {
     const r = guard(dir, args);
     assert.equal(r.status, 2, `${JSON.stringify(args)} was accepted`);
     assert.match(r.stderr, /unknown (argument|command)/);
@@ -206,8 +307,8 @@ test('the snapshot lives outside the working tree, so it cannot dirty it', async
   assert.equal(git(dir, ['status', '--porcelain']), '',
     'taking a snapshot must not dirty the working tree');
 
-  const r = guard(dir, ['verify', '--keep']);
+  const r = guard(dir, ['verify']);
 
   assert.equal(r.status, 0, r.stderr);
-  assert.ok(existsSync(snapshotPath(dir)), '--keep should preserve it');
+  assert.ok(existsSync(snapshotPath(dir)), 'verify keeps the snapshot by default');
 });

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -444,6 +444,54 @@ test('a snapshot from a different repository is an error', async (t) => {
   assert.match(r.stderr, /was taken in/);
 });
 
+test('every command this tool suggests is copy-pasteable', async (t) => {
+  // Advice that does not run is advice that does not get followed, and this tool
+  // only ever speaks at the moment something has gone wrong. Three separate
+  // messages suggested `repo-guard.js …`, which is not runnable from the repo
+  // root, and one interpolated an unquoted path that breaks on a directory name
+  // containing a space.
+  const dir = makeRepo(t);
+
+  const noSnapshot = guard(dir, ['verify']).stderr;
+  guard(dir, ['snapshot']);
+  const alreadyExists = guard(dir, ['snapshot']).stderr;
+
+  for (const stderr of [noSnapshot, alreadyExists]) {
+    // `(?!on)` because the snapshot FILE is `repo-guard.json`, of which
+    // `repo-guard.js` is a prefix — the first version of this test flagged its
+    // own subject's filename.
+    const suggested = stderr.split('\n').filter((l) => /repo-guard\.js(?!on)/.test(l));
+    assert.deepEqual(suggested, [],
+      `message suggests a non-runnable command:\n${stderr}`);
+    assert.match(stderr, /npm run guard:/, `message names no runnable entrypoint:\n${stderr}`);
+  }
+});
+
+test('a path containing spaces is quoted in the recovery command', async (t) => {
+  const parent = mkdtempSync(join(tmpdir(), 'repo guard spaces-'));
+  t.after(() => rmSync(parent, { recursive: true, force: true }));
+  const dir = join(parent, 'repo');
+  mkdirSync(dir, { recursive: true });
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+  writeFileSync(join(dir, 'a.txt'), 'x\n', 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'init']);
+  guard(dir, ['snapshot']);
+
+  // Force the format-mismatch branch, which is the one that prints an `rm`.
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+  snap.formatVersion = 1;
+  writeFileSync(snapshotPath(dir), JSON.stringify(snap), 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /rm -f "[^"]*repo guard spaces[^"]*"/,
+    'the interpolated path must be quoted');
+});
+
 test('an unknown argument is an error, not a silently narrower check', async (t) => {
   const dir = makeRepo(t);
 

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -229,6 +229,27 @@ test('detects an untracked file swapped for a DANGLING symlink', async (t) => {
   assert.match(r.stderr, /notes\.md/);
 });
 
+test('hashes the DESTINATION path of a rename, not the vanished original', async (t) => {
+  // Porcelain -z emits `R  <destination>\0<original>\0` — destination first,
+  // which is the file that exists on disk. Verified directly:
+  //   $ git status --porcelain -z   ->  R  renamed.txt\0original.txt\0
+  //   $ git status --porcelain      ->  R  original.txt -> renamed.txt
+  // Reading the second field instead would hash a path that no longer exists,
+  // leaving a renamed file's contents unguarded. Pinning it because a reviewer
+  // asserted the opposite order.
+  const dir = makeRepo(t);
+  git(dir, ['mv', 'src/a.txt', 'src/b.txt']);
+  guard(dir, ['snapshot']);
+
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+
+  assert.ok(Object.keys(snap.contents).includes('src/b.txt'),
+    `destination not hashed; contents were ${JSON.stringify(Object.keys(snap.contents))}`);
+  assert.ok(!Object.keys(snap.contents).includes('src/a.txt'),
+    'the vanished original must not be hashed — it does not exist on disk');
+  assert.equal(snap.status.length, 1, 'a rename is ONE status entry, not two');
+});
+
 test('detects a new file inside an already-untracked directory', async (t) => {
   // `git status --porcelain` collapses an untracked directory to a single entry,
   // so without -uall a file added inside it moves no line.
@@ -320,6 +341,28 @@ test('recovery advice does not suggest a reset when HEAD never moved', async (t)
   assert.equal(r.status, 1);
   assert.doesNotMatch(r.stderr, /git reset --mixed/);
   assert.match(r.stderr, /HEAD did not move/);
+});
+
+test('an unborn baseline gets advice that is a runnable command', async (t) => {
+  // The code explicitly supports snapshotting a repo with no commits, so the
+  // failure guidance must not print `git reset --mixed (unborn)`.
+  const dir = mkdtempSync(join(tmpdir(), 'repo-guard-unborn-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+  guard(dir, ['snapshot']);
+
+  writeFileSync(join(dir, 'first.txt'), 'x\n', 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'a commit that arrived during the run']);
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.doesNotMatch(r.stderr, /\(unborn\)\.\.HEAD|reset --mixed \(unborn\)/,
+    'must not print an invalid revision in a copy-pasteable command');
+  assert.match(r.stderr, /no earlier revision to reset to/);
 });
 
 test('detects a branch switch', async (t) => {

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -274,6 +274,23 @@ test('an unreadable snapshot is an error, never a pass', async (t) => {
   assert.match(r.stderr, /unreadable/);
 });
 
+test('a snapshot in an older format is an error naming the reason', async (t) => {
+  // Hit for real: a snapshot armed before the `contents` field was added made
+  // verify die with "missing 'contents'" — accurate and useless.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+  delete snap.formatVersion;
+  delete snap.contents;
+  writeFileSync(snapshotPath(dir), JSON.stringify(snap), 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /format v1, but this is v2/);
+  assert.match(r.stderr, /guard:snapshot/, 'should say how to recover');
+});
+
 test('a snapshot from a different repository is an error', async (t) => {
   const a = makeRepo(t);
   const b = makeRepo(t);

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -14,7 +14,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -146,6 +146,60 @@ test('detects a stray write to an ALREADY-modified file', async (t) => {
   assert.equal(r.status, 1, 'a status-line-only comparison would pass here');
   assert.match(r.stderr, /contents changed/);
   assert.match(r.stderr, /src\/a\.txt/);
+});
+
+test('detects a stray write to a NON-ASCII path', async (t) => {
+  // `core.quotePath` C-quotes such paths with octal escapes, which the first
+  // implementation could not parse — it silently recorded no content for them.
+  // Verified live: a clobbered `i18n/ja/読み.md` reported "unchanged", exit 0.
+  // In a repo whose whole i18n tree is non-ASCII that is the common path.
+  const dir = makeRepo(t);
+  mkdirSync(join(dir, 'i18n', 'ja'), { recursive: true });
+  const cjk = join(dir, 'i18n', 'ja', '読み.md');
+  writeFileSync(cjk, 'original\n', 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'add japanese skill']);
+  writeFileSync(cjk, 'my own edit\n', 'utf8');
+  guard(dir, ['snapshot']);
+
+  writeFileSync(cjk, 'CLOBBERED\n', 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1, 'a quoted-path parse failure would report unchanged');
+  assert.match(r.stderr, /contents changed/);
+});
+
+test('detects a same-LENGTH content substitution', async (t) => {
+  // Pins content at byte level, not size. Without this a refactor to a
+  // stat/size fingerprint would pass the whole suite while reinstating the
+  // original blind spot.
+  const dir = makeRepo(t);
+  writeFileSync(join(dir, 'src', 'a.txt'), 'AAAA\n', 'utf8');
+  guard(dir, ['snapshot']);
+
+  writeFileSync(join(dir, 'src', 'a.txt'), 'BBBB\n', 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /contents changed/);
+});
+
+test('detects a tracked file swapped for a symlink', async (t) => {
+  // The status line does not move, and the path stops being a regular file — so
+  // a comparison that iterates only the surviving content keys never visits it.
+  const dir = makeRepo(t);
+  writeFileSync(join(dir, 'src', 'a.txt'), 'work in progress\n', 'utf8');
+  guard(dir, ['snapshot']);
+
+  rmSync(join(dir, 'src', 'a.txt'));
+  symlinkSync('/etc/hostname', join(dir, 'src', 'a.txt'));
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /contents changed/);
 });
 
 test('detects a new file inside an already-untracked directory', async (t) => {

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -87,6 +87,27 @@ test('--release drops the snapshot when the run is genuinely over', async (t) =>
   assert.match(after.stderr, /no snapshot/);
 });
 
+test('--release KEEPS the snapshot when the run failed', async (t) => {
+  // Releasing after a failure destroys the evidence exactly when it is needed:
+  // you could not re-verify after a partial recovery, and the only way back
+  // would be a fresh snapshot — which rebaselines the damage as the new normal,
+  // the laundering hole the refuse-to-overwrite rule exists to close.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  writeFileSync(join(dir, 'strayed.txt'), 'damage\n', 'utf8');
+
+  const r = guard(dir, ['verify', '--release']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /snapshot was KEPT despite --release/);
+  assert.ok(existsSync(snapshotPath(dir)), 'the baseline must survive a failed verify');
+
+  // And it is still usable: the same failure is still detectable afterwards.
+  const again = guard(dir, ['verify']);
+  assert.equal(again.status, 1);
+  assert.match(again.stderr, /strayed\.txt/);
+});
+
 test('snapshot refuses to overwrite, so a nested run cannot rebaseline damage', async (t) => {
   // The laundering path: run A arms, an agent strays, run B arms afresh — now
   // the stray write is part of B's baseline and A's verify reports green.
@@ -455,8 +476,13 @@ test('every command this tool suggests is copy-pasteable', async (t) => {
   const noSnapshot = guard(dir, ['verify']).stderr;
   guard(dir, ['snapshot']);
   const alreadyExists = guard(dir, ['snapshot']).stderr;
+  // `die()` appends USAGE to every argument error, so these carry it too — the
+  // first version of this test checked only the two messages above and so missed
+  // that USAGE itself still named the non-runnable form.
+  const unknownArg = guard(dir, ['verify', '--nope']).stderr;
+  const unknownCommand = guard(dir, ['inspect']).stderr;
 
-  for (const stderr of [noSnapshot, alreadyExists]) {
+  for (const stderr of [noSnapshot, alreadyExists, unknownArg, unknownCommand]) {
     // `(?!on)` because the snapshot FILE is `repo-guard.json`, of which
     // `repo-guard.js` is a prefix — the first version of this test flagged its
     // own subject's filename.

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -1,0 +1,213 @@
+/**
+ * Behavioural tests for `scripts/repo-guard.js` (#493).
+ *
+ * The guard's whole value is detecting changes that other checks miss, so
+ * "verify passes on an untouched repo" is the least interesting case here. Each
+ * test below makes a specific change and asserts the guard goes red — and the
+ * `skip-worktree` case additionally asserts that plain `git status` reads CLEAN
+ * on the same tree, which is what makes that mechanism worth guarding at all.
+ *
+ * Fixtures are built with `mkdtempSync`, never a shared fixed path. That is the
+ * pattern whose absence caused #493: two agents wrote the same scratchpad
+ * filename, and the second clobbered the first.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const GUARD = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'repo-guard.js');
+
+function git(cwd, args) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(r.status, 0, `git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+function guard(cwd, args) {
+  const r = spawnSync(process.execPath, [GUARD, ...args], { cwd, encoding: 'utf8' });
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+/** Inside `.git/`, deliberately — see the note on SNAPSHOT_NAME in repo-guard.js. */
+const snapshotPath = (dir) => join(dir, '.git', 'repo-guard.json');
+
+function makeRepo(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'repo-guard-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(join(dir, 'src', 'a.txt'), 'original\n', 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'initial']);
+  return dir;
+}
+
+// ── the baseline, and proof it is not vacuous ───────────────────────────────
+
+test('verify passes when nothing happened', async (t) => {
+  const dir = makeRepo(t);
+
+  assert.equal(guard(dir, ['snapshot']).status, 0);
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /unchanged at/);
+});
+
+test('verify consumes the snapshot, so a second verify cannot pass on a stale one', async (t) => {
+  // Otherwise a snapshot left behind by an earlier run would answer a later
+  // question it never observed — a green that means nothing.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  assert.equal(guard(dir, ['verify']).status, 0);
+
+  const second = guard(dir, ['verify']);
+
+  assert.equal(second.status, 2);
+  assert.match(second.stderr, /no snapshot/);
+});
+
+// ── the four mechanisms from the incident ───────────────────────────────────
+
+test('detects a stray COMMIT — the case git status cannot see', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+
+  // Exactly what the subagent did: write into the tree, then commit it.
+  mkdirSync(join(dir, 'i18n', 'de'), { recursive: true });
+  writeFileSync(join(dir, 'i18n', 'de', 'SKILL.md'), 'stray fixture\n', 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de translation']);
+
+  // The premise: after committing, the tree is clean and every dirty-check passes.
+  assert.equal(git(dir, ['status', '--porcelain']), '', 'precondition: tree reads clean');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /HEAD moved/);
+  assert.match(r.stderr, /de translation/, 'should name the stray commit');
+  assert.match(r.stderr, /git reset --mixed/, 'should give the recovery command');
+});
+
+test('detects a modified tracked file', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  writeFileSync(join(dir, 'src', 'a.txt'), 'rewritten by a stray --write\n', 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /working tree/);
+  assert.match(r.stderr, /src\/a\.txt/);
+});
+
+test('detects a new untracked file', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  writeFileSync(join(dir, 'fixture.sh'), '#!/bin/sh\n', 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /fixture\.sh/);
+});
+
+test('detects a skip-worktree bit — which makes git status LIE afterwards', async (t) => {
+  // The incident really ran `git update-index --skip-worktree` on a real path.
+  // From that point on git reports the file clean no matter what it contains, so
+  // this bit poisons every later check. A guard blind to it can be disarmed.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+
+  git(dir, ['update-index', '--skip-worktree', 'src/a.txt']);
+  writeFileSync(join(dir, 'src', 'a.txt'), 'changed behind the flag\n', 'utf8');
+
+  assert.equal(git(dir, ['status', '--porcelain']), '',
+    'precondition: git status reads clean despite the file being modified');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /index flags/);
+  assert.match(r.stderr, /src\/a\.txt/);
+});
+
+test('detects a branch switch', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  git(dir, ['checkout', '-q', '-b', 'somewhere-else']);
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /branch changed: main -> somewhere-else/);
+});
+
+// ── failing closed ──────────────────────────────────────────────────────────
+
+test('verify without a snapshot is an error, never a pass', async (t) => {
+  const dir = makeRepo(t);
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 2, 'a comparison that never happened must not report success');
+  assert.match(r.stderr, /no snapshot/);
+});
+
+test('an unreadable snapshot is an error, never a pass', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  writeFileSync(snapshotPath(dir), '{ not json', 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /unreadable/);
+});
+
+test('a snapshot from a different repository is an error', async (t) => {
+  const a = makeRepo(t);
+  const b = makeRepo(t);
+  guard(a, ['snapshot']);
+  writeFileSync(snapshotPath(b), readFileSync(snapshotPath(a), 'utf8'), 'utf8');
+
+  const r = guard(b, ['verify']);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /was taken in/);
+});
+
+test('an unknown argument is an error, not a silently narrower check', async (t) => {
+  const dir = makeRepo(t);
+
+  for (const args of [['snapshot', '--force'], ['verify', '--all'], ['inspect']]) {
+    const r = guard(dir, args);
+    assert.equal(r.status, 2, `${JSON.stringify(args)} was accepted`);
+    assert.match(r.stderr, /unknown (argument|command)/);
+  }
+});
+
+test('the snapshot lives outside the working tree, so it cannot dirty it', async (t) => {
+  // The first version wrote it to the repo root, where it showed up in `git
+  // status` as untracked and an agent's `git add -A` — the very command from the
+  // incident — would have committed it. `.git/` is outside the working tree.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+
+  assert.ok(existsSync(snapshotPath(dir)), 'snapshot should be inside .git/');
+  assert.equal(git(dir, ['status', '--porcelain']), '',
+    'taking a snapshot must not dirty the working tree');
+
+  const r = guard(dir, ['verify', '--keep']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.ok(existsSync(snapshotPath(dir)), '--keep should preserve it');
+});

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -186,20 +186,47 @@ test('detects a same-LENGTH content substitution', async (t) => {
   assert.match(r.stderr, /contents changed/);
 });
 
-test('detects a tracked file swapped for a symlink', async (t) => {
-  // The status line does not move, and the path stops being a regular file — so
-  // a comparison that iterates only the surviving content keys never visits it.
+test('detects an untracked file swapped for a symlink to a DIRECTORY', async (t) => {
+  // The `(not-a-regular-file)` sentinel exists for exactly this. git does not
+  // descend into or dereference the symlink, so `?? notes.md` is byte-identical
+  // before and after; and the path stops being a regular file, so skipping it
+  // from the content map would leave nothing to compare. A symlink to a FILE
+  // does not exercise this — it still hashes, via the target.
   const dir = makeRepo(t);
-  writeFileSync(join(dir, 'src', 'a.txt'), 'work in progress\n', 'utf8');
+  writeFileSync(join(dir, 'notes.md'), 'my notes\n', 'utf8');
+  mkdirSync(join(dir, 'elsewhere'), { recursive: true });
   guard(dir, ['snapshot']);
 
-  rmSync(join(dir, 'src', 'a.txt'));
-  symlinkSync('/etc/hostname', join(dir, 'src', 'a.txt'));
+  const statusBefore = git(dir, ['status', '--porcelain']);
+  rmSync(join(dir, 'notes.md'));
+  symlinkSync(join(dir, 'elsewhere'), join(dir, 'notes.md'));
+  assert.equal(git(dir, ['status', '--porcelain']), statusBefore,
+    'precondition: the status line is unchanged');
 
   const r = guard(dir, ['verify']);
 
   assert.equal(r.status, 1);
   assert.match(r.stderr, /contents changed/);
+  assert.match(r.stderr, /notes\.md/);
+});
+
+test('detects an untracked file swapped for a DANGLING symlink', async (t) => {
+  // The `(absent)` sentinel. Same shape: git still reports `?? notes.md`, but
+  // the path no longer resolves to anything readable.
+  const dir = makeRepo(t);
+  writeFileSync(join(dir, 'notes.md'), 'my notes\n', 'utf8');
+  guard(dir, ['snapshot']);
+
+  const statusBefore = git(dir, ['status', '--porcelain']);
+  rmSync(join(dir, 'notes.md'));
+  symlinkSync(join(dir, 'no-such-target'), join(dir, 'notes.md'));
+  assert.equal(git(dir, ['status', '--porcelain']), statusBefore,
+    'precondition: the status line is unchanged');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /notes\.md/);
 });
 
 test('detects a new file inside an already-untracked directory', async (t) => {

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -387,6 +387,23 @@ test('verify without a snapshot is an error, never a pass', async (t) => {
   assert.match(r.stderr, /no snapshot/);
 });
 
+test('a snapshot that cannot be WRITTEN exits 2, not 1', async (t) => {
+  // An uncaught throw exits 1, which in this tool's vocabulary means "the
+  // repository changed" — so a disk or permission failure would masquerade as a
+  // verdict. Occupying the snapshot path with a directory makes the write fail
+  // deterministically on any filesystem.
+  const dir = makeRepo(t);
+  mkdirSync(snapshotPath(dir), { recursive: true });
+
+  // A directory at that path also trips the "already exists" refusal, which is
+  // a different branch — `--force` gets past it to the write itself.
+  const r = guard(dir, ['snapshot', '--force']);
+
+  assert.equal(r.status, 2, 'must read as uncertainty, never as a verdict');
+  assert.match(r.stderr, /could not write the snapshot/);
+  assert.match(r.stderr, /NOT guarded/);
+});
+
 test('an unreadable snapshot is an error, never a pass', async (t) => {
   const dir = makeRepo(t);
   guard(dir, ['snapshot']);

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -449,7 +449,9 @@ test('a snapshot in an older format is an error naming the reason', async (t) =>
   const r = guard(dir, ['verify']);
 
   assert.equal(r.status, 2);
-  assert.match(r.stderr, /format v1, but this is v2/);
+  // Version-agnostic: hardcoding the pair meant every FORMAT_VERSION bump broke
+  // this test, which is noise rather than signal.
+  assert.match(r.stderr, /format v1, but this is v\d+/);
   assert.match(r.stderr, /guard:snapshot/, 'should say how to recover');
 });
 

--- a/scripts/test/workflow-template.test.js
+++ b/scripts/test/workflow-template.test.js
@@ -1,0 +1,54 @@
+/**
+ * `workflows/_template.mjs` must pass the syntax check its own docs prescribe.
+ *
+ * Authors are told to copy the template and then validate it (step 4). Adding a
+ * second top-level `export` broke that: the documented recipe wraps the file in
+ * an async IIFE and rewrites only `export const meta`, so anything else exported
+ * becomes `SyntaxError: Unexpected token 'export'` inside the wrapper — every
+ * new workflow would start broken, before its author had written a line.
+ *
+ * The recipe is duplicated in four places (the template, the guide, the skill,
+ * and workflows/README.md), so this test pins the template against the recipe
+ * rather than against any one copy of it.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WORKFLOWS = join(ROOT, 'workflows');
+
+/** The documented check: strip `export` from meta, wrap, and parse. */
+function wrapCheck(file) {
+  const source = readFileSync(file, 'utf8').replace(/^\s*export const meta/m, 'const meta');
+  const wrapped = `(async()=>{\n${source}\n})()`;
+  const r = spawnSync(process.execPath, ['--check', '-'], { input: wrapped, encoding: 'utf8' });
+  return { ok: r.status === 0, stderr: r.stderr || '' };
+}
+
+const scripts = readdirSync(WORKFLOWS).filter((f) => f.endsWith('.mjs'));
+
+test('there are workflow scripts to check', () => {
+  // Otherwise the loop below would assert nothing and pass.
+  assert.ok(scripts.length > 0, 'no .mjs files found in workflows/');
+});
+
+for (const name of scripts) {
+  test(`workflows/${name} passes the documented wrap-then-check recipe`, () => {
+    const { ok, stderr } = wrapCheck(join(WORKFLOWS, name));
+    assert.ok(ok, `${name} failed the documented syntax check:\n${stderr.split('\n').slice(0, 6).join('\n')}`);
+  });
+}
+
+test('the template exports nothing but meta', () => {
+  // The recipe only ever rewrites `export const meta`; any other top-level
+  // export is a latent break of the check above.
+  const source = readFileSync(join(WORKFLOWS, '_template.mjs'), 'utf8');
+  const exports = source.split('\n').filter((line) => /^\s*export\b/.test(line));
+  assert.deepEqual(exports.map((l) => l.trim()), ['export const meta = {'],
+    'only `export const meta` may be exported from a workflow');
+});

--- a/skills/create-workflow/SKILL.md
+++ b/skills/create-workflow/SKILL.md
@@ -186,7 +186,14 @@ job, around the `Workflow(...)` call:
 ```bash
 npm run guard:snapshot   # before launching the workflow
 npm run guard:verify     # after it returns
+npm run guard:release    # when the run is genuinely over
 ```
+
+`verify` keeps the snapshot and `snapshot` refuses to overwrite one, so skipping
+`guard:release` leaves the next run failing with "a snapshot already exists".
+That is deliberate — re-arming mid-run would rebaseline the damage — but it means
+release is part of the loop, not an optional tidy-up. Note also that npm swallows
+`--release` as its own config, which is why there is a script rather than a flag.
 
 It compares HEAD, branch, worktree status, the content of every changed or
 untracked file, and index flags. Exit 1 prints the difference; exit 2 means it

--- a/skills/create-workflow/SKILL.md
+++ b/skills/create-workflow/SKILL.md
@@ -179,36 +179,56 @@ The advisory/implementing contract in Step 7 governs the agent type a stage
 tree, and a "read-only" review fleet is exactly where that gap bites: every agent
 inherits the repository as its default working directory.
 
-Apply all four before fanning out against a repo you care about:
+**Bracket the run with `repo-guard`** — this is the mechanical control. A workflow
+body cannot run shell (no filesystem or Node API), so this is the *invoker's*
+job, around the `Workflow(...)` call:
 
-1. **Give each agent its own scratch namespace.** Parallel agents told to build
-   fixtures independently converge on the same obvious filename. Instruct them to
-   `mktemp -d` unconditionally, or hand each a distinct directory — never a shared
-   fixed path.
-2. **Require `cd <dir> || exit 1`.** A bare `cd` that fails does not reliably
-   abort the surrounding script, and every following relative path then resolves
-   against the repository.
-3. **Require a cwd assertion before any destructive step** — `git add -A`,
-   `git commit`, or a tool run with a write flag:
+```bash
+npm run guard:snapshot   # before launching the workflow
+npm run guard:verify     # after it returns
+```
+
+It compares HEAD, branch, worktree status, the content of every changed or
+untracked file, and index flags. Exit 1 prints the difference; exit 2 means it
+could not answer and must never be read as a pass. Two comparisons carry most of
+the weight: HEAD, the only one that catches a subagent that *committed* (the tree
+reads clean afterwards), and file content, without which a stray write to an
+already-modified file is invisible — its status line does not move.
+
+It does **not** cover ignored paths; walking them would mean hashing
+`node_modules`.
+
+**Contain the agents themselves.** Prepend the `REPO_SAFETY` preamble from
+`workflows/_template.mjs` to the prompt of every agent that may run shell
+commands — verifiers included, since a verifier reproducing a finding is the
+agent most likely to build a fixture. Copying the template gets this by default.
+It carries three rules:
+
+1. **`mktemp -d`, never a shared fixed path.** Parallel agents told to build
+   fixtures independently converge on the same obvious filename, and the second
+   clobbers the first.
+2. **`cd "$DIR" || exit 1`.** A bare `cd` that fails does not reliably abort the
+   surrounding script, and every following relative path then resolves against
+   the repository.
+3. **A cwd assertion before any destructive step** — `git add`, `git commit`, or
+   a tool run with a write flag:
 
    ```bash
-   [ "$(git rev-parse --show-toplevel)" = "$FIXTURE_DIR" ] || exit 1
+   [ "$(git rev-parse --show-toplevel)" = "$DIR" ] || exit 1
    ```
 
-4. **Record `HEAD` before the run and compare after.** This is the only check that
-   catches a subagent that *committed*: `git status` reads clean afterwards, so
-   every dirty-tree check passes.
+Prefer `isolation: 'worktree'` for any stage that might mutate. Treat the preamble
+as documentation and the guard as the control — the prompt in #493 already named
+the directory, the tool and the file to copy, and the agent complied with all
+three.
 
-Prefer `isolation: 'worktree'` for any stage that might mutate, and treat a prompt
-sentence as documentation rather than as a control.
+**Expected:** `npm run guard:verify` exits 0 after the run.
 
-**Expected:** A repo-touching fan-out leaves `git rev-parse HEAD` and
-`git status --porcelain` exactly as it found them.
-
-**On failure:** If HEAD moved, find the commit before pushing —
-`git log --oneline <recorded-head>..HEAD`. A stray commit is unpushed and
-recoverable; state what a reset destroys, confirm it is unpushed, then
-`git reset --mixed <recorded-head>` and remove the stray files.
+**On failure:** Exit 1 prints what moved and the recovery command. A stray commit
+is recoverable while unpushed: confirm it is unpushed, state what the reset
+destroys, then `git reset --mixed <recorded-head>` and remove the stray files.
+Exit 2 means the guard could not compare — re-snapshot and re-run rather than
+treating it as a pass.
 
 ## Validation
 
@@ -221,7 +241,7 @@ recoverable; state what a reset destroys, confirm it is unpushed, then
 - [ ] Verification stages gate on a confirmation quorum and `filter(Boolean)` null results.
 - [ ] No forbidden calls: `Date.now()`, `Math.random()`, argless `new Date()`; no TypeScript syntax; no filesystem/Node APIs.
 - [ ] The wrap-then-`node --check` recipe passes.
-- [ ] A repo-touching fan-out carries the Step 11 containment, and `HEAD` is verified unchanged after the run.
+- [ ] A repo-touching fan-out is bracketed by `npm run guard:snapshot` / `guard:verify`, and agents with shell access carry the `REPO_SAFETY` preamble (Step 11).
 - [ ] No `workflows/_registry.yml` entry or translation scaffold was created (both are Phase 2 / i18n-excluded).
 
 ## Common Pitfalls

--- a/workflows/_template.mjs
+++ b/workflows/_template.mjs
@@ -83,9 +83,15 @@ const items =
 // `SyntaxError: Unexpected token 'export'` inside the wrapper — the template
 // would fail its own step 4 before an author had written a line.
 const REPO_SAFETY = `SAFETY — you are running inside a live git repository.
-Work only in a directory you created yourself with \`mktemp -d\`; never a shared
-or fixed path, because parallel agents pick the same obvious filename.
-- Write \`cd "$DIR" || exit 1\`. A bare \`cd\` that fails does not stop the script.
+Work only in a directory you created yourself; never a shared or fixed path,
+because parallel agents pick the same obvious filename and clobber each other.
+Start every shell block that touches files with exactly this:
+
+    DIR="$(mktemp -d)" || exit 1
+    cd "$DIR" || exit 1
+
+- The \`|| exit 1\` on \`cd\` is load-bearing: a bare \`cd\` that fails does NOT stop
+  the script, and every relative path after it resolves against the repository.
 - Before any \`git add\`, \`git commit\`, or a tool run with a write flag, assert:
     [ "$(git rev-parse --show-toplevel)" = "$DIR" ] || exit 1
 - Never run \`git commit\`, \`git update-index\`, or \`git checkout --\` against the

--- a/workflows/_template.mjs
+++ b/workflows/_template.mjs
@@ -60,9 +60,7 @@ export const meta = {
 const items =
   Array.isArray(args?.items) && args.items.length ? args.items : ['example-a', 'example-b']
 
-// A JSON Schema turns agent() into structured output: the subagent is forced to
-// call StructuredOutput and agent() returns the validated object (no parsing).
-// Prepend to the prompt of any agent that may run shell commands.
+// REPO_SAFETY — prepend to the prompt of any agent that may run shell commands.
 //
 // Every agent inherits the repository as its working directory, and the
 // advisory/implementing contract constrains the agent TYPE a stage declares, not
@@ -75,9 +73,11 @@ const items =
 // The prompt in that run already said "build fixtures under /tmp", and the agent
 // complied with it. These lines are mechanical instead: they remove the shared
 // path, make the failed `cd` fatal, and assert the target before anything
-// destructive. Bracket the whole run with `npm run guard:snapshot` /
-// `npm run guard:verify`, which is the only check that catches a stray COMMIT —
-// `git status` reads clean once a stray write has been committed.
+// destructive. Bracket the whole run with `npm run guard:snapshot`, then
+// `npm run guard:verify` and `npm run guard:release` — the HEAD comparison is the
+// only check that catches a stray COMMIT, since `git status` reads clean once a
+// stray write has been committed. Release is part of the loop, not a tidy-up:
+// verify keeps the snapshot and snapshot refuses to overwrite one.
 // NOT exported. The documented syntax check wraps the file in an async IIFE and
 // rewrites only `export const meta`, so any other top-level `export` becomes
 // `SyntaxError: Unexpected token 'export'` inside the wrapper — the template
@@ -97,6 +97,8 @@ Start every shell block that touches files with exactly this:
 - Never run \`git commit\`, \`git update-index\`, or \`git checkout --\` against the
   repository itself, and never invoke a repo tool with a write flag there.`
 
+// A JSON Schema turns agent() into structured output: the subagent is forced to
+// call StructuredOutput and agent() returns the validated object (no parsing).
 const FINDING_SCHEMA = {
   type: 'object',
   required: ['item', 'summary', 'confidence'],

--- a/workflows/_template.mjs
+++ b/workflows/_template.mjs
@@ -62,6 +62,31 @@ const items =
 
 // A JSON Schema turns agent() into structured output: the subagent is forced to
 // call StructuredOutput and agent() returns the validated object (no parsing).
+// Prepend to the prompt of any agent that may run shell commands.
+//
+// Every agent inherits the repository as its working directory, and the
+// advisory/implementing contract constrains the agent TYPE a stage declares, not
+// what Bash does once the agent has it. In #493 a review subagent's fixture
+// landed in the corpus and was committed: two parallel agents had written the
+// same shared scratchpad filename, the second clobbered the first, and the
+// victim's `cd` into a directory that was never created failed WITHOUT stopping
+// the script — so every following relative path resolved against the repo.
+//
+// The prompt in that run already said "build fixtures under /tmp", and the agent
+// complied with it. These lines are mechanical instead: they remove the shared
+// path, make the failed `cd` fatal, and assert the target before anything
+// destructive. Bracket the whole run with `npm run guard:snapshot` /
+// `npm run guard:verify`, which is the only check that catches a stray COMMIT —
+// `git status` reads clean once a stray write has been committed.
+const REPO_SAFETY = `SAFETY — you are running inside a live git repository.
+Work only in a directory you created yourself with \`mktemp -d\`; never a shared
+or fixed path, because parallel agents pick the same obvious filename.
+- Write \`cd "$DIR" || exit 1\`. A bare \`cd\` that fails does not stop the script.
+- Before any \`git add\`, \`git commit\`, or a tool run with a write flag, assert:
+    [ "$(git rev-parse --show-toplevel)" = "$DIR" ] || exit 1
+- Never run \`git commit\`, \`git update-index\`, or \`git checkout --\` against the
+  repository itself, and never invoke a repo tool with a write flag there.`
+
 const FINDING_SCHEMA = {
   type: 'object',
   required: ['item', 'summary', 'confidence'],
@@ -98,8 +123,12 @@ const results = await pipeline(
   // that MUTATES artifacts (Write/Edit/Bash, or isolation: 'worktree') must
   // target an `implementing` agent type — the workflow analogue of the #285
   // team-assignment rule (advisory vs implementing capability contract).
+  //
+  // Prepend REPO_SAFETY to any prompt whose agent may run shell commands: the
+  // capability contract governs the agent type a stage DECLARES, not what a
+  // Bash-capable agent does to the working tree (#493).
   (item) =>
-    agent(`Examine "${item}" and report one finding.`, {
+    agent(`${REPO_SAFETY}\n\nExamine "${item}" and report one finding.`, {
       label: `scan:${item}`,
       phase: 'Scan',
       agentType: 'Explore', // advisory: Read/Grep/Glob/Bash, no Write/Edit — honors the contract above

--- a/workflows/_template.mjs
+++ b/workflows/_template.mjs
@@ -78,7 +78,11 @@ const items =
 // destructive. Bracket the whole run with `npm run guard:snapshot` /
 // `npm run guard:verify`, which is the only check that catches a stray COMMIT —
 // `git status` reads clean once a stray write has been committed.
-export const REPO_SAFETY = `SAFETY — you are running inside a live git repository.
+// NOT exported. The documented syntax check wraps the file in an async IIFE and
+// rewrites only `export const meta`, so any other top-level `export` becomes
+// `SyntaxError: Unexpected token 'export'` inside the wrapper — the template
+// would fail its own step 4 before an author had written a line.
+const REPO_SAFETY = `SAFETY — you are running inside a live git repository.
 Work only in a directory you created yourself with \`mktemp -d\`; never a shared
 or fixed path, because parallel agents pick the same obvious filename.
 - Write \`cd "$DIR" || exit 1\`. A bare \`cd\` that fails does not stop the script.

--- a/workflows/_template.mjs
+++ b/workflows/_template.mjs
@@ -78,7 +78,7 @@ const items =
 // destructive. Bracket the whole run with `npm run guard:snapshot` /
 // `npm run guard:verify`, which is the only check that catches a stray COMMIT —
 // `git status` reads clean once a stray write has been committed.
-const REPO_SAFETY = `SAFETY — you are running inside a live git repository.
+export const REPO_SAFETY = `SAFETY — you are running inside a live git repository.
 Work only in a directory you created yourself with \`mktemp -d\`; never a shared
 or fixed path, because parallel agents pick the same obvious filename.
 - Write \`cd "$DIR" || exit 1\`. A bare \`cd\` that fails does not stop the script.
@@ -140,7 +140,10 @@ const results = await pipeline(
   // this is what kills the false-positive flood in naive multi-agent review.
   (finding, item) =>
     agent(
-      `Independently verify this finding about "${item}": ${finding?.summary}. ` +
+      // Every Bash-capable stage carries the preamble, not just the first —
+      // a verifier that reproduces a finding is exactly the agent most likely
+      // to build a fixture, which is how #493 happened.
+      `${REPO_SAFETY}\n\nIndependently verify this finding about "${item}": ${finding?.summary}. ` +
         `Default to confirmed=false unless you can reproduce it.`,
       { label: `verify:${item}`, phase: 'Verify', agentType: 'Explore', schema: VERDICT_SCHEMA },
     ).then((verdict) => ({ ...finding, verdict })),


### PR DESCRIPTION
Closes #493.

#491 wrote down how to fan out agents against a live repository without letting them write to it. Writing it down is what already failed: in the incident that prompted it, the prompt named the directory, the tool and the file to copy, and the agent complied with all three. The failure was mechanical — a shared scratchpad filename clobbered by a parallel agent, then a `cd` into a directory that was never created failing without stopping the script.

So this is the check that runs.

## Detection — `scripts/repo-guard.js`

```bash
npm run guard:snapshot   # before the fan-out
npm run guard:verify     # after it returns; --release when done
```

Compares five things, each a way a change can hide:

| | Catches |
|---|---|
| HEAD | a stray **commit** — `git status` reads clean afterwards, so every dirty-tree check passes |
| branch | a checkout that moved the working branch |
| status lines | files appearing, vanishing, changing state |
| **file contents** | a stray write to an **already-modified** file, whose status line does not move |
| index flags | `skip-worktree` / `assume-unchanged`, which make git report a modified file as clean from then on |

Fails closed. Missing, unreadable, foreign, or stale-format snapshot → exit 2, never 0. `snapshot` refuses to overwrite and `verify` keeps by default, so a nested run cannot rebaseline the outer run's damage into a green.

Scope limit, stated in the header and all three doc sites: **ignored paths are not covered** — walking them means hashing `node_modules`.

## Prevention — `REPO_SAFETY` in `workflows/_template.mjs`

An exported prompt preamble, wired into **both** example agent stages: `mktemp -d` rather than a shared path, `cd "$DIR" || exit 1`, and a `git rev-parse --show-toplevel` assertion before anything destructive. Copying the template inherits it.

## What the dogfood found

I armed the guard, pointed an adversarial fan-out at it, and the run was interrupted — which turned out to be the most useful thing that could have happened. Two of four lenses reported before the kill, and they found **three blocking defects in the guard itself**:

1. **The worktree baseline stored status *lines*, not content.** Overwriting an already-modified file leaves ` M CLAUDE.md` byte-identical, so the guard passed while the file had been rewritten. This repo is normally mid-edit, making that the common case — and it is exactly the #493 scenario, where the stray write landed on a tree that already had pending work. *The guard would have missed the incident it was built for.*
2. **A single global snapshot slot** let a nested run launder damage into a green.
3. **`verify` consumed the snapshot by default**, which silently disarmed the guard during this very run — something ran verify mid-run and the real check afterwards had nothing to compare against.

Plus: `ls-files -v` is cwd-scoped (a `skip-worktree` bit set outside cwd was invisible); `--porcelain` collapses untracked directories; the recovery advice printed `git reset --mixed` unconditionally, which would unstage the caller's own work when HEAD never moved; and the template wired `REPO_SAFETY` into only the first of two Bash-capable stages while the docs claimed otherwise.

All fixed here, each with a test.

## Verification

38 tests. Twelve mutations, each killed and restored:

| Mutation | Killed by |
|---|---|
| content hashing → constant | 1 |
| content comparison → skipped | 1 |
| `-uall` dropped | 1 |
| clobber refusal removed | 1 |
| toplevel scoping removed from `ls-files` | 1 |
| HEAD comparison removed | 1 |
| index-flag capture neutered | 1 |
| missing-snapshot treated as pass | 2 |
| worktree comparison removed | 2 |
| branch comparison removed | 1 |
| foreign-snapshot check removed | 1 |
| exit 1 → exit 0 | 5 |

The blocking test asserts the porcelain line is byte-identical before and after the stray write, so it fails against any status-line-only comparison.

`npm test`, `test:cli`, `test:scripts`, line-endings and content-style all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZHXCqANCeAZEy3ixDuiYk