### PR TITLE
fix(i18n): tag-scoped batches, and #477 batch 1 (yaml+json)

### DIFF
--- a/i18n/caveman-lite/skills/build-ci-cd-pipeline/SKILL.md
+++ b/i18n/caveman-lite/skills/build-ci-cd-pipeline/SKILL.md
@@ -53,11 +53,6 @@ Create `.github/workflows/ci.yml` with trigger configuration and basic job struc
 
 ```yaml
 name: CI Pipeline
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 on:
   push:

--- a/i18n/caveman-lite/skills/create-agent/SKILL.md
+++ b/i18n/caveman-lite/skills/create-agent/SKILL.md
@@ -135,11 +135,6 @@ Fill in the YAML frontmatter:
 ```yaml
 ---
 name: agent-name
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: One to two sentences describing primary capability and domain
 tools: [Read, Write, Edit, Bash, Grep, Glob]
 model: sonnet

--- a/i18n/caveman-lite/skills/create-skill/SKILL.md
+++ b/i18n/caveman-lite/skills/create-skill/SKILL.md
@@ -76,11 +76,6 @@ Naming conventions:
 ```yaml
 ---
 name: skill-name-here
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: >
   One to three sentences plus key activation triggers. Must be clear
   enough for an agent to decide whether to activate this skill from

--- a/i18n/caveman-lite/skills/enforce-policy-as-code/SKILL.md
+++ b/i18n/caveman-lite/skills/enforce-policy-as-code/SKILL.md
@@ -357,11 +357,6 @@ echo "=== Policy Validation for CI/CD ==="
 ```yaml
 # .github/workflows/policy-validation.yaml
 name: Policy Validation
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 on:
   pull_request:

--- a/i18n/caveman-lite/skills/provision-infrastructure-terraform/SKILL.md
+++ b/i18n/caveman-lite/skills/provision-infrastructure-terraform/SKILL.md
@@ -296,11 +296,6 @@ For automated CI/CD integration:
 ```yaml
 # .github/workflows/terraform.yml
 name: Terraform
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 on:
   pull_request:

--- a/i18n/caveman-lite/skills/redact-for-public-disclosure/SKILL.md
+++ b/i18n/caveman-lite/skills/redact-for-public-disclosure/SKILL.md
@@ -210,11 +210,6 @@ Run `tools/check-redaction.sh` on every commit to the public-sync branch. A fail
 ```yaml
 # .github/workflows/redaction-check.yml (in the public mirror repo)
 name: redaction-check
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-26"
 on:
   push:
     branches: [main, publish-*]

--- a/i18n/caveman-lite/skills/register-ml-model/SKILL.md
+++ b/i18n/caveman-lite/skills/register-ml-model/SKILL.md
@@ -169,11 +169,6 @@ Integrate model registration into CI/CD pipelines for automated promotion.
 ```yaml
 # .github/workflows/model_promotion.yml
 name: Model Promotion Pipeline
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-26"
 
 on:
   workflow_dispatch:

--- a/i18n/caveman-lite/skills/setup-github-actions-ci/SKILL.md
+++ b/i18n/caveman-lite/skills/setup-github-actions-ci/SKILL.md
@@ -55,11 +55,6 @@ on:
     branches: [main, master]
 
 name: R-CMD-check
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -121,11 +116,6 @@ on:
     branches: [main, master]
 
 name: test-coverage
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -183,11 +173,6 @@ on:
   workflow_dispatch:
 
 name: pkgdown
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions:
   contents: write

--- a/i18n/caveman-lite/skills/setup-local-kubernetes/SKILL.md
+++ b/i18n/caveman-lite/skills/setup-local-kubernetes/SKILL.md
@@ -115,11 +115,6 @@ Create a multi-node cluster with ingress and local registry support.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: dev-cluster
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 nodes:
 - role: control-plane
   extraPortMappings:

--- a/i18n/caveman-lite/skills/version-ml-data/SKILL.md
+++ b/i18n/caveman-lite/skills/version-ml-data/SKILL.md
@@ -286,11 +286,6 @@ GitHub Actions CI/CD:
 ```yaml
 # .github/workflows/ml-pipeline.yml
 name: ML Pipeline
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 on:
   push:

--- a/i18n/caveman-lite/skills/write-helm-chart/SKILL.md
+++ b/i18n/caveman-lite/skills/write-helm-chart/SKILL.md
@@ -99,11 +99,6 @@ cd my-app
 # Chart.yaml (excerpt - see EXAMPLES.md for complete file)
 apiVersion: v2
 name: my-app
-locale: caveman-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: A Helm chart for deploying my-app to Kubernetes
 version: 0.1.0
 appVersion: "1.0.0"

--- a/i18n/caveman-ultra/skills/instrument-distributed-tracing/SKILL.md
+++ b/i18n/caveman-ultra/skills/instrument-distributed-tracing/SKILL.md
@@ -106,7 +106,7 @@ server:
 distributor:
   receivers:
     jaeger:
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Prod w/ S3 storage**:
@@ -408,7 +408,7 @@ metrics_generator:
     external_labels:
       cluster: production
   storage:
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 Prometheus metrics produced:

--- a/i18n/caveman-ultra/skills/manage-kubernetes-secrets/SKILL.md
+++ b/i18n/caveman-ultra/skills/manage-kubernetes-secrets/SKILL.md
@@ -350,7 +350,7 @@ metadata:
   name: myapp-ingress
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 → cert-manager obtains cert from Let's Encrypt. TLS secret created w/ valid cert + private key. Cert auto-renews before expiration. Ingress uses for HTTPS termination.
@@ -403,7 +403,7 @@ kind: Namespace
 metadata:
   name: production
 ---
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 Test RBAC:

--- a/i18n/caveman-ultra/skills/metal/SKILL.md
+++ b/i18n/caveman-ultra/skills/metal/SKILL.md
@@ -211,11 +211,6 @@ Produce agentskills.io standard outputs.
 ```yaml
 # Skill: [generalized-name]
 name: [generalized-name]
-locale: caveman-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: [one-line, framework-agnostic]
 domain: [closest domain from the 52 existing domains, or suggest a new one]
 complexity: [basic/intermediate/advanced]
@@ -231,11 +226,6 @@ complexity: [basic/intermediate/advanced]
 ```yaml
 # Agent: [role-name]
 name: [role-name]
-locale: caveman-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: [one-line purpose]
 tools: [minimal tool set needed]
 skills: [list of extracted skills this agent would carry]
@@ -247,11 +237,6 @@ skills: [list of extracted skills this agent would carry]
 ```yaml
 # Team: [group-name]
 name: [group-name]
-locale: caveman-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: [one-line purpose]
 lead: [lead agent from extracted agents]
 members: [list of member agents]

--- a/i18n/caveman-ultra/skills/setup-github-actions-ci/SKILL.md
+++ b/i18n/caveman-ultra/skills/setup-github-actions-ci/SKILL.md
@@ -55,11 +55,6 @@ on:
     branches: [main, master]
 
 name: R-CMD-check
-locale: caveman-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -121,11 +116,6 @@ on:
     branches: [main, master]
 
 name: test-coverage
-locale: caveman-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -183,11 +173,6 @@ on:
   workflow_dispatch:
 
 name: pkgdown
-locale: caveman-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions:
   contents: write

--- a/i18n/caveman-ultra/skills/setup-local-kubernetes/SKILL.md
+++ b/i18n/caveman-ultra/skills/setup-local-kubernetes/SKILL.md
@@ -115,11 +115,6 @@ Create a multi-node cluster with ingress and local registry support.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: dev-cluster
-locale: caveman-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 nodes:
 - role: control-plane
   extraPortMappings:

--- a/i18n/caveman-ultra/skills/version-ml-data/SKILL.md
+++ b/i18n/caveman-ultra/skills/version-ml-data/SKILL.md
@@ -286,11 +286,6 @@ GitHub Actions CI/CD:
 ```yaml
 # .github/workflows/ml-pipeline.yml
 name: ML Pipeline
-locale: caveman-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 on:
   push:

--- a/i18n/caveman-ultra/skills/write-helm-chart/SKILL.md
+++ b/i18n/caveman-ultra/skills/write-helm-chart/SKILL.md
@@ -99,11 +99,6 @@ cd my-app
 # Chart.yaml (excerpt - see EXAMPLES.md for complete file)
 apiVersion: v2
 name: my-app
-locale: caveman-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: A Helm chart for deploying my-app to Kubernetes
 version: 0.1.0
 appVersion: "1.0.0"

--- a/i18n/caveman/skills/setup-github-actions-ci/SKILL.md
+++ b/i18n/caveman/skills/setup-github-actions-ci/SKILL.md
@@ -55,11 +55,6 @@ on:
     branches: [main, master]
 
 name: R-CMD-check
-locale: caveman
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -121,11 +116,6 @@ on:
     branches: [main, master]
 
 name: test-coverage
-locale: caveman
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -183,11 +173,6 @@ on:
   workflow_dispatch:
 
 name: pkgdown
-locale: caveman
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions:
   contents: write

--- a/i18n/caveman/skills/setup-local-kubernetes/SKILL.md
+++ b/i18n/caveman/skills/setup-local-kubernetes/SKILL.md
@@ -115,11 +115,6 @@ Create a multi-node cluster with ingress and local registry support.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: dev-cluster
-locale: caveman
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 nodes:
 - role: control-plane
   extraPortMappings:

--- a/i18n/caveman/skills/version-ml-data/SKILL.md
+++ b/i18n/caveman/skills/version-ml-data/SKILL.md
@@ -286,11 +286,6 @@ GitHub Actions CI/CD:
 ```yaml
 # .github/workflows/ml-pipeline.yml
 name: ML Pipeline
-locale: caveman
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 on:
   push:

--- a/i18n/caveman/skills/write-helm-chart/SKILL.md
+++ b/i18n/caveman/skills/write-helm-chart/SKILL.md
@@ -99,11 +99,6 @@ cd my-app
 # Chart.yaml (excerpt - see EXAMPLES.md for complete file)
 apiVersion: v2
 name: my-app
-locale: caveman
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: A Helm chart for deploying my-app to Kubernetes
 version: 0.1.0
 appVersion: "1.0.0"

--- a/i18n/de/skills/add-puzzle-type/SKILL.md
+++ b/i18n/de/skills/add-puzzle-type/SKILL.md
@@ -190,7 +190,7 @@ Standards und Beschraenkungen fuer den neuen Typ hinzufuegen:
     default: 20
     min: 5
     max: 50
-  # Typspezifische Parameter hier hinzufuegen
+  # Add type-specific params here
 ```
 
 **Erwartet:** Konfiguration ist gueltiges YAML. Standardwerte erzeugen ein funktionierendes Puzzle bei Verwendung durch `generate_puzzle()`.

--- a/i18n/de/skills/circuit-breaker-pattern/SKILL.md
+++ b/i18n/de/skills/circuit-breaker-pattern/SKILL.md
@@ -61,44 +61,44 @@ Dokumentieren, was jedes Tool bereitstellt und welche Alternativen existieren. D
 ```yaml
 capability_map:
   - tool: Grep
-    provides: Inhaltssuche ueber Dateien
+    provides: content search across files
     alternatives:
       - tool: Bash
-        method: "rg oder grep Befehl"
-        degradation: "verliert Greps eingebaute Ausgabeformatierung"
+        method: "rg or grep command"
+        degradation: "loses Grep's built-in output formatting"
       - tool: Read
-        method: "vermutete Dateien direkt lesen"
-        degradation: "erfordert zu wissen welche Dateien zu pruefen; keine breite Suche"
-    fallback: "Nutzer fragen, welche Dateien untersucht werden sollen"
+        method: "read suspected files directly"
+        degradation: "requires knowing which files to check; no broad search"
+    fallback: "ask the user which files to examine"
 
   - tool: Bash
-    provides: Befehlsausfuehrung, Build-Tools, Git-Operationen
+    provides: command execution, build tools, git operations
     alternatives: []
-    fallback: "Befehle berichten, die manuell ausgefuehrt werden muessen"
+    fallback: "report commands that need to be run manually"
 
   - tool: Read
-    provides: Dateiinhalt-Inspektion
+    provides: file content inspection
     alternatives:
       - tool: Bash
-        method: "cat oder head Befehl"
-        degradation: "verliert Zeilennummerierung und Kuerzungssicherheit"
-    fallback: "Nutzer bitten, Dateiinhalte einzufuegen"
+        method: "cat or head command"
+        degradation: "loses line numbering and truncation safety"
+    fallback: "ask the user to paste file contents"
 
   - tool: Write
-    provides: Dateierstellung
+    provides: file creation
     alternatives:
       - tool: Edit
-        method: "ueber vollstaendige Datei-Edit erstellen"
-        degradation: "erfordert, dass die Datei bereits fuer Edit existiert"
+        method: "create via full-file edit"
+        degradation: "requires file to already exist for Edit"
       - tool: Bash
         method: "echo/cat heredoc"
-        degradation: "verliert Writes atomare Dateierstellung"
-    fallback: "Dateiinhalte ausgeben, damit Nutzer manuell speichert"
+        degradation: "loses Write's atomic file creation"
+    fallback: "output file contents for the user to save manually"
 
   - tool: WebSearch
-    provides: Externe Informationsabfrage
+    provides: external information retrieval
     alternatives: []
-    fallback: "Benoettigte Informationen benennen; Nutzer bitten sie bereitzustellen"
+    fallback: "state what information is needed; ask user to provide it"
 ```
 
 Fuer jedes Tool dokumentieren:

--- a/i18n/de/skills/create-agent/SKILL.md
+++ b/i18n/de/skills/create-agent/SKILL.md
@@ -136,7 +136,7 @@ Das YAML-Frontmatter ausfuellen:
 ```yaml
 ---
 name: agent-name
-description: Ein bis zwei Saetze zur primaeren Faehigkeit und Domain
+description: One to two sentences describing primary capability and domain
 tools: [Read, Write, Edit, Bash, Grep, Glob]
 model: sonnet
 version: "1.0.0"
@@ -149,9 +149,9 @@ max_context_tokens: 200000
 skills:
   - assigned-skill-one
   - assigned-skill-two
-# Hinweis: Alle Agenten erben Standard-Skills (meditate, heal) aus der Registry.
-# Diese nur hier aufführen, wenn sie Kern der Methodik dieses Agenten sind.
-# mcp_servers: []  # Bei Bedarf auskommentieren und befuellen
+# Note: All agents inherit default skills (meditate, heal) from the registry.
+# Only list them here if they are core to this agent's methodology.
+# mcp_servers: []  # Uncomment and populate if MCP servers are needed
 ---
 ```
 
@@ -248,7 +248,7 @@ Beschreibung eines anderen gaengigen Anwendungsfalls.
 ```yaml
   - id: agent-name
     path: agents/agent-name.md
-    description: Dieselbe einzeilige Beschreibung wie im Frontmatter
+    description: Same one-line description from frontmatter
     tags: [domain, specialty]
     priority: normal
     tools: [Read, Write, Edit, Bash, Grep, Glob]

--- a/i18n/de/skills/create-team/SKILL.md
+++ b/i18n/de/skills/create-team/SKILL.md
@@ -176,17 +176,17 @@ Der CONFIG-Block zwischen `<!-- CONFIG:START -->` und `<!-- CONFIG:END -->` lief
       members:
         - agent: <agent-id>
           role: <role-title>
-          subagent_type: <agent-id>
-        # ... fuer jedes Mitglied wiederholen
+          subagent_type: <agent-id>  # Claude Code subagent type for spawning
+        # ... repeat for each member
       tasks:
         - name: <task-name>
           assignee: <agent-id>
-          description: <einzeilige Beschreibung>
-        # ... fuer jede Aufgabe wiederholen
-        - name: synthesize-report
+          description: <one-line description>
+        # ... repeat for each task
+        - name: synthesize-report  # final task if hub-and-spoke
           assignee: <lead-agent-id>
-          description: <Synthesebeschreibung>
-          blocked_by: [<prior-task-names>]
+          description: <synthesis description>
+          blocked_by: [<prior-task-names>]  # for dependency ordering
     ```
     <!-- CONFIG:END -->
 
@@ -206,7 +206,7 @@ Das Feld `subagent_type` ordnet Claude Code-Agententypen zu. Fuer Agenten in `.c
   lead: <lead-agent-id>
   members: [<agent-id-1>, <agent-id-2>, ...]
   coordination: <pattern>
-  description: <einzeilige Beschreibung, die dem Frontmatter entspricht>
+  description: <one-line description matching frontmatter>
 ```
 
 Den `total_teams`-Zaehler am Anfang der Registry aktualisieren.

--- a/i18n/de/skills/evolve-agent/SKILL.md
+++ b/i18n/de/skills/evolve-agent/SKILL.md
@@ -273,7 +273,7 @@ Den neuen Agenten in `agents/_registry.yml` in alphabetischer Position hinzufueg
 ```yaml
   - id: <agent-name>-advanced
     path: agents/<agent-name>-advanced.md
-    description: Einzeilige Beschreibung der fortgeschrittenen Variante
+    description: One-line description of the advanced variant
     tags: [domain, specialty, advanced]
     priority: normal
     tools: [Read, Write, Edit, Bash, Grep, Glob]

--- a/i18n/de/skills/evolve-skill/SKILL.md
+++ b/i18n/de/skills/evolve-skill/SKILL.md
@@ -254,7 +254,7 @@ Den neuen Skill zu `skills/_registry.yml` hinzufuegen:
   path: <skill-name>-advanced/SKILL.md
   complexity: advanced
   language: multi
-  description: Einzeilige Beschreibung der fortgeschrittenen Variante
+  description: One-line description of the advanced variant
 ```
 
 Dann:

--- a/i18n/de/skills/evolve-team/SKILL.md
+++ b/i18n/de/skills/evolve-team/SKILL.md
@@ -260,10 +260,10 @@ team:
   tasks:
     - name: <task-name>
       assignee: <agent-id>
-      description: <einzeilig>
+      description: <one-line>
     - name: synthesize-results
       assignee: <lead-agent>
-      description: Alle Mitglieder-Ausgaben sammeln und synthetisieren
+      description: Collect and synthesize all member outputs
       blocked_by: [<prior-task-names>]
 ```
 
@@ -314,7 +314,7 @@ Das neue Team zu `teams/_registry.yml` hinzufuegen:
   lead: <lead-agent>
   members: [agent-1, agent-2, agent-3]
   coordination: <pattern>
-  description: Einzeilige Beschreibung der spezialisierten Variante
+  description: One-line description of the specialized variant
 ```
 
 Dann:

--- a/i18n/de/skills/metal/SKILL.md
+++ b/i18n/de/skills/metal/SKILL.md
@@ -210,39 +210,39 @@ Die agentskills.io-Standard-Ausgabedokumente produzieren.
 1. Fuer jeden extrahierten **Skill** eine Skelettdefinition schreiben:
 
 ```yaml
-# Skill: [generalisierter-name]
-name: [generalisierter-name]
-description: [einzeilig, framework-agnostisch]
-domain: [naechste Domaene aus den 52 bestehenden, oder neue vorschlagen]
+# Skill: [generalized-name]
+name: [generalized-name]
+description: [one-line, framework-agnostic]
+domain: [closest domain from the 52 existing domains, or suggest a new one]
 complexity: [basic/intermediate/advanced]
-# Prozedur auf Konzeptebene (3-5 Schritte, KEINE volle Implementierung):
-# Schritt 1: [uebergeordnete Aktion]
-# Schritt 2: [uebergeordnete Aktion]
-# Schritt 3: [uebergeordnete Aktion]
-# Abgeleitet von: [Quellkonzept im Originalprojekt]
+# Concept-level procedure (3-5 steps, NOT full implementation):
+# Step 1: [high-level action]
+# Step 2: [high-level action]
+# Step 3: [high-level action]
+# Derived from: [source concept in original project]
 ```
 
 2. Fuer jeden extrahierten **Agent** eine Skelettdefinition schreiben:
 
 ```yaml
-# Agent: [rollenname]
-name: [rollenname]
-description: [einzeiliger Zweck]
-tools: [minimaler Werkzeugsatz]
-skills: [Liste extrahierter Skills, die dieser Agent tragen wuerde]
-# Abgeleitet von: [Quellrolle/-modul im Originalprojekt]
+# Agent: [role-name]
+name: [role-name]
+description: [one-line purpose]
+tools: [minimal tool set needed]
+skills: [list of extracted skills this agent would carry]
+# Derived from: [source role/module in original project]
 ```
 
 3. Fuer jedes extrahierte **Team** eine Skelettdefinition schreiben:
 
 ```yaml
-# Team: [gruppenname]
-name: [gruppenname]
-description: [einzeiliger Zweck]
-lead: [fuehrender Agent aus extrahierten Agents]
-members: [Liste der Mitglieder-Agents]
+# Team: [group-name]
+name: [group-name]
+description: [one-line purpose]
+lead: [lead agent from extracted agents]
+members: [list of member agents]
 coordination: [hub-and-spoke/sequential/parallel/adaptive]
-# Abgeleitet von: [Quell-Workflow/-prozess im Originalprojekt]
+# Derived from: [source workflow/process in original project]
 ```
 
 4. Alle Extraktionen im **Assay-Bericht** zusammenstellen — ein einzelnes Dokument mit Abschnitten fuer Skills, Agents und Teams, plus einer Zusammenfassungstabelle

--- a/i18n/de/skills/prepare-print-model/SKILL.md
+++ b/i18n/de/skills/prepare-print-model/SKILL.md
@@ -248,20 +248,20 @@ Verfahrensgerechte Parameter einstellen:
 **FDM**:
 ```yaml
 layer_height: 0.2mm
-line_width: 0.4mm (= Duesendurchmesser)
-perimeters: 3-4 (strukturell), 2 (kosmetisch)
-top_bottom_layers: 5 (0.2mm Schichten = 1mm Vollmaterial)
-infill_percentage: 20% (kosmetisch), 40-60% (funktional)
-infill_pattern: gyroid (FDM), grid (einfach)
-print_speed: 50mm/s Perimeter, 80mm/s Fuellung
-temperature: materialspezifisch (siehe select-print-material Skill)
+line_width: 0.4mm (= nozzle diameter)
+perimeters: 3-4 (structural), 2 (cosmetic)
+top_bottom_layers: 5 (0.2mm layers = 1mm solid)
+infill_percentage: 20% (cosmetic), 40-60% (functional)
+infill_pattern: gyroid (FDM), grid (basic)
+print_speed: 50mm/s perimeter, 80mm/s infill
+temperature: material-specific (see select-print-material skill)
 ```
 
 **SLA**:
 ```yaml
 layer_height: 0.05mm
-bottom_layers: 6-8 (starke Betthaftung)
-exposure_time: materialspezifisch (2-8s pro Schicht)
+bottom_layers: 6-8 (strong bed adhesion)
+exposure_time: material-specific (2-8s per layer)
 bottom_exposure_time: 30-60s
 lift_speed: 60-80mm/min
 retract_speed: 150-180mm/min

--- a/i18n/de/skills/render-publication-graphic/SKILL.md
+++ b/i18n/de/skills/render-publication-graphic/SKILL.md
@@ -55,39 +55,39 @@ Publikationsfertige Grafiken erzeugen die technische Anforderungen fuer akademis
 Technische Spezifikationen fuer die Zielpublikation identifizieren:
 
 ```yaml
-# Gaengige Publikationsanforderungen
+# Common publication requirements
 
 academic_journal:
   dpi: 300-600
   format: TIFF, EPS, PDF
-  color_space: RGB oder CMYK (Richtlinien pruefen)
-  max_width: 180mm (einspaltig) oder 390mm (zweispaltig)
-  fonts: Einbetten oder als Pfade konvertieren
+  color_space: RGB or CMYK (check guidelines)
+  max_width: 180mm (single column) or 390mm (double column)
+  fonts: Embed or outline
   resolution_minimums:
     line_art: 1000 DPI
     halftone: 300 DPI
     combination: 600 DPI
 
 web_publication:
-  dpi: 72-96 (Retina: 144-192)
+  dpi: 72-96 (retina: 144-192)
   format: PNG, WebP, SVG
   color_space: sRGB
   max_file_size: 200KB-500KB
-  optimization: Komprimieren, progressives Laden
+  optimization: Compress, progressive loading
 
 presentation:
   dpi: 96-150
   format: PNG, PDF, SVG
   color_space: RGB
-  dimensions: 16:9 oder 4:3 Seitenverhaeltnis
-  contrast: Hoher Kontrast fuer Projektoren
+  dimensions: 16:9 or 4:3 aspect ratio
+  contrast: High contrast for projectors
 
 print_book:
   dpi: 300-600
   format: TIFF, PDF/X
   color_space: CMYK
-  bleed: 3-5mm ueber Beschnitt hinaus
-  fonts: Eingebettet
+  bleed: 3-5mm beyond trim
+  fonts: Embedded
 ```
 
 **Erwartet:** Klares Verstaendnis der Zielanforderungen

--- a/i18n/de/skills/select-print-material/SKILL.md
+++ b/i18n/de/skills/select-print-material/SKILL.md
@@ -275,7 +275,7 @@ print_speed: 50mm/s
 retraction_distance: 4.5mm
 retraction_speed: 40mm/s
 cooling: 50% (after layer 3)
-notes: "Maessiges Stringing, Z-hop hilft. 6h bei 65°C getrocknet."
+notes: "Strings moderately, Z-hop helps. Dried 6h at 65°C."
 ```
 
 **SLA-Einstellungsvorlage**:
@@ -287,7 +287,7 @@ exposure_time: 6s
 bottom_exposure: 40s
 lift_distance: 6mm
 lift_speed: 65mm/min
-notes: "Nachhaerten 15min bei 60°C fuer volle Festigkeit. Ohne Haertung sproede."
+notes: "Post-cure 15min at 60°C for full strength. Brittle without cure."
 ```
 
 **Erwartet:** Einstellungen in Projektnotizen oder Slicer-Profilbibliothek dokumentiert.

--- a/i18n/de/skills/setup-compose-stack/SKILL.md
+++ b/i18n/de/skills/setup-compose-stack/SKILL.md
@@ -206,7 +206,7 @@ services:
 ```yaml
 services:
   app:
-    # startet immer
+    # always starts
     build: .
 
   mailhog:

--- a/i18n/de/skills/setup-docker-compose/SKILL.md
+++ b/i18n/de/skills/setup-docker-compose/SKILL.md
@@ -87,7 +87,7 @@ volumes:
 ```yaml
 services:
   r-dev:
-    # ... wie oben
+    # ... as above
     depends_on:
       - postgres
     environment:

--- a/i18n/de/skills/setup-prometheus-monitoring/SKILL.md
+++ b/i18n/de/skills/setup-prometheus-monitoring/SKILL.md
@@ -72,27 +72,27 @@ global:
     cluster: 'production'
     region: 'us-east-1'
 
-# Alertmanager-Konfiguration
+# Alertmanager configuration
 alerting:
   alertmanagers:
     - static_configs:
         - targets:
             - localhost:9093
 
-# Aufzeichnungs- und Alerting-Regeln laden
+# Load recording and alerting rules
 rule_files:
   - "rules/*.yml"
 
-# Scrape-Konfigurationen
+# Scrape configurations
 scrape_configs:
-  # Prometheus-Selbstmonitoring
+  # Prometheus self-monitoring
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
         labels:
           env: 'production'
 
-  # Node Exporter fuer Host-Metriken
+  # Node exporter for host metrics
   - job_name: 'node'
     static_configs:
       - targets:
@@ -101,7 +101,7 @@ scrape_configs:
         labels:
           env: 'production'
 
-  # Anwendungsmetriken mit dateibasierter Service Discovery
+  # Application metrics with file-based service discovery
   - job_name: 'app-services'
     file_sd_configs:
       - files:
@@ -132,20 +132,20 @@ Fuer **Kubernetes**-Umgebungen zu `scrape_configs` hinzufuegen:
     kubernetes_sd_configs:
       - role: pod
     relabel_configs:
-      # Nur Pods mit prometheus.io/scrape-Annotation scrapen
+      # Only scrape pods with prometheus.io/scrape annotation
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
-      # Benutzerdefinierten Port verwenden, falls angegeben
+      # Use custom port if specified
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         target_label: __address__
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
-      # Namespace als Label hinzufuegen
+      # Add namespace as label
       - source_labels: [__meta_kubernetes_namespace]
         target_label: kubernetes_namespace
-      # Pod-Name als Label hinzufuegen
+      # Add pod name as label
       - source_labels: [__meta_kubernetes_pod_name]
         target_label: kubernetes_pod_name
 ```
@@ -179,7 +179,7 @@ Fuer **Consul** Service Discovery:
   - job_name: 'consul-services'
     consul_sd_configs:
       - server: 'consul.example.com:8500'
-        services: []  # Leere Liste bedeutet alle Dienste entdecken
+        services: []  # Empty list means discover all services
     relabel_configs:
       - source_labels: [__meta_consul_service]
         target_label: job
@@ -206,14 +206,14 @@ groups:
   - name: api_aggregations
     interval: 30s
     rules:
-      # Anfragerate pro Endpunkt berechnen (5-Minuten-Fenster)
+      # Calculate request rate per endpoint (5m window)
       - record: job:http_requests:rate5m
         expr: |
           sum by (job, endpoint, method) (
             rate(http_requests_total[5m])
           )
 
-      # Fehlerrate in Prozent berechnen
+      # Calculate error rate percentage
       - record: job:http_errors:rate5m
         expr: |
           sum by (job) (
@@ -222,7 +222,7 @@ groups:
             rate(http_requests_total[5m])
           ) * 100
 
-      # P95-Latenz pro Endpunkt
+      # P95 latency by endpoint
       - record: job:http_request_duration_seconds:p95
         expr: |
           histogram_quantile(0.95,
@@ -234,21 +234,21 @@ groups:
   - name: resource_aggregations
     interval: 1m
     rules:
-      # CPU-Auslastung pro Instanz
+      # CPU usage by instance
       - record: instance:cpu_usage:ratio
         expr: |
           1 - avg by (instance) (
             rate(node_cpu_seconds_total{mode="idle"}[5m])
           )
 
-      # Speicherauslastung in Prozent
+      # Memory usage percentage
       - record: instance:memory_usage:ratio
         expr: |
           1 - (
             node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
           )
 
-      # Festplattenauslastung pro Einhängepunkt
+      # Disk usage by mount point
       - record: instance:disk_usage:ratio
         expr: |
           1 - (
@@ -358,11 +358,11 @@ scrape_configs:
     metrics_path: '/federate'
     params:
       'match[]':
-        # Nur vorab berechnete Aufzeichnungsregeln aggregieren
+        # Aggregate only pre-computed recording rules
         - '{__name__=~"job:.*"}'
-        # Alert-Zustände einschliessen
+        # Include alert states
         - '{__name__=~"ALERTS.*"}'
-        # Kritische Infrastrukturmetriken einschliessen
+        # Include critical infrastructure metrics
         - 'up{job=~".*"}'
     static_configs:
       - targets:
@@ -400,14 +400,14 @@ Redundante Prometheus-Instanzen mit identischen Konfigurationen fuer Failover be
 **Thanos** oder **Cortex** fuer echte HA oder einfaches lastverteiltes Setup:
 
 ```yaml
-# prometheus-1.yml und prometheus-2.yml (identische Konfigurationen)
+# prometheus-1.yml and prometheus-2.yml (identical configs)
 global:
   scrape_interval: 15s
   external_labels:
-    prometheus: 'prometheus-1'  # Unterschiedlich pro Instanz
+    prometheus: 'prometheus-1'  # Different per instance
     replica: 'A'
 
-# --web.external-url-Flag fuer jede Instanz verwenden
+# Use --web.external-url flag for each instance
 # prometheus-1: --web.external-url=http://prometheus-1.example.com:9090
 # prometheus-2: --web.external-url=http://prometheus-2.example.com:9090
 ```

--- a/i18n/de/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/de/skills/troubleshoot-print-issues/SKILL.md
@@ -197,18 +197,18 @@ Sofortloesungen fuer gaengige Probleme umsetzen:
 
 **Einzugs-Tuning**:
 ```yaml
-# Direktantrieb-Extruder:
+# Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
 
-# Bowden-Extruder:
+# Bowden extruder:
 retraction_distance: 4.0-6.0mm
 retraction_speed: 40-60mm/s
 
-# Wenn Fadenziehen bestehen bleibt:
-- Z-Hop aktivieren: 0.2-0.4mm (hebt Duese bei Fahrwegen an)
-- Fahrgeschwindigkeit reduzieren (hilft paradoxerweise)
-- Combing-Modus aktivieren (Fahrwege innerhalb der Fuellung)
+# If stringing persists:
+- Enable z-hop: 0.2-0.4mm (lifts nozzle during travel)
+- Reduce travel speed (paradoxically helps)
+- Enable combing mode (travels within infill)
 ```
 
 **Erwartet:** Minimales Fadenziehen, duenne Faeden leicht von Hand entfernbar.
@@ -235,11 +235,11 @@ retraction_speed: 40-60mm/s
 
 **Geschwindigkeitsreduzierung**:
 ```yaml
-# Diese Geschwindigkeiten reduzieren:
-perimeter_speed: 40mm/s (von 50)
-travel_speed: 120mm/s (von 150)
-acceleration: 500mm/s² (von 1000)
-jerk: 8mm/s (von 15)
+# Reduce these speeds:
+perimeter_speed: 40mm/s (from 50)
+travel_speed: 120mm/s (from 150)
+acceleration: 500mm/s² (from 1000)
+jerk: 8mm/s (from 15)
 ```
 
 **Erwartet:** Keine Schichtversetzungen im Neudruck mit gespannten Riemen und reduzierten Geschwindigkeiten.
@@ -250,19 +250,19 @@ jerk: 8mm/s (von 15)
 
 **Waermemanagement**:
 ```yaml
-# Betttemperatur erhoehen:
+# Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
 ABS: 100°C → 110°C
 
-# Teilekuehlung deaktivieren/reduzieren:
+# Disable/reduce part cooling:
 first_layer_fan: 0%
 regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 
-# Drucker einhausen (kritisch fuer ABS/ASA):
-# - Karton (temporaer)
-# - Acrylplatten (permanent)
-# - Ziel-Bauraumtemperatur: 40-50 Grad C
+# Enclose printer (critical for ABS/ASA):
+- Cardboard box (temporary)
+- Acrylic panels (permanent)
+- Target chamber temp: 40-50°C
 ```
 
 **Haftungsverbesserung**:
@@ -310,13 +310,13 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 
 **Durchflussraten-Reduzierung**:
 ```yaml
-# Durchfluss in 2%-Schritten reduzieren:
+# Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 
-# Zeichen fuer korrekten Durchfluss:
-- Glatte obere Oberflaeche (nicht uebergefuellt)
-- Perimeter woelben sich nicht nach aussen
-- Fuellung ueberfuellt nicht und drueckt Schichten nicht auseinander
+# Signs of correct flow:
+- Smooth top surface (not overstuffed)
+- Perimeters don't bulge outward
+- Infill doesn't overfill and push layers apart
 ```
 
 **Massgenauigkeitstest**:
@@ -354,17 +354,17 @@ Erfolgreiche Korrektur fuer zukuenftige Referenz festhalten:
 **Problemprotokoll-Vorlage**:
 ```yaml
 date: 2026-02-16
-issue: "Schichtversatz bei 50mm Hoehe"
-symptoms: "X-Achse versetzt sich um 10mm, passiert konsistent bei gleicher Hoehe"
+issue: "Layer shifts at 50mm height"
+symptoms: "X-axis shifts 10mm, happens consistently at same height"
 printer: "Ender 3 V2"
 material: "PETG, PolyMaker PolyLite"
-root_cause: "Loser X-Achsen-Riemen, Riemenscheiben-Madenschraube nicht auf Abflachung"
+root_cause: "Loose X-axis belt, pulley set screw not on flat"
 solution:
-  - "X-Achsen-Riemen auf 120Hz Resonanz gespannt"
-  - "Riemenscheiben-Madenschraube auf Motorwellen-Abflachung ausgerichtet"
-  - "Druckgeschwindigkeit auf 40mm/s Perimeter reduziert"
-verification: "100mm Testzylinder gedruckt - keine Versetzungen"
-notes: "Riemenspannung monatlich pruefen, Riemenscheibe neigt zum Verrutschen"
+  - "Tightened X-axis belt to 120Hz resonance"
+  - "Realigned pulley set screw on motor shaft flat"
+  - "Reduced print speed to 40mm/s perimeter"
+verification: "Printed 100mm test cylinder - no shifts"
+notes: "Check belt tension monthly, pulley tends to slip"
 ```
 
 **Erwartet:** Problem mit Grundursache und Loesung fuer Wissensdatenbank dokumentiert.

--- a/i18n/de/skills/verify-agent-output/SKILL.md
+++ b/i18n/de/skills/verify-agent-output/SKILL.md
@@ -271,26 +271,25 @@ failures:
     expected: 500
     actual: 487
     severity: warning
-    note: "13 Zeilen entfernt — Filter-Logik untersuchen"
+    note: "13 rows dropped — investigate filter logic"
   - check: "score_range"
     expected: "[0, 100]"
     actual: "[-3, 100]"
     severity: error
-    note: "3 negative Werte gefunden — Dateneingabevalidierung fehlt"
+    note: "3 negative scores found — data validation missing"
   - check: "column_presence"
     expected: "grade"
     actual: null
     severity: error
-    note: "grade-Spalte fehlt in Ausgabe"
+    note: "grade column missing from output"
 passes:
   - check: "file_exists"
   - check: "checksum_stable"
   - check: "test_suite"
 recommendation: >
-  Mit aktivierter Eingabevalidierung neu ausfuehren. Die score_range- und
-  column_presence-Fehler deuten darauf hin, dass der Transformationsschritt
-  Grenzfaelle nicht behandelt. Ausgabe nicht flicken — Transformation korrigieren
-  und von Quelle neu ausfuehren.
+  Re-run with input validation enabled. The score_range and column_presence
+  failures suggest the transform step is not handling edge cases. Do not
+  patch the output — fix the transform and re-execute from source.
 ```
 
 Schluesselgrundsaetze fuer Uneinigkeitsberichte:

--- a/i18n/es/skills/create-skill/SKILL.md
+++ b/i18n/es/skills/create-skill/SKILL.md
@@ -77,11 +77,11 @@ Convenciones de nomenclatura:
 ---
 name: skill-name-here
 description: >
-  Una a tres oraciones más los disparadores clave de activación. Debe ser
-  suficientemente claro para que un agente decida si activar esta habilidad
-  solo a partir de la descripción. Máx. 1024 caracteres. Comenzar con un verbo.
+  One to three sentences plus key activation triggers. Must be clear
+  enough for an agent to decide whether to activate this skill from
+  the description alone. Max 1024 characters. Start with a verb.
 license: MIT
-allowed-tools: Read Write Edit Bash Grep Glob  # opcional, experimental
+allowed-tools: Read Write Edit Bash Grep Glob  # optional, experimental
 metadata:
   author: Philipp Thoss
   version: "1.0"

--- a/i18n/es/skills/create-team/SKILL.md
+++ b/i18n/es/skills/create-team/SKILL.md
@@ -177,16 +177,16 @@ El bloque CONFIG entre los marcadores `<!-- CONFIG:START -->` y `<!-- CONFIG:END
         - agent: <agent-id>
           role: <role-title>
           subagent_type: <agent-id>  # Claude Code subagent type for spawning
-        # ... repetir para cada miembro
+        # ... repeat for each member
       tasks:
         - name: <task-name>
           assignee: <agent-id>
           description: <one-line description>
-        # ... repetir para cada tarea
-        - name: synthesize-report  # tarea final si hub-and-spoke
+        # ... repeat for each task
+        - name: synthesize-report  # final task if hub-and-spoke
           assignee: <lead-agent-id>
           description: <synthesis description>
-          blocked_by: [<prior-task-names>]  # para ordenación de dependencias
+          blocked_by: [<prior-task-names>]  # for dependency ordering
     ```
     <!-- CONFIG:END -->
 

--- a/i18n/es/skills/troubleshoot-mcp-connection/SKILL.md
+++ b/i18n/es/skills/troubleshoot-mcp-connection/SKILL.md
@@ -98,7 +98,7 @@ Solución: Usar variables de entorno en lugar de argumentos `--header`:
   "hf-mcp-server": {
     "command": "mcp-remote",
     "args": ["https://huggingface.co/mcp"],
-    "env": { "HF_TOKEN": "tu_token" }
+    "env": { "HF_TOKEN": "your_token" }
   }
 }
 ```

--- a/i18n/ja/skills/add-puzzle-type/SKILL.md
+++ b/i18n/ja/skills/add-puzzle-type/SKILL.md
@@ -191,7 +191,7 @@ geom_puzzle_<type> <- function(mapping = NULL, data = NULL, ...) {
     default: 20
     min: 5
     max: 50
-  # タイプ固有のパラメータをここに追加
+  # Add type-specific params here
 ```
 
 **期待結果：** 設定が有効なYAMLである。デフォルト値が`generate_puzzle()`で使用されたとき動作するパズルを生成する。

--- a/i18n/ja/skills/build-grafana-dashboards/SKILL.md
+++ b/i18n/ja/skills/build-grafana-dashboards/SKILL.md
@@ -263,7 +263,7 @@ Real-time operational view for on-call engineers monitoring the API service.
   "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
   "targets": [
     {
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **ヒートマップパネル**（レイテンシ分布）：
@@ -275,7 +275,7 @@ Real-time operational view for on-call engineers monitoring the API service.
   "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
   "targets": [
     {
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 パネル選択ガイド：
@@ -307,7 +307,7 @@ Real-time operational view for on-call engineers monitoring the API service.
       "type": "row",
       "title": "High-Level Metrics",
       "collapsed": false,
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 レイアウトのベストプラクティス：
@@ -338,7 +338,7 @@ JSONのダッシュボードレベルのリンク：
       "title": "Service Details",
       "type": "link",
       "icon": "external link",
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 パネルレベルのデータリンク：
@@ -350,7 +350,7 @@ JSONのダッシュボードレベルのリンク：
       "links": [
         {
           "title": "View Logs for ${__field.labels.instance}",
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 リンク変数：
@@ -386,7 +386,7 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 ダッシュボードのプロビジョニング（`/etc/grafana/provisioning/dashboards/default.yml`）：

--- a/i18n/ja/skills/configure-alerting-rules/SKILL.md
+++ b/i18n/ja/skills/configure-alerting-rules/SKILL.md
@@ -65,7 +65,7 @@ services:
       - "9093:9093"
     volumes:
       - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml
-    # ... (完全な設定はEXAMPLES.mdを参照)
+    # ... (see EXAMPLES.md for complete configuration)
 ```
 
 **基本的なAlertmanager設定**（`alertmanager.yml`の抜粋）：
@@ -87,7 +87,7 @@ route:
         severity: critical
       receiver: pagerduty-critical
 
-# ... (完全なルーティング、インヒビションルール、レシーバーはEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete routing, inhibition rules, and receivers)
 ```
 
 **AlertmanagerをPrometheusに設定**（`prometheus.yml`）：
@@ -139,7 +139,7 @@ groups:
           severity: warning
         annotations:
           summary: "High CPU usage on {{ $labels.instance }}"
-          # ... (完全なアラートはEXAMPLES.mdを参照)
+          # ... (see EXAMPLES.md for complete alerts)
 ```
 
 **アラート設計のベストプラクティス**：
@@ -238,7 +238,7 @@ route:
           repeat_interval: 15m
           continue: true   # Also send to Slack
 
-# ... (時間間隔付きの完全なルーティングはEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete routing with time intervals)
 ```
 
 **グルーピング戦略**：
@@ -281,7 +281,7 @@ inhibit_rules:
       alertname: '(HighLatency|HighErrorRate)'
     equal: ['service', 'namespace']
 
-# ... (その他のインヒビションパターンはEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for more inhibition patterns)
 ```
 
 **サイレンスをプログラムで作成**：
@@ -322,7 +322,7 @@ receivers:
         details:
           firing: '{{ .Alerts.Firing | len }}'
           alertname: '{{ .GroupLabels.alertname }}'
-        # ... (完全な統合例はEXAMPLES.mdを参照)
+        # ... (see EXAMPLES.md for complete integration examples)
 ```
 
 **カスタム統合のためのWebhook**：

--- a/i18n/ja/skills/configure-api-gateway/SKILL.md
+++ b/i18n/ja/skills/configure-api-gateway/SKILL.md
@@ -57,7 +57,7 @@ metadata:
 
 **KongとPostgreSQLの場合：**
 ```yaml
-# kong-deployment.yaml（抜粋 - 完全なファイルはEXAMPLES.mdを参照）
+# kong-deployment.yaml (excerpt - see EXAMPLES.md for complete file)
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -70,12 +70,12 @@ metadata:
   namespace: kong
 spec:
   replicas: 2
-  # ... (PostgreSQL、マイグレーション、サービス - EXAMPLES.mdを参照)
+  # ... (PostgreSQL, migrations, services - see EXAMPLES.md)
 ```
 
 **Traefikの場合：**
 ```yaml
-# traefik-deployment.yaml（抜粋 - 完全なファイルはEXAMPLES.mdを参照）
+# traefik-deployment.yaml (excerpt - see EXAMPLES.md for complete file)
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -88,7 +88,7 @@ metadata:
   namespace: traefik
 spec:
   replicas: 2
-  # ... (RBAC、ConfigMap、サービス - EXAMPLES.mdを参照)
+  # ... (RBAC, ConfigMap, services - see EXAMPLES.md)
 ```
 
 完全なデプロイマニフェストは[EXAMPLES.md](references/EXAMPLES.md#step-1-install-api-gateway)を参照
@@ -126,7 +126,7 @@ curl -i http://localhost:8001/routes  # ルートを確認
 
 **Traefikの場合（IngressRoute CRDを使用）：**
 ```yaml
-# traefik-routes.yaml（抜粋）
+# traefik-routes.yaml (excerpt)
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -135,7 +135,7 @@ spec:
   entryPoints: [websecure]
   routes:
   - match: Host(`api.example.com`) && PathPrefix(`/api/users`)
-    # ... (完全な設定はEXAMPLES.mdを参照)
+    # ... (see EXAMPLES.md for full configuration)
 ```
 
 ルートを適用：
@@ -160,7 +160,7 @@ APIセキュリティのための認証プラグイン/ミドルウェアを設�
 
 **Kongの場合（APIキーとJWT認証）：**
 ```yaml
-# kong-auth-config.yaml（抜粋）
+# kong-auth-config.yaml (excerpt)
 consumers:
 - username: mobile-app
   custom_id: app-001
@@ -172,7 +172,7 @@ keyauth_credentials:
 plugins:
 - name: key-auth
   service: user-api
-  # ... (完全な設定はEXAMPLES.mdを参照)
+  # ... (see EXAMPLES.md for full configuration)
 ```
 
 ```bash
@@ -182,7 +182,7 @@ curl -i -H "apikey: mobile-secret-key-123" http://GATEWAY_IP/api/users
 
 **Traefikの場合（BasicAuthとForwardAuthミドルウェア）：**
 ```yaml
-# traefik-auth-middleware.yaml（抜粋）
+# traefik-auth-middleware.yaml (excerpt)
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -191,7 +191,7 @@ spec:
   basicAuth:
     secret: basic-auth
     removeHeader: true
-# ... (OAuth2、レート制限はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for OAuth2, rate limiting)
 ```
 
 ```bash
@@ -215,7 +215,7 @@ curl -u user1:password https://GATEWAY_IP/api/protected
 
 **Kongの場合：**
 ```yaml
-# kong-transformations.yaml（抜粋）
+# kong-transformations.yaml (excerpt)
 plugins:
 - name: request-transformer
   service: user-api
@@ -225,7 +225,7 @@ plugins:
     remove:
       headers: [X-Internal-Token]
 - name: correlation-id
-  # ... (完全な設定はEXAMPLES.mdを参照)
+  # ... (see EXAMPLES.md for full configuration)
 ```
 
 ```bash
@@ -234,7 +234,7 @@ deck sync --kong-addr http://localhost:8001 -s kong-transformations.yaml
 
 **Traefikの場合：**
 ```yaml
-# traefik-transformations.yaml（抜粋）
+# traefik-transformations.yaml (excerpt)
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -243,7 +243,7 @@ spec:
   headers:
     customRequestHeaders:
       X-Gateway-Version: "1.0"
-    # ... (サーキットブレーカー、リトライ、チェーンはEXAMPLES.mdを参照)
+    # ... (see EXAMPLES.md for circuit breaker, retry, chain)
 ```
 
 ```bash
@@ -267,14 +267,14 @@ API可視性のためのメトリクス、ログ、ダッシュボードを設�
 
 **Kongのモニタリングセットアップ：**
 ```yaml
-# kong-monitoring.yaml（抜粋）
+# kong-monitoring.yaml (excerpt)
 plugins:
 - name: prometheus
   config:
     per_consumer: true
 - name: http-log
   service: user-api
-  # ... (Datadog、file-log設定はEXAMPLES.mdを参照)
+  # ... (see EXAMPLES.md for Datadog, file-log configuration)
 ```
 
 ```bash
@@ -287,7 +287,7 @@ curl http://localhost:8100/metrics
 
 **Traefikのモニタリング（組み込み）：**
 ```yaml
-# ServiceMonitor（抜粋 - GrafanaダッシュボードはEXAMPLES.mdを参照）
+# ServiceMonitor (excerpt - see EXAMPLES.md for Grafana dashboard)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -320,7 +320,7 @@ kubectl port-forward -n traefik svc/traefik-dashboard 8080:8080
 
 **Kongのバージョニング戦略：**
 ```yaml
-# kong-versioning.yaml（抜粋）
+# kong-versioning.yaml (excerpt)
 services:
 - name: user-api-v1
   url: http://user-service-v1.default.svc.cluster.local:8080
@@ -334,12 +334,12 @@ services:
         headers:
         - X-Deprecation-Notice:"API v1 deprecated on 2024-12-31"
         - Sunset:"Wed, 31 Dec 2024 23:59:59 GMT"
-# ... (v2、デフォルトルーティング、レート制限はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for v2, default routing, rate limits)
 ```
 
 **Traefikのバージョニング：**
 ```yaml
-# traefik-versioning.yaml（抜粋）
+# traefik-versioning.yaml (excerpt)
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -348,7 +348,7 @@ spec:
   headers:
     customResponseHeaders:
       X-Deprecation-Notice: "API v1 deprecated on 2024-12-31"
-# ... (完全なIngressRoutesはEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete IngressRoutes)
 ```
 
 バージョニングをテスト：

--- a/i18n/ja/skills/configure-log-aggregation/SKILL.md
+++ b/i18n/ja/skills/configure-log-aggregation/SKILL.md
@@ -134,7 +134,7 @@ server:
   http_listen_port: 3100
   grpc_listen_port: 9096
 
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 S3ストレージを使用した**本番環境**向け：
@@ -172,7 +172,7 @@ server:
 
 positions:
   filename: /tmp/positions.yaml
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 Promtailの主要な概念：
@@ -399,7 +399,7 @@ compactor:
   compaction_interval: 10m
   retention_enabled: true
   retention_delete_delay: 2h
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 複数のルールが一致する場合の優先度（数字が小さいほど優先度が高い）。
@@ -413,7 +413,7 @@ chunk_store_config:
     fifocache:
       max_size_bytes: 1GB
       ttl: 24h
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **保持の監視**：

--- a/i18n/ja/skills/correlate-observability-signals/SKILL.md
+++ b/i18n/ja/skills/correlate-observability-signals/SKILL.md
@@ -411,7 +411,7 @@ GrafanaでLokiデータソースを設定する:
     "templating": {
       "list": [
         {
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 インシデント中のワークフロー:

--- a/i18n/ja/skills/define-slo-sli-sla/SKILL.md
+++ b/i18n/ja/skills/define-slo-sli-sla/SKILL.md
@@ -196,7 +196,7 @@ slos:
     objective: 99.9
     description: |
       99.9% of requests return non-5xx status codes
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **時間ウィンドウの選択**：
@@ -274,7 +274,7 @@ labels:
   team: "platform"
   tier: "1"
 slos:
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Prometheusルールを生成**：
@@ -296,7 +296,7 @@ groups:
     rules:
       # SLI: Ratio of good events
       - record: slo:sli_error:ratio_rate5m
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **生成されたアラート**：
@@ -308,7 +308,7 @@ groups:
       # Fast burn: 2% budget consumed in 1 hour
       - alert: UserAPIHighErrorRate
         expr: |
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **ルールをPrometheusに読み込む**：
@@ -346,7 +346,7 @@ GrafanaでSLOコンプライアンスとエラーバジェット消費を可視�
     "panels": [
       {
         "type": "stat",
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **可視化すべき主要メトリクス**：
@@ -389,7 +389,7 @@ slo:
   latency_p99: 200ms
   window: 30 days
 
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **ポリシー実施の自動化**：

--- a/i18n/ja/skills/enforce-policy-as-code/SKILL.md
+++ b/i18n/ja/skills/enforce-policy-as-code/SKILL.md
@@ -150,7 +150,7 @@ kind: ConstraintTemplate
 metadata:
   name: k8srequiredlabels
   annotations:
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Kyverno ClusterPolicy：**
@@ -161,7 +161,7 @@ kind: ClusterPolicy
 metadata:
   name: require-labels
   annotations:
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 ポリシーを適用：
@@ -202,7 +202,7 @@ kind: Deployment
 metadata:
   name: test-no-labels
   namespace: production
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 ポリシーをテスト：
@@ -257,7 +257,7 @@ kind: Assign
 metadata:
   name: add-default-labels
 spec:
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Kyvernoの変異ポリシー：**
@@ -268,7 +268,7 @@ kind: ClusterPolicy
 metadata:
   name: add-default-labels
 spec:
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 変異を適用してテスト：
@@ -325,7 +325,7 @@ kind: PrometheusRule
 metadata:
   name: policy-alerts
   namespace: monitoring
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **期待結果：** 監査がデプロイをブロックせずに既存リソースの違反を特定。合格/不合格の数でポリシーレポートが生成済み。違反がレビューのためにエクスポート可能。メトリクスがモニタリング用に公開。増加する違反でアラートが発火。
@@ -360,7 +360,7 @@ name: Policy Validation
 on:
   pull_request:
     paths:
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **プリコミットフック：**

--- a/i18n/ja/skills/evolve-team/SKILL.md
+++ b/i18n/ja/skills/evolve-team/SKILL.md
@@ -312,7 +312,7 @@ grep -A 10 "id: <team-name>" teams/_registry.yml
   lead: <lead-agent>
   members: [agent-1, agent-2, agent-3]
   coordination: <pattern>
-  description: 専門化されたバリアントの一行説明
+  description: One-line description of the specialized variant
 ```
 
 次に：

--- a/i18n/ja/skills/instrument-distributed-tracing/SKILL.md
+++ b/i18n/ja/skills/instrument-distributed-tracing/SKILL.md
@@ -109,7 +109,7 @@ server:
 distributor:
   receivers:
     jaeger:
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **S3ストレージを使用した本番環境**：
@@ -411,7 +411,7 @@ metrics_generator:
     external_labels:
       cluster: production
   storage:
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 これにより以下のPrometheusメトリクスが生成される：

--- a/i18n/ja/skills/setup-compose-stack/SKILL.md
+++ b/i18n/ja/skills/setup-compose-stack/SKILL.md
@@ -204,7 +204,7 @@ services:
 ```yaml
 services:
   app:
-    # 常に起動する
+    # always starts
     build: .
 
   mailhog:

--- a/i18n/ja/skills/setup-docker-compose/SKILL.md
+++ b/i18n/ja/skills/setup-docker-compose/SKILL.md
@@ -85,7 +85,7 @@ volumes:
 ```yaml
 services:
   r-dev:
-    # ... 上記と同様
+    # ... as above
     depends_on:
       - postgres
     environment:

--- a/i18n/ja/skills/setup-prometheus-monitoring/SKILL.md
+++ b/i18n/ja/skills/setup-prometheus-monitoring/SKILL.md
@@ -70,27 +70,27 @@ global:
     cluster: 'production'
     region: 'us-east-1'
 
-# Alertmanagerの設定
+# Alertmanager configuration
 alerting:
   alertmanagers:
     - static_configs:
         - targets:
             - localhost:9093
 
-# 記録ルールとアラートルールの読み込み
+# Load recording and alerting rules
 rule_files:
   - "rules/*.yml"
 
-# スクレイプ設定
+# Scrape configurations
 scrape_configs:
-  # Prometheus自己モニタリング
+  # Prometheus self-monitoring
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
         labels:
           env: 'production'
 
-  # ホストメトリクス用ノードエクスポーター
+  # Node exporter for host metrics
   - job_name: 'node'
     static_configs:
       - targets:
@@ -99,7 +99,7 @@ scrape_configs:
         labels:
           env: 'production'
 
-  # ファイルベースのサービスディスカバリによるアプリメトリクス
+  # Application metrics with file-based service discovery
   - job_name: 'app-services'
     file_sd_configs:
       - files:
@@ -130,20 +130,20 @@ scrape_configs:
     kubernetes_sd_configs:
       - role: pod
     relabel_configs:
-      # prometheus.io/scrapeアノテーションがあるポッドのみスクレイプ
+      # Only scrape pods with prometheus.io/scrape annotation
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
-      # 指定されている場合はカスタムポートを使用
+      # Use custom port if specified
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         target_label: __address__
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
-      # ネームスペースをラベルとして追加
+      # Add namespace as label
       - source_labels: [__meta_kubernetes_namespace]
         target_label: kubernetes_namespace
-      # ポッド名をラベルとして追加
+      # Add pod name as label
       - source_labels: [__meta_kubernetes_pod_name]
         target_label: kubernetes_pod_name
 ```
@@ -177,7 +177,7 @@ scrape_configs:
   - job_name: 'consul-services'
     consul_sd_configs:
       - server: 'consul.example.com:8500'
-        services: []  # 空リストはすべてのサービスを対象にする
+        services: []  # Empty list means discover all services
     relabel_configs:
       - source_labels: [__meta_consul_service]
         target_label: job
@@ -204,14 +204,14 @@ groups:
   - name: api_aggregations
     interval: 30s
     rules:
-      # エンドポイントごとのリクエストレートを計算（5分ウィンドウ）
+      # Calculate request rate per endpoint (5m window)
       - record: job:http_requests:rate5m
         expr: |
           sum by (job, endpoint, method) (
             rate(http_requests_total[5m])
           )
 
-      # エラーレートの割合を計算
+      # Calculate error rate percentage
       - record: job:http_errors:rate5m
         expr: |
           sum by (job) (
@@ -220,7 +220,7 @@ groups:
             rate(http_requests_total[5m])
           ) * 100
 
-      # エンドポイントごとのP95レイテンシ
+      # P95 latency by endpoint
       - record: job:http_request_duration_seconds:p95
         expr: |
           histogram_quantile(0.95,
@@ -232,21 +232,21 @@ groups:
   - name: resource_aggregations
     interval: 1m
     rules:
-      # インスタンスごとのCPU使用率
+      # CPU usage by instance
       - record: instance:cpu_usage:ratio
         expr: |
           1 - avg by (instance) (
             rate(node_cpu_seconds_total{mode="idle"}[5m])
           )
 
-      # メモリ使用率
+      # Memory usage percentage
       - record: instance:memory_usage:ratio
         expr: |
           1 - (
             node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
           )
 
-      # マウントポイントごとのディスク使用率
+      # Disk usage by mount point
       - record: instance:disk_usage:ratio
         expr: |
           1 - (
@@ -356,11 +356,11 @@ scrape_configs:
     metrics_path: '/federate'
     params:
       'match[]':
-        # 事前計算された記録ルールのみを集計
+        # Aggregate only pre-computed recording rules
         - '{__name__=~"job:.*"}'
-        # アラート状態を含める
+        # Include alert states
         - '{__name__=~"ALERTS.*"}'
-        # 重要なインフラメトリクスを含める
+        # Include critical infrastructure metrics
         - 'up{job=~".*"}'
     static_configs:
       - targets:
@@ -398,14 +398,14 @@ scrape_configs:
 **Thanos**または**Cortex**を使用した真のHA、または単純な負荷分散構成:
 
 ```yaml
-# prometheus-1.yml と prometheus-2.yml（同一設定）
+# prometheus-1.yml and prometheus-2.yml (identical configs)
 global:
   scrape_interval: 15s
   external_labels:
-    prometheus: 'prometheus-1'  # インスタンスごとに異なる
+    prometheus: 'prometheus-1'  # Different per instance
     replica: 'A'
 
-# 各インスタンスに --web.external-url フラグを使用
+# Use --web.external-url flag for each instance
 # prometheus-1: --web.external-url=http://prometheus-1.example.com:9090
 # prometheus-2: --web.external-url=http://prometheus-2.example.com:9090
 ```

--- a/i18n/ja/skills/setup-service-mesh/SKILL.md
+++ b/i18n/ja/skills/setup-service-mesh/SKILL.md
@@ -71,7 +71,7 @@ linkerd check
 
 リソース制限とトレーシングを含むサービスメッシュ設定を作成します：
 ```yaml
-# service-mesh-config.yaml（省略版）
+# service-mesh-config.yaml (abbreviated)
 spec:
   profile: production
   meshConfig:
@@ -80,7 +80,7 @@ spec:
     pilot:
       k8s:
         resources: { requests: { cpu: 500m, memory: 2Gi } }
-# 完全な設定はEXAMPLES.md ステップ1を参照
+# See EXAMPLES.md Step 1 for complete configuration
 ```
 
 **期待結果：** コントロールプレーンのPodがistio-system（Istio）またはlinkerd（Linkerd）Namespaceで稼働中。`istioctl version`または`linkerd version`がクライアントとサーバーの一致するバージョンを表示。
@@ -110,7 +110,7 @@ kubectl annotate namespace default linkerd.io/inject=enabled
 
 サンプルデプロイでサイドカーインジェクションをテストします：
 ```yaml
-# test-deployment.yaml（省略版）
+# test-deployment.yaml (abbreviated)
 apiVersion: apps/v1
 kind: Deployment
 spec:
@@ -120,7 +120,7 @@ spec:
       containers:
       - name: app
         image: nginx:alpine
-# 完全なテストデプロイはEXAMPLES.md ステップ2を参照
+# See EXAMPLES.md Step 2 for complete test deployment
 ```
 
 適用して確認します：
@@ -144,7 +144,7 @@ kubectl get pods -n default
 
 **Istioの場合：**
 ```yaml
-# mtls-policy.yaml（省略版）
+# mtls-policy.yaml (abbreviated)
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -153,7 +153,7 @@ metadata:
 spec:
   mtls:
     mode: STRICT
-# Namespace単位とpermissiveモードの例はEXAMPLES.md ステップ3を参照
+# See EXAMPLES.md Step 3 for per-namespace and permissive mode examples
 ```
 
 **Linkerdの場合：**
@@ -184,7 +184,7 @@ istioctl authn tls-check $(kubectl get pod -n default -l app=test-app -o jsonpat
 
 トラフィック管理ポリシーを作成します：
 ```yaml
-# traffic-management.yaml（省略版）
+# traffic-management.yaml (abbreviated)
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 spec:
@@ -197,7 +197,7 @@ spec:
     - destination: { host: api-service, subset: v1 }
       weight: 90
     retries: { attempts: 3, perTryTimeout: 2s }
-# 完全なルーティング、サーキットブレーカー、ゲートウェイ設定はEXAMPLES.md ステップ4を参照
+# See EXAMPLES.md Step 4 for complete routing, circuit breaker, and gateway configs
 ```
 
 **Linkerdのトラフィック分割：**
@@ -249,7 +249,7 @@ linkerd jaeger install | kubectl apply -f -
 
 カスタムメトリクスとダッシュボードを設定します：
 ```yaml
-# service-monitor.yaml（省略版）
+# service-monitor.yaml (abbreviated)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -259,7 +259,7 @@ spec:
   endpoints:
   - port: http-monitoring
     interval: 30s
-# GrafanaダッシュボードとテレメトリはEXAMPLES.md ステップ5を参照
+# See EXAMPLES.md Step 5 for Grafana dashboards and telemetry config
 ```
 
 ダッシュボードへアクセスします：

--- a/i18n/wenyan-lite/skills/setup-github-actions-ci/SKILL.md
+++ b/i18n/wenyan-lite/skills/setup-github-actions-ci/SKILL.md
@@ -55,11 +55,6 @@ on:
     branches: [main, master]
 
 name: R-CMD-check
-locale: wenyan-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -121,11 +116,6 @@ on:
     branches: [main, master]
 
 name: test-coverage
-locale: wenyan-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -183,11 +173,6 @@ on:
   workflow_dispatch:
 
 name: pkgdown
-locale: wenyan-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions:
   contents: write

--- a/i18n/wenyan-lite/skills/setup-local-kubernetes/SKILL.md
+++ b/i18n/wenyan-lite/skills/setup-local-kubernetes/SKILL.md
@@ -115,11 +115,6 @@ Create a multi-node cluster with ingress and local registry support.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: dev-cluster
-locale: wenyan-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 nodes:
 - role: control-plane
   extraPortMappings:

--- a/i18n/wenyan-lite/skills/version-ml-data/SKILL.md
+++ b/i18n/wenyan-lite/skills/version-ml-data/SKILL.md
@@ -286,11 +286,6 @@ GitHub Actions CI/CD:
 ```yaml
 # .github/workflows/ml-pipeline.yml
 name: ML Pipeline
-locale: wenyan-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 on:
   push:

--- a/i18n/wenyan-lite/skills/write-helm-chart/SKILL.md
+++ b/i18n/wenyan-lite/skills/write-helm-chart/SKILL.md
@@ -99,11 +99,6 @@ cd my-app
 # Chart.yaml (excerpt - see EXAMPLES.md for complete file)
 apiVersion: v2
 name: my-app
-locale: wenyan-lite
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: A Helm chart for deploying my-app to Kubernetes
 version: 0.1.0
 appVersion: "1.0.0"

--- a/i18n/wenyan-ultra/skills/run-chaos-experiment/SKILL.md
+++ b/i18n/wenyan-ultra/skills/run-chaos-experiment/SKILL.md
@@ -76,6 +76,15 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: chaos-testing
+
+---
+# Label pods participating in chaos experiments
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    chaos-enabled: "true"
+    environment: staging  # NEVER production for first run
 ```
 
 設護：
@@ -139,7 +148,7 @@ metadata:
   namespace: chaos-testing
 spec:
   action: pod-kill
-  mode: one
+  mode: one  # Kill one pod only
   selector:
     namespaces:
       - production
@@ -147,6 +156,8 @@ spec:
       app: api-gateway
       chaos-enabled: "true"
   duration: "30s"
+  scheduler:
+    cron: "@every 5m"  # Repeat every 5 minutes (for sustained testing)
 ```
 
 施驗：
@@ -203,15 +214,24 @@ date,experiment,environment,status,error_rate_peak,recovery_time_s,outcome
 預驗常過後：
 
 ```yaml
+# Production pod-kill experiment (more conservative)
 apiVersion: chaos-mesh.org/v1alpha1
 kind: PodChaos
 metadata:
   name: api-pod-kill-prod
+  namespace: chaos-testing
 spec:
   action: pod-kill
-  duration: "10s"
+  mode: one
+  selector:
+    namespaces:
+      - production
+    labelSelectors:
+      app: api-gateway
+      chaos-enabled: "true"
+  duration: "10s"  # Shorter than staging
   scheduler:
-    cron: "0 10 * * 2"
+    cron: "0 10 * * 2"  # Tuesdays at 10 AM only (predictable, low-risk time)
 ```
 
 產護：

--- a/i18n/wenyan-ultra/skills/select-print-material/SKILL.md
+++ b/i18n/wenyan-ultra/skills/select-print-material/SKILL.md
@@ -254,7 +254,7 @@ exposure_time: 6s
 bottom_exposure: 40s
 lift_distance: 6mm
 lift_speed: 65mm/min
-notes: "Post-cure 15min at 60°C for full strength."
+notes: "Post-cure 15min at 60°C for full strength. Brittle without cure."
 ```
 
 得：設文於項註或切片器庫。

--- a/i18n/wenyan-ultra/skills/setup-compose-stack/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-compose-stack/SKILL.md
@@ -206,6 +206,7 @@ services:
 ```yaml
 services:
   app:
+    # always starts
     build: .
 
   mailhog:

--- a/i18n/wenyan-ultra/skills/setup-docker-compose/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-docker-compose/SKILL.md
@@ -86,6 +86,7 @@ volumes:
 ```yaml
 services:
   r-dev:
+    # ... as above
     depends_on:
       - postgres
     environment:

--- a/i18n/wenyan-ultra/skills/setup-github-actions-ci/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-github-actions-ci/SKILL.md
@@ -55,11 +55,6 @@ on:
     branches: [main, master]
 
 name: R-CMD-check
-locale: wenyan-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -121,11 +116,6 @@ on:
     branches: [main, master]
 
 name: test-coverage
-locale: wenyan-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -183,11 +173,6 @@ on:
   workflow_dispatch:
 
 name: pkgdown
-locale: wenyan-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions:
   contents: write

--- a/i18n/wenyan-ultra/skills/setup-local-kubernetes/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-local-kubernetes/SKILL.md
@@ -115,11 +115,6 @@ Create a multi-node cluster with ingress and local registry support.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: dev-cluster
-locale: wenyan-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 nodes:
 - role: control-plane
   extraPortMappings:

--- a/i18n/wenyan-ultra/skills/setup-prometheus-monitoring/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-prometheus-monitoring/SKILL.md
@@ -69,22 +69,27 @@ global:
     cluster: 'production'
     region: 'us-east-1'
 
+# Alertmanager configuration
 alerting:
   alertmanagers:
     - static_configs:
         - targets:
             - localhost:9093
 
+# Load recording and alerting rules
 rule_files:
   - "rules/*.yml"
 
+# Scrape configurations
 scrape_configs:
+  # Prometheus self-monitoring
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
         labels:
           env: 'production'
 
+  # Node exporter for host metrics
   - job_name: 'node'
     static_configs:
       - targets:
@@ -93,6 +98,7 @@ scrape_configs:
         labels:
           env: 'production'
 
+  # Application metrics with file-based service discovery
   - job_name: 'app-services'
     file_sd_configs:
       - files:
@@ -123,16 +129,20 @@ scrape_configs:
     kubernetes_sd_configs:
       - role: pod
     relabel_configs:
+      # Only scrape pods with prometheus.io/scrape annotation
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
+      # Use custom port if specified
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         target_label: __address__
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
+      # Add namespace as label
       - source_labels: [__meta_kubernetes_namespace]
         target_label: kubernetes_namespace
+      # Add pod name as label
       - source_labels: [__meta_kubernetes_pod_name]
         target_label: kubernetes_pod_name
 ```
@@ -166,7 +176,7 @@ scrape_configs:
   - job_name: 'consul-services'
     consul_sd_configs:
       - server: 'consul.example.com:8500'
-        services: []
+        services: []  # Empty list means discover all services
     relabel_configs:
       - source_labels: [__meta_consul_service]
         target_label: job
@@ -193,12 +203,14 @@ groups:
   - name: api_aggregations
     interval: 30s
     rules:
+      # Calculate request rate per endpoint (5m window)
       - record: job:http_requests:rate5m
         expr: |
           sum by (job, endpoint, method) (
             rate(http_requests_total[5m])
           )
 
+      # Calculate error rate percentage
       - record: job:http_errors:rate5m
         expr: |
           sum by (job) (
@@ -207,6 +219,7 @@ groups:
             rate(http_requests_total[5m])
           ) * 100
 
+      # P95 latency by endpoint
       - record: job:http_request_duration_seconds:p95
         expr: |
           histogram_quantile(0.95,
@@ -218,18 +231,21 @@ groups:
   - name: resource_aggregations
     interval: 1m
     rules:
+      # CPU usage by instance
       - record: instance:cpu_usage:ratio
         expr: |
           1 - avg by (instance) (
             rate(node_cpu_seconds_total{mode="idle"}[5m])
           )
 
+      # Memory usage percentage
       - record: instance:memory_usage:ratio
         expr: |
           1 - (
             node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
           )
 
+      # Disk usage by mount point
       - record: instance:disk_usage:ratio
         expr: |
           1 - (
@@ -336,8 +352,11 @@ scrape_configs:
     metrics_path: '/federate'
     params:
       'match[]':
+        # Aggregate only pre-computed recording rules
         - '{__name__=~"job:.*"}'
+        # Include alert states
         - '{__name__=~"ALERTS.*"}'
+        # Include critical infrastructure metrics
         - 'up{job=~".*"}'
     static_configs:
       - targets:
@@ -375,11 +394,16 @@ scrape_configs:
 用 **Thanos** 或 **Cortex** 為真 HA、或簡負衡：
 
 ```yaml
+# prometheus-1.yml and prometheus-2.yml (identical configs)
 global:
   scrape_interval: 15s
   external_labels:
-    prometheus: 'prometheus-1'
+    prometheus: 'prometheus-1'  # Different per instance
     replica: 'A'
+
+# Use --web.external-url flag for each instance
+# prometheus-1: --web.external-url=http://prometheus-1.example.com:9090
+# prometheus-2: --web.external-url=http://prometheus-2.example.com:9090
 ```
 
 配 Grafana 詢二：

--- a/i18n/wenyan-ultra/skills/setup-service-mesh/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-service-mesh/SKILL.md
@@ -79,6 +79,7 @@ spec:
     pilot:
       k8s:
         resources: { requests: { cpu: 500m, memory: 2Gi } }
+# See EXAMPLES.md Step 1 for complete configuration
 ```
 
 得：控面 pod 行於 istio-system 或 linkerd 名空。`istioctl version` 或 `linkerd version` 示客服合本。
@@ -116,6 +117,7 @@ spec:
       containers:
       - name: app
         image: nginx:alpine
+# See EXAMPLES.md Step 2 for complete test deployment
 ```
 
 施驗：
@@ -148,6 +150,7 @@ metadata:
 spec:
   mtls:
     mode: STRICT
+# See EXAMPLES.md Step 3 for per-namespace and permissive mode examples
 ```
 
 **Linkerd：**
@@ -187,6 +190,7 @@ spec:
     - destination: { host: api-service, subset: v1 }
       weight: 90
     retries: { attempts: 3, perTryTimeout: 2s }
+# See EXAMPLES.md Step 4 for complete routing, circuit breaker, and gateway configs
 ```
 
 **Linkerd 流分：**
@@ -247,6 +251,7 @@ spec:
   endpoints:
   - port: http-monitoring
     interval: 30s
+# See EXAMPLES.md Step 5 for Grafana dashboards and telemetry config
 ```
 
 達板：

--- a/i18n/wenyan-ultra/skills/setup-uptime-checks/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-uptime-checks/SKILL.md
@@ -63,6 +63,7 @@ docker run -d \
 Kubernetes 釋：
 
 ```yaml
+# blackbox-exporter-deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -113,7 +114,9 @@ spec:
 建 `blackbox.yml` 含諸探型：
 
 ```yaml
+# blackbox.yml
 modules:
+  # Basic HTTP 200 check
   http_2xx:
     prober: http
     timeout: 5s
@@ -123,6 +126,7 @@ modules:
       follow_redirects: true
       preferred_ip_protocol: "ip4"
 
+  # HTTP with authentication
   http_2xx_auth:
     prober: http
     timeout: 5s
@@ -132,6 +136,7 @@ modules:
       headers:
         Authorization: "Bearer ${AUTH_TOKEN}"
 
+  # API health check (expects JSON response)
   http_json_health:
     prober: http
     timeout: 5s
@@ -141,6 +146,7 @@ modules:
       fail_if_body_not_matches_regexp:
         - '"status":"healthy"'
 
+  # SSL certificate check
   http_2xx_ssl:
     prober: http
     timeout: 5s
@@ -151,18 +157,21 @@ modules:
         insecure_skip_verify: false
       fail_if_ssl_not_present: true
 
+  # TCP port check (e.g., database)
   tcp_connect:
     prober: tcp
     timeout: 5s
     tcp:
       preferred_ip_protocol: "ip4"
 
+  # ICMP ping
   icmp:
     prober: icmp
     timeout: 5s
     icmp:
       preferred_ip_protocol: "ip4"
 
+  # DNS resolution check
   dns_google:
     prober: dns
     timeout: 5s
@@ -191,11 +200,14 @@ kubectl create configmap blackbox-exporter-config \
 加 Blackbox 標於 Prometheus 配：
 
 ```yaml
+# prometheus.yml
 scrape_configs:
+  # Blackbox exporter itself
   - job_name: 'blackbox-exporter'
     static_configs:
       - targets: ['blackbox-exporter:9115']
 
+  # HTTP endpoint checks
   - job_name: 'blackbox-http'
     metrics_path: /probe
     params:
@@ -213,6 +225,7 @@ scrape_configs:
       - target_label: __address__
         replacement: blackbox-exporter:9115
 
+  # SSL certificate expiry checks
   - job_name: 'blackbox-ssl'
     metrics_path: /probe
     params:
@@ -229,6 +242,7 @@ scrape_configs:
       - target_label: __address__
         replacement: blackbox-exporter:9115
 
+  # TCP connectivity checks (databases, etc.)
   - job_name: 'blackbox-tcp'
     metrics_path: /probe
     params:
@@ -263,6 +277,7 @@ kubectl rollout restart deployment/prometheus -n monitoring
 定警則：
 
 ```yaml
+# uptime-alerts.yml
 groups:
   - name: uptime
     interval: 30s
@@ -365,6 +380,7 @@ curl -X POST https://api.statuspage.io/v1/pages/PAGE_ID/incidents \
 選乙：自託 Cachet：
 
 ```yaml
+# docker-compose.yml for Cachet
 version: '3'
 services:
   cachet:

--- a/i18n/wenyan-ultra/skills/version-ml-data/SKILL.md
+++ b/i18n/wenyan-ultra/skills/version-ml-data/SKILL.md
@@ -286,11 +286,6 @@ GitHub Actions CI/CD:
 ```yaml
 # .github/workflows/ml-pipeline.yml
 name: ML Pipeline
-locale: wenyan-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 on:
   push:

--- a/i18n/wenyan-ultra/skills/write-helm-chart/SKILL.md
+++ b/i18n/wenyan-ultra/skills/write-helm-chart/SKILL.md
@@ -99,11 +99,6 @@ cd my-app
 # Chart.yaml (excerpt - see EXAMPLES.md for complete file)
 apiVersion: v2
 name: my-app
-locale: wenyan-ultra
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: A Helm chart for deploying my-app to Kubernetes
 version: 0.1.0
 appVersion: "1.0.0"

--- a/i18n/wenyan/skills/setup-github-actions-ci/SKILL.md
+++ b/i18n/wenyan/skills/setup-github-actions-ci/SKILL.md
@@ -55,11 +55,6 @@ on:
     branches: [main, master]
 
 name: R-CMD-check
-locale: wenyan
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -121,11 +116,6 @@ on:
     branches: [main, master]
 
 name: test-coverage
-locale: wenyan
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions: read-all
 
@@ -183,11 +173,6 @@ on:
   workflow_dispatch:
 
 name: pkgdown
-locale: wenyan
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 permissions:
   contents: write

--- a/i18n/wenyan/skills/setup-local-kubernetes/SKILL.md
+++ b/i18n/wenyan/skills/setup-local-kubernetes/SKILL.md
@@ -115,11 +115,6 @@ Create a multi-node cluster with ingress and local registry support.
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: dev-cluster
-locale: wenyan
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 nodes:
 - role: control-plane
   extraPortMappings:

--- a/i18n/wenyan/skills/version-ml-data/SKILL.md
+++ b/i18n/wenyan/skills/version-ml-data/SKILL.md
@@ -286,11 +286,6 @@ GitHub Actions CI/CD:
 ```yaml
 # .github/workflows/ml-pipeline.yml
 name: ML Pipeline
-locale: wenyan
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 
 on:
   push:

--- a/i18n/wenyan/skills/write-helm-chart/SKILL.md
+++ b/i18n/wenyan/skills/write-helm-chart/SKILL.md
@@ -99,11 +99,6 @@ cd my-app
 # Chart.yaml (excerpt - see EXAMPLES.md for complete file)
 apiVersion: v2
 name: my-app
-locale: wenyan
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
 description: A Helm chart for deploying my-app to Kubernetes
 version: 0.1.0
 appVersion: "1.0.0"

--- a/i18n/zh-CN/skills/build-ci-cd-pipeline/SKILL.md
+++ b/i18n/zh-CN/skills/build-ci-cd-pipeline/SKILL.md
@@ -344,7 +344,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Deployment Status: ${{ steps.status.outputs.status }}"
+                    "text": "🚀 Deployment Status: ${{ steps.status.outputs.status }}"
                   }
                 },
                 {

--- a/i18n/zh-CN/skills/setup-prometheus-monitoring/SKILL.md
+++ b/i18n/zh-CN/skills/setup-prometheus-monitoring/SKILL.md
@@ -70,27 +70,27 @@ global:
     cluster: 'production'
     region: 'us-east-1'
 
-# Alertmanager 配置
+# Alertmanager configuration
 alerting:
   alertmanagers:
     - static_configs:
         - targets:
             - localhost:9093
 
-# 加载记录规则和告警规则
+# Load recording and alerting rules
 rule_files:
   - "rules/*.yml"
 
-# 抓取配置
+# Scrape configurations
 scrape_configs:
-  # Prometheus 自监控
+  # Prometheus self-monitoring
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
         labels:
           env: 'production'
 
-  # 主机指标的 Node exporter
+  # Node exporter for host metrics
   - job_name: 'node'
     static_configs:
       - targets:
@@ -99,7 +99,7 @@ scrape_configs:
         labels:
           env: 'production'
 
-  # 基于文件的服务发现的应用指标
+  # Application metrics with file-based service discovery
   - job_name: 'app-services'
     file_sd_configs:
       - files:
@@ -130,20 +130,20 @@ scrape_configs:
     kubernetes_sd_configs:
       - role: pod
     relabel_configs:
-      # 仅抓取带有 prometheus.io/scrape 注解的 Pod
+      # Only scrape pods with prometheus.io/scrape annotation
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
-      # 如果指定了自定义端口，则使用该端口
+      # Use custom port if specified
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         target_label: __address__
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2
-      # 将命名空间添加为标签
+      # Add namespace as label
       - source_labels: [__meta_kubernetes_namespace]
         target_label: kubernetes_namespace
-      # 将 Pod 名称添加为标签
+      # Add pod name as label
       - source_labels: [__meta_kubernetes_pod_name]
         target_label: kubernetes_pod_name
 ```
@@ -177,7 +177,7 @@ scrape_configs:
   - job_name: 'consul-services'
     consul_sd_configs:
       - server: 'consul.example.com:8500'
-        services: []  # 空列表表示发现所有服务
+        services: []  # Empty list means discover all services
     relabel_configs:
       - source_labels: [__meta_consul_service]
         target_label: job
@@ -204,14 +204,14 @@ groups:
   - name: api_aggregations
     interval: 30s
     rules:
-      # 计算每个端点的请求速率（5 分钟窗口）
+      # Calculate request rate per endpoint (5m window)
       - record: job:http_requests:rate5m
         expr: |
           sum by (job, endpoint, method) (
             rate(http_requests_total[5m])
           )
 
-      # 计算错误率百分比
+      # Calculate error rate percentage
       - record: job:http_errors:rate5m
         expr: |
           sum by (job) (
@@ -220,7 +220,7 @@ groups:
             rate(http_requests_total[5m])
           ) * 100
 
-      # 按端点统计 P95 延迟
+      # P95 latency by endpoint
       - record: job:http_request_duration_seconds:p95
         expr: |
           histogram_quantile(0.95,
@@ -232,21 +232,21 @@ groups:
   - name: resource_aggregations
     interval: 1m
     rules:
-      # 按实例统计 CPU 使用率
+      # CPU usage by instance
       - record: instance:cpu_usage:ratio
         expr: |
           1 - avg by (instance) (
             rate(node_cpu_seconds_total{mode="idle"}[5m])
           )
 
-      # 内存使用率百分比
+      # Memory usage percentage
       - record: instance:memory_usage:ratio
         expr: |
           1 - (
             node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
           )
 
-      # 按挂载点统计磁盘使用率
+      # Disk usage by mount point
       - record: instance:disk_usage:ratio
         expr: |
           1 - (
@@ -356,11 +356,11 @@ scrape_configs:
     metrics_path: '/federate'
     params:
       'match[]':
-        # 仅聚合预计算的记录规则
+        # Aggregate only pre-computed recording rules
         - '{__name__=~"job:.*"}'
-        # 包含告警状态
+        # Include alert states
         - '{__name__=~"ALERTS.*"}'
-        # 包含关键基础设施指标
+        # Include critical infrastructure metrics
         - 'up{job=~".*"}'
     static_configs:
       - targets:
@@ -398,14 +398,14 @@ scrape_configs:
 使用 **Thanos** 或 **Cortex** 实现真正的高可用，或使用简单的负载均衡设置：
 
 ```yaml
-# prometheus-1.yml 和 prometheus-2.yml（配置相同）
+# prometheus-1.yml and prometheus-2.yml (identical configs)
 global:
   scrape_interval: 15s
   external_labels:
-    prometheus: 'prometheus-1'  # 每个实例不同
+    prometheus: 'prometheus-1'  # Different per instance
     replica: 'A'
 
-# 每个实例使用 --web.external-url 标志
+# Use --web.external-url flag for each instance
 # prometheus-1: --web.external-url=http://prometheus-1.example.com:9090
 # prometheus-2: --web.external-url=http://prometheus-2.example.com:9090
 ```

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -73,7 +73,8 @@
  *   node scripts/normalize-i18n-fences.js --dry          # preview, explicitly
  *   node scripts/normalize-i18n-fences.js --write        # apply
  *   node scripts/normalize-i18n-fences.js --basis head
- *   node scripts/normalize-i18n-fences.js --locale de    # restrict
+ *   node scripts/normalize-i18n-fences.js --locale de    # restrict to one locale
+ *   node scripts/normalize-i18n-fences.js --tag yaml,json  # restrict to tags (#477 batches)
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
@@ -111,7 +112,7 @@ const argv = process.argv.slice(2);
  * `"--dry"` as the locale value.
  */
 const BOOL_FLAGS = new Set(['--write', '--dry']);
-const VALUE_FLAGS = new Set(['--basis', '--locale']);
+const VALUE_FLAGS = new Set(['--basis', '--locale', '--tag']);
 
 function usageError(message) {
   console.error(`ERROR: ${message}`);
@@ -119,7 +120,7 @@ function usageError(message) {
   process.exit(2);
 }
 
-const opts = { write: false, dry: false, basis: 'source-commit', locale: null };
+const opts = { write: false, dry: false, basis: 'source-commit', locale: null, tag: null };
 for (let i = 0; i < argv.length; i++) {
   const arg = argv[i];
   const eq = arg.indexOf('=');
@@ -157,6 +158,28 @@ if (!['source-commit', 'head'].includes(BASIS)) {
   console.error(`ERROR: --basis must be 'source-commit' or 'head' (got '${BASIS}')`);
   process.exit(2);
 }
+
+/**
+ * Restrict the run to fences carrying these tags — the tag-scoped batches #477
+ * calls for, so a 1,307-fence backlog lands as reviewable, individually
+ * revertable slices instead of one 300-file diff.
+ *
+ * Scoping is applied to the DIVERGENT set only, never to the soundness checks:
+ * fence-count and tag-sequence alignment still consider every fence in the file,
+ * because whether ordinal mapping is trustworthy is a property of the whole
+ * file, not of the slice being repaired. Narrowing those would let a batch
+ * rewrite fences in a file the unscoped run correctly refuses to touch.
+ */
+const ONLY_TAGS = opts.tag === null ? null : new Set(
+  opts.tag.split(',').map((t) => t.trim().toLowerCase()).filter((t) => t !== ''),
+);
+if (ONLY_TAGS !== null && ONLY_TAGS.size === 0) {
+  console.error("ERROR: --tag was given no usable value (got '" + opts.tag + "').");
+  process.exit(2);
+}
+// `untagged` names the empty info string, which is gated under default-deny and
+// would otherwise be unaddressable from the command line.
+const tagOf = (fence) => (fence.lang === '' ? 'untagged' : fence.lang);
 
 /**
  * The locales this tool can actually scan: a directory under `i18n/` carrying a
@@ -327,6 +350,8 @@ const changedByLocale = new Map();
 // Every edit is planned first and applied afterwards, so preview and write walk
 // identical code and the preview cannot describe a run the write does not make.
 const plan = [];
+/** tag -> divergent-fence count, for validating --tag against reality. */
+const seenTags = new Map();
 
 for (const t of targets) {
   let basisText = null;
@@ -355,7 +380,12 @@ for (const t of targets) {
   // English revision. Using the same predicate as the checker is what keeps the
   // two tools from disagreeing — an ordinal-only test would rewrite fences the
   // gate considers legitimately stale.
-  const divergent = translatedFences.filter((f) => isGated(f) && !everEnglish.has(f.body));
+  const allDivergent = translatedFences.filter((f) => isGated(f) && !everEnglish.has(f.body));
+  // Every divergent tag anywhere in the corpus, INCLUDING in files this run will
+  // skip as unrepairable — the set `--tag` is validated against. Collecting only
+  // from repairable files would reject a real tag as a typo.
+  for (const f of allDivergent) seenTags.set(tagOf(f), (seenTags.get(tagOf(f)) || 0) + 1);
+  const divergent = ONLY_TAGS === null ? allDivergent : allDivergent.filter((f) => ONLY_TAGS.has(tagOf(f)));
   if (divergent.length === 0) continue;
 
   if (translatedFences.length !== basisFences.length) {
@@ -405,6 +435,23 @@ for (const t of targets) {
   fencesRestored += restoredHere;
   changedByLocale.set(t.locale, (changedByLocale.get(t.locale) || 0) + restoredHere);
   plan.push({ path: t.path, relPath: t.relPath, text: lines.join('\n'), n: restoredHere, basisLabel });
+}
+
+// Validate `--tag` against what the scan actually saw, not against a hand-kept
+// list of language names. A tag matching nothing would otherwise report
+// "files to change: 0" — the clean-looking zero `--locale` already exists to
+// prevent, arriving by typo. Checked after the scan because the accept-list is
+// the scan's own output; checked before any write, so a mistyped batch cannot
+// touch the corpus.
+if (ONLY_TAGS !== null) {
+  const unknown = [...ONLY_TAGS].filter((t) => !seenTags.has(t));
+  if (unknown.length) {
+    console.error(`ERROR: --tag matched no divergent fence: ${unknown.join(', ')}`);
+    console.error('Nothing would be restored, and the run would report a clean-looking zero.');
+    const available = [...seenTags.entries()].sort((a, b) => b[1] - a[1]);
+    console.error(`Divergent tags present: ${available.map(([t, n]) => `${t}=${n}`).join('  ')}`);
+    process.exit(2);
+  }
 }
 
 if (!PREVIEW && plan.length) {

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -91,6 +91,39 @@ function run(dir, args = []) {
   return { status: r.status, stdout: r.stdout, stderr: r.stderr };
 }
 
+/**
+ * Add a second skill carrying TWO divergent fences with different tags, so a
+ * tag-scoped run has something to include and something to leave alone. This is
+ * the shape #477's batches face: 54 of the 108 files holding yaml divergences
+ * also hold bash, r or python ones belonging to later batches.
+ */
+function addMixedSkill(dir) {
+  const english = [
+    '---', 'name: mixed-skill', 'description: Two fences.', '---', '',
+    '# Mixed', '', '## Procedure', '',
+    '```bash', 'echo "english-bash"', '```', '',
+    '```yaml', 'key: english-yaml', '```', '',
+  ].join('\n');
+  mkdirSync(join(dir, 'skills', 'mixed-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'mixed-skill', 'SKILL.md'), english, 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english mixed skill']);
+  const sc = git(dir, ['rev-parse', 'HEAD']);
+
+  const translatedPath = join(dir, 'i18n', 'de', 'skills', 'mixed-skill', 'SKILL.md');
+  mkdirSync(dirname(translatedPath), { recursive: true });
+  writeFileSync(translatedPath, [
+    '---', 'name: mixed-skill', 'description: Zwei Bloecke.',
+    'locale: de', 'source_locale: en', `source_commit: ${sc}`, '---', '',
+    '# Gemischt', '', '## Ablauf', '',
+    '```bash', 'echo "uebersetzt-bash"', '```', '',
+    '```yaml', 'key: uebersetzt-yaml', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de mixed translation, both fences divergent']);
+  return translatedPath;
+}
+
 const isDirty = (dir) => git(dir, ['status', '--porcelain']) !== '';
 
 // ── the gate ────────────────────────────────────────────────────────────────
@@ -219,6 +252,77 @@ test('a preview run is unaffected by a dirty tree', async (t) => {
   // tree normally" from "previewed it and silently found nothing" — and preview
   // is now the default mode, so this count is the number a caller acts on.
   assert.match(r.stdout, /files to change: 1/);
+});
+
+// ── --tag: the #477 batch scoping ───────────────────────────────────────────
+
+test('--tag restores only the named tag, leaving other tags divergent', async (t) => {
+  const { dir } = makeFixture(t);
+  const mixed = addMixedSkill(dir);
+
+  const r = run(dir, ['--tag', 'yaml', '--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  const after = readFileSync(mixed, 'utf8');
+  assert.ok(after.includes('key: english-yaml'), 'the yaml fence should be restored');
+  assert.ok(after.includes('echo "uebersetzt-bash"'),
+    'the bash fence belongs to a later batch and must be left alone');
+});
+
+test('--tag accepts a comma list, and the = form', async (t) => {
+  const { dir } = makeFixture(t);
+  addMixedSkill(dir);
+
+  const list = run(dir, ['--tag', 'yaml,bash']);
+  assert.equal(list.status, 0, list.stderr);
+  assert.match(list.stdout, /fences to restore: 3/, 'both mixed fences plus the demo bash one');
+
+  const eq = run(dir, ['--tag=yaml']);
+  assert.equal(eq.status, 0, eq.stderr);
+  assert.match(eq.stdout, /fences to restore: 1/);
+});
+
+test('a --tag matching nothing is an error, not a clean-looking zero', async (t) => {
+  // The `--locale` lesson, one flag over: a scoping value that matches nothing
+  // reports "files to change: 0", which reads as "this batch is already done".
+  const { dir } = makeFixture(t);
+  addMixedSkill(dir);
+
+  const r = run(dir, ['--tag', 'yaml,nosuchtag', '--write']);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /matched no divergent fence: nosuchtag/);
+  assert.match(r.stderr, /Divergent tags present:.*yaml/, 'should list what IS available');
+  assert.equal(isDirty(dir), false, 'a rejected batch must not have written anything');
+});
+
+test('--tag with no usable value is an error', async (t) => {
+  const { dir } = makeFixture(t);
+
+  for (const args of [['--tag'], ['--tag', '--write'], ['--tag='], ['--tag', ',, ,']]) {
+    const r = run(dir, args);
+    assert.equal(r.status, 2, `${JSON.stringify(args)} was accepted`);
+  }
+});
+
+test('--tag does NOT relax the alignment checks', async (t) => {
+  // Scoping narrows what gets repaired, never whether ordinal mapping is
+  // trustworthy. A file the unscoped run refuses to touch must stay refused,
+  // or a batch could rewrite fences on a mapping the tool knows is unsound.
+  const { dir } = makeFixture(t);
+  const mixed = addMixedSkill(dir);
+  // Drop a fence from the translation so counts no longer match the basis.
+  writeFileSync(mixed, readFileSync(mixed, 'utf8')
+    .replace('```bash\necho "uebersetzt-bash"\n```\n\n', ''), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'drop a fence, breaking ordinal mapping']);
+
+  const r = run(dir, ['--tag', 'yaml', '--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /skipped/, 'the misaligned file must be reported, not repaired');
+  assert.ok(readFileSync(mixed, 'utf8').includes('key: uebersetzt-yaml'),
+    'a file with unsound ordinal mapping must not be rewritten by a scoped run');
 });
 
 // ── argument parsing ────────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #477. First tag-scoped batch, plus the tooling that makes batching possible.

## Why the tooling came first

#477 plans the backlog as tag-scoped batches — `yaml`+`json`, then `bash` (574), then `r` (320) — "to keep each diff reviewable and a bad batch revertable in isolation". The normalizer could not do that: it restores every divergent gated fence in a file, and **54 of the 108 files** carrying a yaml/json divergence also carry `bash`, `r` or `python` ones belonging to later batches. Running it unscoped produces exactly the 300-file diff the batching exists to avoid.

`--tag yaml,json` (also `--tag=yaml`) restricts the run. Two design points worth review:

- **Scoping applies to the divergent set only, never to the soundness checks.** Fence-count and tag-sequence alignment still consider every fence in the file, because whether ordinal mapping is trustworthy is a property of the whole file, not of the slice being repaired. Narrowing those would let a batch rewrite fences in a file the unscoped run correctly refuses to touch — there is a test for exactly that.
- **A tag matching nothing exits 2**, not "files to change: 0". That is the `--locale` lesson one flag over: a scoping value that silently matches nothing reads as "this batch is already done". Validation runs against the tags the scan actually saw — including in files it will skip as unrepairable, so a real tag is not rejected as a typo — after the scan but before any write.

Two mutations killed: disabling the filter (2 tests), removing the unknown-tag validation (1). 58 tests total.

## Batch 1

**76 files, 172 fences.** Gate: **1,307 → 1,135**, and *only* the batch's tags moved:

| tag | before | after | delta |
|---|---|---|---|
| yaml | 198 | 34 | **−164** |
| json | 15 | 7 | **−8** |
| bash, r, python, … | — | — | unchanged |

Most of this is **#475 landing in reverse**. The caveman scaffolder injected translation frontmatter into body fences, so the corpus shipped examples like a Helm `Chart.yaml` with this between `name:` and `description:`:

```
-locale: wenyan
-source_locale: en
-source_commit: 82c77053
-translator: "Julius Brussee homage — caveman"
-translation_date: "2026-04-19"
```

138 such lines are removed. Not cosmetic — these are the literal contents of files a reader is meant to copy.

## Deliberately excluded

7 fences in `setup-putior-ci` (6 locales) and `de/escalate-issues`. Those sit inside **#476's runaway-fence regions**, where the English basis itself mis-parses, so restoring against it would perpetuate broken content. #477's Order section calls for #476 first; this honours that for the affected files rather than blocking the whole batch. They are reverted explicitly and appear nowhere in the diff.

Remaining yaml+json, fully accounted for:

| | |
|---|---|
| 7 | `agents/` mirrors — normalizer covers skills only (#477 step 5) |
| 7 | the #476-blocked files above |
| 27 | content forks the ordinal mapping cannot reconstruct (#478) |

## Verification

- Frontmatter untouched, **verified per file against HEAD** — so #278's staleness backlog (2,553) is unchanged. `check-translation-freshness` runs `--warn` in CI and reads exactly as before.
- No translated SKILL.md crosses the 500-line budget.
- `npm test`, `test:scripts`, line-endings, and content-style `--added` all green locally.

## Review notes

Per #477, these are not rubber-stamp diffs. Worth a look: whether any restored fence leaves surrounding prose contradicting it (the issue cites `caveman-lite/refactor-skill-structure` renaming a heading to match a modified in-fence grep, and `de/design-shiny-ui` renaming `my_theme`→`mein_theme` across five sites). Those specific files are not in this batch, but the class applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZHXCqANCeAZEy3ixDuiYk