### PR TITLE
fix(i18n): restore r code fences to their English source (#477 batch 3)

### DIFF
--- a/i18n/caveman/skills/deploy-shiny-app/SKILL.md
+++ b/i18n/caveman/skills/deploy-shiny-app/SKILL.md
@@ -55,7 +55,7 @@ rsconnect::appDependencies("path/to/app")
 # For golem apps, ensure DESCRIPTION lists all Imports
 devtools::check()
 
-# Verify app runs cleanly
+# Verify the app runs cleanly
 shiny::runApp("path/to/app")
 ```
 
@@ -189,7 +189,7 @@ docker run -p 3838:3838 myapp:latest
 ### Step 3: Verify Deployment
 
 ```r
-# Check deployed URL responds
+# Check the deployed URL responds
 response <- httr::GET("https://your-app-url/")
 httr::status_code(response)  # Should be 200
 

--- a/i18n/de/skills/add-puzzle-type/SKILL.md
+++ b/i18n/de/skills/add-puzzle-type/SKILL.md
@@ -50,11 +50,11 @@ Einen neuen Puzzletyp ueber alle Pipeline-Integrationspunkte in jigsawR aufsetze
 #' Generate <type> puzzle pieces (internal)
 #' @noRd
 generate_<type>_pieces_internal <- function(params, seed) {
-  # 1. RNG-Zustand initialisieren
-  # 2. Teilegeometrien generieren
-  # 3. Kantenpfade erstellen (SVG-Pfaddaten)
-  # 4. Adjazenz berechnen
-  # 5. Liste zurueckgeben: pieces, edges, adjacency, metadata
+  # 1. Initialize RNG state
+  # 2. Generate piece geometries
+  # 3. Build edge paths (SVG path data)
+  # 4. Compute adjacency
+  # 5. Return list: pieces, edges, adjacency, metadata
 }
 ```
 
@@ -90,7 +90,7 @@ valid_types <- c("rectangular", "hexagonal", "concentric", "voronoi", "snic", "<
 2. Fusionsbehandlung hinzufuegen, falls der Typ PILES-Notation unterstuetzt
 
 ```r
-# Im switch/dispatch
+# In the switch/dispatch
 "<type>" = generate_<type>_pieces_internal(params, seed)
 ```
 

--- a/i18n/de/skills/analyze-codebase-workflow/SKILL.md
+++ b/i18n/de/skills/analyze-codebase-workflow/SKILL.md
@@ -51,11 +51,11 @@ Quelldateien und ihre Sprachen identifizieren, um zu verstehen, was putior analy
 ```r
 library(putior)
 
-# Alle unterstützten Sprachen und ihre Erweiterungen auflisten
+# List all supported languages and their extensions
 list_supported_languages()
-list_supported_languages(detection_only = TRUE)  # Nur Sprachen mit Auto-Erkennung
+list_supported_languages(detection_only = TRUE)  # Only languages with auto-detection
 
-# Unterstützte Erweiterungen abrufen
+# Get supported extensions
 exts <- get_supported_extensions()
 ```
 
@@ -75,15 +75,15 @@ find /path/to/repo -type f | sed 's/.*\.//' | sort | uniq -c | sort -rn | head -
 Für jede erkannte Sprache die Verfügbarkeit von Auto-Erkennungsmustern verifizieren.
 
 ```r
-# Prüfen welche Sprachen Auto-Erkennungsmuster haben (18 Sprachen, 902 Muster)
+# Check which languages have auto-detection patterns (18 languages, 902 patterns)
 detection_langs <- list_supported_languages(detection_only = TRUE)
-cat("Sprachen mit Auto-Erkennung:\n")
+cat("Languages with auto-detection:\n")
 print(detection_langs)
 
-# Musterzahlen für spezifische im Repo gefundene Sprachen abrufen
+# Get pattern counts for specific languages found in the repo
 for (lang in c("r", "python", "javascript", "sql", "dockerfile", "makefile")) {
   patterns <- get_detection_patterns(lang)
-  cat(sprintf("%s: %d Input-, %d Output-, %d Abhängigkeitsmuster\n",
+  cat(sprintf("%s: %d input, %d output, %d dependency patterns\n",
     lang,
     length(patterns$input),
     length(patterns$output),
@@ -101,14 +101,14 @@ for (lang in c("r", "python", "javascript", "sql", "dockerfile", "makefile")) {
 `put_auto()` auf das Zielverzeichnis ausführen, um Workflow-Elemente zu entdecken.
 
 ```r
-# Vollständige Auto-Erkennung
+# Full auto-detection
 workflow <- put_auto("./src/",
   detect_inputs = TRUE,
   detect_outputs = TRUE,
   detect_dependencies = TRUE
 )
 
-# Build-Skripte und Test-Helfer vom Scan ausschließen
+# Exclude build scripts and test helpers from scanning
 workflow <- put_auto("./src/",
   detect_inputs = TRUE,
   detect_outputs = TRUE,
@@ -116,17 +116,17 @@ workflow <- put_auto("./src/",
   exclude = c("build-", "test_helper")
 )
 
-# Erkannte Workflow-Knoten anzeigen
+# View detected workflow nodes
 print(workflow)
 
-# Knotenanzahl prüfen
-cat(sprintf("Erkannte %d Workflow-Knoten\n", nrow(workflow)))
+# Check node count
+cat(sprintf("Detected %d workflow nodes\n", nrow(workflow)))
 ```
 
 Für große Repos, Unterverzeichnisse schrittweise analysieren:
 
 ```r
-# Spezifische Unterverzeichnisse analysieren
+# Analyze specific subdirectories
 etl_workflow <- put_auto("./src/etl/")
 api_workflow <- put_auto("./src/api/")
 ```
@@ -140,13 +140,13 @@ api_workflow <- put_auto("./src/api/")
 Den automatisch erkannten Workflow visualisieren, um Abdeckung zu beurteilen und Lücken zu identifizieren.
 
 ```r
-# Diagramm aus auto-erkanntem Workflow generieren
+# Generate diagram from auto-detected workflow
 cat(put_diagram(workflow, theme = "github"))
 
-# Mit Quelldatei-Info für Nachverfolgbarkeit
+# With source file info for traceability
 cat(put_diagram(workflow, show_source_info = TRUE))
 
-# Zur Überprüfung in Datei speichern
+# Save to file for review
 writeLines(put_diagram(workflow, theme = "github"), "workflow-auto.md")
 ```
 
@@ -159,13 +159,13 @@ writeLines(put_diagram(workflow, theme = "github"), "workflow-auto.md")
 Einen strukturierten Plan erstellen, der Gefundenes und manuell Anzunotierendes dokumentiert.
 
 ```r
-# Annotationsvorschläge generieren
+# Generate annotation suggestions
 put_generate("./src/", style = "single")
 
-# Mehrzeiliger Stil (lesbarer für komplexe Workflows)
+# For multiline style (more readable for complex workflows)
 put_generate("./src/", style = "multiline")
 
-# Vorschläge in die Zwischenablage kopieren
+# Copy suggestions to clipboard for easy pasting
 put_generate("./src/", output = "clipboard")
 ```
 

--- a/i18n/de/skills/create-r-package/SKILL.md
+++ b/i18n/de/skills/create-r-package/SKILL.md
@@ -187,10 +187,10 @@ NULL
 ## Beispiele
 
 ```r
-# Minimale Erstellung
+# Minimal creation
 usethis::create_package("myanalysis")
 
-# Vollstaendiges Setup in einer Sitzung
+# Full setup in one session
 usethis::create_package("myanalysis")
 usethis::use_mit_license()
 usethis::use_testthat(edition = 3)

--- a/i18n/de/skills/fail-early-pattern/SKILL.md
+++ b/i18n/de/skills/fail-early-pattern/SKILL.md
@@ -71,21 +71,21 @@ Eingaben am Anfang jeder oeffentlichen Funktion validieren, bevor irgendeine Arb
 
 ```r
 calculate_summary <- function(data, method = c("mean", "median", "trim"), trim_pct = 0.1) {
-  # Guard: Typenpruefung
+  # Guard: type check
   if (!is.data.frame(data)) {
     stop("'data' must be a data frame, not ", class(data)[[1]], call. = FALSE)
   }
-  # Guard: Nicht leer
+  # Guard: non-empty
   if (nrow(data) == 0L) {
     stop("'data' must have at least one row", call. = FALSE)
   }
-  # Guard: Argument-Abgleich
+  # Guard: argument matching
   method <- match.arg(method)
-  # Guard: Bereichspruefung
+  # Guard: range check
   if (!is.numeric(trim_pct) || trim_pct < 0 || trim_pct > 0.5) {
     stop("'trim_pct' must be a number between 0 and 0.5, got: ", trim_pct, call. = FALSE)
   }
-  # --- Alle Guards bestanden, echte Arbeit beginnen ---
+  # --- All guards passed, begin real work ---
   # ...
 }
 ```
@@ -139,16 +139,16 @@ Jede Fehlermeldung sollte vier Fragen beantworten:
 **Gute Meldungen:**
 
 ```r
-# Was + Warum (erwartet vs. tatsaechlich)
+# What + Why (expected vs. actual)
 stop("'n' must be a positive integer, got: ", n, call. = FALSE)
 
-# Was + Warum + Wie zu beheben
+# What + Why + How to fix
 cli::cli_abort(c(
   "{.arg config_path} does not exist: {.file {config_path}}",
   "i" = "Create it with {.run create_config({.file {config_path}})}."
 ))
 
-# Was + Kontext
+# What + context
 cli::cli_abort(c(
   "Column {.val {col_name}} not found in {.arg data}.",
   "i" = "Available columns: {.val {names(data)}}"
@@ -158,9 +158,9 @@ cli::cli_abort(c(
 **Schlechte Meldungen:**
 
 ```r
-stop("Error")                    # Was ist gescheitert? Keine Ahnung
-stop("Invalid input")           # Welche Eingabe? Was ist damit falsch?
-stop(paste("Error in step", i)) # Keine handlungsrelevante Information
+stop("Error")                    # What failed? No idea
+stop("Invalid input")           # Which input? What's wrong with it?
+stop(paste("Error in step", i)) # No actionable information
 ```
 
 **Erwartet:** Fehlermeldungen sind selbstdokumentierend — ein Entwickler, der den Fehler zum ersten Mal sieht, kann ihn ohne Lesen des Quellcodes diagnostizieren und beheben.
@@ -174,7 +174,7 @@ stop(paste("Error in step", i)) # Keine handlungsrelevante Information
 **Faustregel:** Falls ein Benutzer still eine falsche Antwort erhalten koennte, ist das ein `stop()`, kein `warning()`.
 
 ```r
-# RICHTIG: stop wenn Ergebnis falsch waere
+# CORRECT: stop when result would be wrong
 read_config <- function(path) {
   if (!file.exists(path)) {
     stop("Config file not found: ", path, call. = FALSE)
@@ -182,13 +182,13 @@ read_config <- function(path) {
   yaml::read_yaml(path)
 }
 
-# RICHTIG: warnen wenn Ergebnis noch verwendbar ist
+# CORRECT: warn when result is still usable
 summarize_data <- function(data) {
   if (any(is.na(data$value))) {
     warning(sum(is.na(data$value)), " NA values dropped from 'value' column", call. = FALSE)
     data <- data[!is.na(data$value), ]
   }
-  # Mit gueltigen Daten fortfahren
+  # proceed with valid data
 }
 ```
 
@@ -201,7 +201,7 @@ summarize_data <- function(data) {
 Fuer Bedingungen, die "niemals passieren sollten" in korrektem Code, Assertions verwenden. Diese fangen Programmiererfehler waehrend der Entwicklung auf:
 
 ```r
-# R: stopifnot fuer interne Invarianten
+# R: stopifnot for internal invariants
 process_chunk <- function(chunk, total_size) {
   stopifnot(
     is.list(chunk),
@@ -211,11 +211,11 @@ process_chunk <- function(chunk, total_size) {
   # ...
 }
 
-# R: explizite Assertion mit Kontext
+# R: explicit assertion with context
 merge_results <- function(left, right) {
   if (ncol(left) != ncol(right)) {
     stop("Internal error: column count mismatch (", ncol(left), " vs ", ncol(right),
-         "). This is a bug -- please report it.", call. = FALSE)
+         "). This is a bug — please report it.", call. = FALSE)
   }
   # ...
 }
@@ -232,13 +232,13 @@ Diese gaengigen Anti-Muster identifizieren und beheben:
 **Anti-Muster 1: Leeres tryCatch (Fehler verschlucken)**
 
 ```r
-# VORHER: Fehler verschwindet still
+# BEFORE: Error silently disappears
 result <- tryCatch(
   parse_data(input),
   error = function(e) NULL
 )
 
-# NACHHER: Protokollieren, neu werfen oder typisierter Fehler
+# AFTER: Log, re-throw, or return a typed error
 result <- tryCatch(
   parse_data(input),
   error = function(e) {
@@ -250,13 +250,13 @@ result <- tryCatch(
 **Anti-Muster 2: Standardwerte, die schlechte Eingaben verdecken**
 
 ```r
-# VORHER: Aufrufer weiss nie, dass seine Eingabe ignoriert wurde
+# BEFORE: Caller never knows their input was ignored
 process <- function(x = 10) {
-  if (!is.numeric(x)) x <- 10  # ersetzt schlechte Eingabe still
+  if (!is.numeric(x)) x <- 10  # silently replaces bad input
   x * 2
 }
 
-# NACHHER: Aufrufer ueber das Problem informieren
+# AFTER: Tell the caller about the problem
 process <- function(x = 10) {
   if (!is.numeric(x)) {
     stop("'x' must be numeric, got ", class(x)[[1]], call. = FALSE)
@@ -268,10 +268,10 @@ process <- function(x = 10) {
 **Anti-Muster 3: suppressWarnings als Loesung**
 
 ```r
-# VORHER: Symptom verstecken statt Ursache beheben
+# BEFORE: Hiding the symptom instead of fixing the cause
 result <- suppressWarnings(as.numeric(user_input))
 
-# NACHHER: Explizit validieren, erwarteten Fall behandeln
+# AFTER: Validate explicitly, handle the expected case
 if (!grepl("^-?\\d+\\.?\\d*$", user_input)) {
   stop("Expected a number, got: '", user_input, "'", call. = FALSE)
 }
@@ -281,20 +281,20 @@ result <- as.numeric(user_input)
 **Anti-Muster 4: Catch-All-Ausnahmebehandler**
 
 ```r
-# VORHER: Jeder Fehler wird gleich behandelt
+# BEFORE: Every error treated the same
 tryCatch(
   complex_operation(),
   error = function(e) message("Something went wrong")
 )
 
-# NACHHER: Spezifische Bedingungen behandeln, unerwartete propagieren lassen
+# AFTER: Handle specific conditions, let unexpected ones propagate
 tryCatch(
   complex_operation(),
   custom_validation_error = function(e) {
     cli::cli_warn("Validation issue: {e$message}")
     fallback_value
   }
-  # Unerwartete Fehler propagieren natuerlich
+  # Unexpected errors propagate naturally
 )
 ```
 
@@ -307,12 +307,12 @@ tryCatch(
 Die Testsuite ausfuehren, um zu bestaetigen, dass Fehlerpfade korrekt funktionieren:
 
 ```r
-# Fehlermeldungen pruefen ob sie ausgeloest werden
+# Verify error messages are triggered
 testthat::expect_error(calculate_summary("not_a_df"), "must be a data frame")
 testthat::expect_error(calculate_summary(data.frame()), "at least one row")
 testthat::expect_error(calculate_summary(mtcars, trim_pct = 2), "between 0 and 0.5")
 
-# Pruefen ob gueltige Eingaben noch funktionieren
+# Verify valid inputs still work
 testthat::expect_no_error(calculate_summary(mtcars, method = "mean"))
 ```
 

--- a/i18n/de/skills/generate-puzzle/SKILL.md
+++ b/i18n/de/skills/generate-puzzle/SKILL.md
@@ -94,9 +94,9 @@ result <- generate_puzzle(
   layout = "grid"
 )
 
-cat("Teile:", length(result$pieces), "\n")
-cat("SVG-Laenge:", nchar(result$svg_content), "\n")
-cat("Dateien:", paste(result$files, collapse = ", "), "\n")
+cat("Pieces:", length(result$pieces), "\n")
+cat("SVG length:", nchar(result$svg_content), "\n")
+cat("Files:", paste(result$files, collapse = ", "), "\n")
 ```
 
 In einer temporaeren Skriptdatei speichern.

--- a/i18n/de/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/de/skills/generate-workflow-diagram/SKILL.md
@@ -52,16 +52,16 @@ Workflowdaten aus einer von drei Quellen beziehen.
 ```r
 library(putior)
 
-# Aus manuellen Annotationen
+# From manual annotations
 workflow <- put("./src/")
 
-# Aus manuellen Annotationen, bestimmte Dateien ausschliessend
+# From manual annotations, excluding specific files
 workflow <- put("./src/", exclude = c("build-workflow\\.R$", "test_"))
 
-# Nur aus Auto-Erkennung
+# From auto-detection only
 workflow <- put_auto("./src/")
 
-# Aus zusammengefuehrt (manuell + auto)
+# From merged (manual + auto)
 workflow <- put_merge("./src/", merge_strategy = "supplement")
 ```
 
@@ -86,21 +86,21 @@ Jeder `node_type` erhaelt auch eine entsprechende CSS-Klasse (z.B. `class nodeId
 Ein fuer die Zielgruppe geeignetes Thema auswaehlen.
 
 ```r
-# Alle verfuegbaren Themen auflisten
+# List all available themes
 get_diagram_themes()
 
-# Standardthemen
-# "light"   — Standard, helle Farben
-# "dark"    — Fuer Dunkelmodusumgebungen
-# "auto"    — GitHub-adaptiv mit Volltonfarben
-# "minimal" — Graustufen, druckfreundlich
-# "github"  — Optimiert fuer GitHub-README-Dateien
+# Standard themes
+# "light"   — Default, bright colors
+# "dark"    — For dark mode environments
+# "auto"    — GitHub-adaptive with solid colors
+# "minimal" — Grayscale, print-friendly
+# "github"  — Optimized for GitHub README files
 
-# Farbenblindensichere Themen (Viridis-Familie)
-# "viridis" — Lila→Blau→Gruen→Gelb, allgemeine Barrierefreiheit
-# "magma"   — Lila→Rot→Gelb, hoher Kontrast fuer Druck
-# "plasma"  — Lila→Pink→Orange→Gelb, Praesentationen
-# "cividis" — Blau→Grau→Gelb, maximale Barrierefreiheit (kein Rot-Gruen)
+# Colorblind-safe themes (viridis family)
+# "viridis" — Purple→Blue→Green→Yellow, general accessibility
+# "magma"   — Purple→Red→Yellow, high contrast for print
+# "plasma"  — Purple→Pink→Orange→Yellow, presentations
+# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
 
 Zusaetzliche Parameter:
@@ -119,7 +119,7 @@ Zusaetzliche Parameter:
 Wenn die 9 eingebauten Themen nicht zur Projektpalette passen, ein benutzerdefiniertes Thema mit `put_theme()` erstellen.
 
 ```r
-# Benutzerdefinierte Palette erstellen — nicht angegebene Typen erben vom Basisthema
+# Create custom palette — unspecified types inherit from base theme
 cyberpunk <- put_theme(
   base = "dark",
   input    = c(fill = "#1a1a2e", stroke = "#00ff88", color = "#00ff88"),
@@ -128,7 +128,7 @@ cyberpunk <- put_theme(
   decision = c(fill = "#1a1a2e", stroke = "#ffaa33", color = "#ffaa33")
 )
 
-# Palette-Parameter verwenden (ueberschreibt Thema wenn angegeben)
+# Use the palette parameter (overrides theme when provided)
 mermaid_content <- put_diagram(workflow, palette = cyberpunk, output = "raw")
 writeLines(mermaid_content, "workflow.mmd")
 ```
@@ -154,26 +154,26 @@ mermaid_content <- paste(c(lines, custom_defs), collapse = "\n")
 Das Diagramm im gewuenschten Ausgabemodus erzeugen.
 
 ```r
-# Auf Konsole ausgeben (Standard)
+# Print to console (default)
 cat(put_diagram(workflow, theme = "github"))
 
-# In Datei speichern
+# Save to file
 writeLines(put_diagram(workflow, theme = "github"), "docs/workflow.md")
 
-# Rohtext fuer Einbettung erhalten
+# Get raw string for embedding
 mermaid_code <- put_diagram(workflow, output = "raw", theme = "github")
 
-# Mit Quelldateiinformation (zeigt woher jeder Knoten kommt)
+# With source file info (shows which file each node comes from)
 cat(put_diagram(workflow, theme = "github", show_source_info = TRUE))
 
-# Mit klickbaren Knoten (fuer VS Code, RStudio oder file://-Protokoll)
+# With clickable nodes (for VS Code, RStudio, or file:// protocol)
 cat(put_diagram(workflow,
   theme = "github",
   enable_clicks = TRUE,
-  click_protocol = "vscode"  # oder "rstudio", "file"
+  click_protocol = "vscode"  # or "rstudio", "file"
 ))
 
-# Voll ausgestattet
+# Full-featured
 cat(put_diagram(workflow,
   theme = "viridis",
   show_source_info = TRUE,
@@ -203,13 +203,13 @@ flowchart TD
 
 **Quarto-Dokument (nativer Mermaid-Chunk ueber knit_child):**
 ```r
-# Chunk 1: Code generieren (sichtbar, faltbar)
+# Chunk 1: Generate code (visible, foldable)
 workflow <- put("./src/")
 mermaid_code <- put_diagram(workflow, output = "raw", theme = "github")
 ```
 
 ```r
-# Chunk 2: Als nativen Mermaid-Chunk ausgeben (versteckt)
+# Chunk 2: Output as native mermaid chunk (hidden)
 #| output: asis
 #| echo: false
 mermaid_chunk <- paste0("```{mermaid}\n", mermaid_code, "\n```")

--- a/i18n/de/skills/install-putior/SKILL.md
+++ b/i18n/de/skills/install-putior/SKILL.md
@@ -50,7 +50,7 @@ Sicherstellen dass R verfuegbar ist und die Mindestversionsanforderung erfuellt.
 
 ```r
 R.Version()$version.string
-# Muss >= 4.1.0 sein
+# Must be >= 4.1.0
 ```
 
 ```bash
@@ -67,10 +67,10 @@ R.Version()$version.string
 Von CRAN (stabil) oder GitHub (Entwicklung) installieren.
 
 ```r
-# CRAN (empfohlen)
+# CRAN (recommended)
 install.packages("putior")
 
-# GitHub-Entwicklungsversion (wenn neueste Funktionen benoetigt)
+# GitHub dev version (if latest features needed)
 remotes::install_github("pjt222/putior")
 ```
 
@@ -83,18 +83,18 @@ remotes::install_github("pjt222/putior")
 Optionale Pakete je nach benoetigter Funktionalitaet installieren.
 
 ```r
-# MCP-Server-Integration (fuer KI-Assistenten-Zugriff)
+# MCP server integration (for AI assistant access)
 remotes::install_github("posit-dev/mcptools")
 install.packages("ellmer")
 
-# Interaktive Sandbox
+# Interactive sandbox
 install.packages("shiny")
 install.packages("shinyAce")
 
-# Strukturierte Protokollierung
+# Structured logging
 install.packages("logger")
 
-# ACP-Server (Agent-zu-Agent-Kommunikation)
+# ACP server (agent-to-agent communication)
 install.packages("plumber2")
 ```
 
@@ -109,10 +109,10 @@ Die grundlegende Pipeline ausfuehren um zu bestaetigen dass alles funktioniert.
 ```r
 library(putior)
 
-# Paketversion pruefen
+# Check package version
 packageVersion("putior")
 
-# Verfuegbarkeit der Kernfunktionen ueberpruefen
+# Verify core functions are available
 stopifnot(
   is.function(put),
   is.function(put_auto),
@@ -122,7 +122,7 @@ stopifnot(
   is.function(put_theme)
 )
 
-# Grundlegende Pipeline mit einer temporaeren Datei testen
+# Test basic pipeline with a temp file
 tmp <- tempfile(fileext = ".R")
 writeLines("# put id:'test', label:'Hello putior'", tmp)
 cat(put_diagram(put(tmp)))

--- a/i18n/de/skills/manage-renv-dependencies/SKILL.md
+++ b/i18n/de/skills/manage-renv-dependencies/SKILL.md
@@ -91,13 +91,13 @@ renv::restore()
 ### Schritt 4: Abhaengigkeiten aktualisieren
 
 ```r
-# Ein bestimmtes Paket aktualisieren
+# Update a specific package
 renv::update("dplyr")
 
-# Alle Pakete aktualisieren
+# Update all packages
 renv::update()
 
-# Snapshot nach Aktualisierungen
+# Snapshot after updates
 renv::snapshot()
 ```
 

--- a/i18n/de/skills/release-package-version/SKILL.md
+++ b/i18n/de/skills/release-package-version/SKILL.md
@@ -59,7 +59,7 @@ Semantische Versionierung befolgen:
 ### Schritt 2: Version aktualisieren
 
 ```r
-usethis::use_version("minor")  # oder "patch" oder "major"
+usethis::use_version("minor")  # or "patch" or "major"
 ```
 
 Dies aktualisiert das `Version`-Feld in DESCRIPTION und fuegt eine Ueberschrift zu NEWS.md hinzu.

--- a/i18n/de/skills/render-publication-graphic/SKILL.md
+++ b/i18n/de/skills/render-publication-graphic/SKILL.md
@@ -125,15 +125,15 @@ print(f"Erforderliche Aufloesung: {width}x{height} Pixel")
 ```
 
 ```r
-# R ggplot2-Export mit korrekter DPI
+# R ggplot2 export with proper DPI
 library(ggplot2)
 
-# Plot erstellen
+# Create plot
 p <- ggplot(mtcars, aes(x = wt, y = mpg)) +
   geom_point() +
   theme_minimal(base_size = 12)
 
-# Fuer Publikation speichern (300 DPI)
+# Save for publication (300 DPI)
 ggsave(
   filename = "figure1.png",
   plot = p,
@@ -143,14 +143,14 @@ ggsave(
   dpi = 300
 )
 
-# Als Vektorgrafik fuer Flexibilitaet speichern
+# Save as vector for flexibility
 ggsave(
   filename = "figure1.pdf",
   plot = p,
   width = 180,
   height = 120,
   units = "mm",
-  device = cairo_pdf  # Bessere Textdarstellung
+  device = cairo_pdf  # Better text rendering
 )
 ```
 
@@ -236,15 +236,15 @@ typography_specs = {
 ```
 
 ```r
-# R publikationsqualitaet Typografie
+# R publication-quality typography
 library(ggplot2)
 
 p <- ggplot(mtcars, aes(x = wt, y = mpg)) +
   geom_point(size = 2) +
   labs(
-    title = "Kraftstoffeffizienz vs. Gewicht",
-    x = "Gewicht (1000 lbs)",
-    y = "Meilen pro Gallone"
+    title = "Fuel Efficiency vs Weight",
+    x = "Weight (1000 lbs)",
+    y = "Miles per Gallon"
   ) +
   theme_bw(base_size = 12, base_family = "Arial") +
   theme(
@@ -253,7 +253,8 @@ p <- ggplot(mtcars, aes(x = wt, y = mpg)) +
     axis.text = element_text(size = 10),
     legend.text = element_text(size = 10),
     panel.grid.minor = element_blank(),
-    text = element_text(color = "black")  # Schwarz fuer Druck
+    # Ensure text is black for print
+    text = element_text(color = "black")
   )
 ```
 

--- a/i18n/de/skills/security-audit-codebase/SKILL.md
+++ b/i18n/de/skills/security-audit-codebase/SKILL.md
@@ -105,8 +105,8 @@ safety check
 **R**:
 
 ```r
-# Auf bekannte Schwachstellen in Paketen pruefen
-# Kein eingebautes Werkzeug, aber Paketquellen verifizieren
+# Check for known vulnerabilities in packages
+# No built-in tool, but verify package sources
 renv::status()
 ```
 

--- a/i18n/de/skills/serialize-data-formats/SKILL.md
+++ b/i18n/de/skills/serialize-data-formats/SKILL.md
@@ -100,14 +100,14 @@ data = json.loads(json_str)
 ```
 
 ```r
-# R: JSON mit jsonlite
+# R: JSON with jsonlite
 library(jsonlite)
 
-# Serialisieren
+# Serialize
 df <- data.frame(sensor_id = "sensor-01", value = 23.5, unit = "celsius")
 json_str <- jsonlite::toJSON(df, auto_unbox = TRUE, pretty = TRUE)
 
-# Deserialisieren
+# Deserialize
 df_back <- jsonlite::fromJSON(json_str)
 ```
 
@@ -219,14 +219,14 @@ df_subset = table_back.to_pandas()
 ```
 
 ```r
-# R: Parquet mit arrow
+# R: Parquet with arrow
 library(arrow)
 
-# Schreiben
+# Write
 df <- data.frame(sensor_id = rep("s-01", 1000), value = rnorm(1000))
 arrow::write_parquet(df, "measurements.parquet")
 
-# Lesen (mit Spaltenauswahl -- liest nur ausgewaehlte Spalten von der Festplatte)
+# Read (with column selection — only reads selected columns from disk)
 df_back <- arrow::read_parquet("measurements.parquet", col_select = c("value"))
 ```
 

--- a/i18n/de/skills/submit-to-cran/SKILL.md
+++ b/i18n/de/skills/submit-to-cran/SKILL.md
@@ -145,10 +145,10 @@ Fuer Aktualisierungen Folgendes einschliessen:
 ### Schritt 8: Letzte Vorabpruefung
 
 ```r
-# Eine letzte Pruefung
+# One last check
 devtools::check()
 
-# Das gebaute Tarball verifizieren
+# Verify the built tarball
 devtools::build()
 ```
 
@@ -175,10 +175,10 @@ Alternativ manuell unter https://cran.r-project.org/submit.html einreichen, inde
 Nach der Annahme:
 
 ```r
-# Release taggen
+# Tag the release
 usethis::use_github_release()
 
-# Auf Entwicklungsversion hochsetzen
+# Bump to development version
 usethis::use_dev_version()
 ```
 
@@ -210,13 +210,13 @@ usethis::use_dev_version()
 ## Beispiele
 
 ```r
-# Vollstaendiger Voreinreichungs-Workflow
+# Full pre-submission workflow
 devtools::spell_check()
 urlchecker::url_check()
 devtools::check()
 devtools::check_win_devel()
 rhub::rhub_check()
-# Auf Ergebnisse warten...
+# Wait for results...
 devtools::release()
 ```
 

--- a/i18n/de/skills/validate-piles-notation/SKILL.md
+++ b/i18n/de/skills/validate-piles-notation/SKILL.md
@@ -48,7 +48,7 @@ PILES-Notationszeichenketten fuer Puzzle-Teilefusionsgruppen parsen und validier
 ```r
 library(jigsawR)
 result <- validate_piles_syntax("1-2-3,4-5")
-# Gibt TRUE zurueck wenn gueltig, Fehlermeldung wenn ungueltig
+# Returns TRUE if valid, error message if invalid
 ```
 
 Auf haeufige Syntaxfehler pruefen:
@@ -64,13 +64,13 @@ Auf haeufige Syntaxfehler pruefen:
 
 ```r
 groups <- parse_piles("1-2-3,4-5")
-# Gibt zurueck: list(c(1, 2, 3), c(4, 5))
+# Returns: list(c(1, 2, 3), c(4, 5))
 ```
 
 Fuer Zeichenketten mit Bereichen:
 ```r
 groups <- parse_piles("1:6,7-8")
-# Gibt zurueck: list(c(1, 2, 3, 4, 5, 6), c(7, 8))
+# Returns: list(c(1, 2, 3, 4, 5, 6), c(7, 8))
 ```
 
 **Erwartet:** Liste von Integer-Vektoren, einer pro Fusionsgruppe, mit korrekten Teil-IDs und Gruppengrenzen.
@@ -94,10 +94,10 @@ Jede Gruppe fuer den Benutzer beschreiben:
 Wenn ein Puzzle-Ergebnisobjekt verfuegbar ist, verifizieren:
 
 ```r
-# Zuerst das Puzzle generieren
+# Generate the puzzle first
 puzzle <- generate_puzzle(type = "hexagonal", grid = c(3), size = c(200))
 
-# Mit Puzzle-Kontext parsen (loest Schluesselwoerter auf)
+# Parse with puzzle context (resolves keywords)
 groups <- parse_fusion("center,ring1", puzzle)
 ```
 
@@ -118,10 +118,10 @@ Parse/Serialize-Treue verifizieren:
 original <- "1-2-3,4-5"
 groups <- parse_piles(original)
 roundtrip <- to_piles(groups)
-# roundtrip sollte gleich original sein (oder kanonisch aequivalent)
+# roundtrip should equal original (or canonical equivalent)
 
 groups2 <- parse_piles(roundtrip)
-identical(groups, groups2)  # Muss TRUE sein
+identical(groups, groups2)  # Must be TRUE
 ```
 
 **Erwartet:** Der Round-Trip erzeugt identische Gruppenlisten, was bestaetigt dass `parse_piles()` und `to_piles()` zueinander invers sind.

--- a/i18n/de/skills/write-testthat-tests/SKILL.md
+++ b/i18n/de/skills/write-testthat-tests/SKILL.md
@@ -123,7 +123,7 @@ test_that("weighted_mean handles edge cases", {
 `tests/testthat/fixtures/` fuer Testdaten erstellen:
 
 ```r
-# tests/testthat/helper.R (wird automatisch geladen)
+# tests/testthat/helper.R (loaded automatically)
 create_test_data <- function() {
   data.frame(
     x = c(1, 2, 3, NA, 5),
@@ -133,7 +133,7 @@ create_test_data <- function() {
 ```
 
 ```r
-# In der Testdatei
+# In test file
 test_that("process_data works with grouped data", {
   test_data <- create_test_data()
   result <- process_data(test_data)
@@ -215,14 +215,14 @@ test_that("parallel computation works", {
 ### Schritt 9: Tests ausfuehren und Abdeckung pruefen
 
 ```r
-# Alle Tests ausfuehren
+# Run all tests
 devtools::test()
 
-# Bestimmte Testdatei ausfuehren
+# Run specific test file
 devtools::test_active_file()  # in RStudio
 testthat::test_file("tests/testthat/test-function_name.R")
 
-# Abdeckung pruefen
+# Check coverage
 covr::package_coverage()
 covr::report()
 ```
@@ -252,16 +252,16 @@ covr::report()
 ## Beispiele
 
 ```r
-# Muster: Testdatei spiegelt R/-Datei
+# Pattern: test file mirrors R/ file
 # R/weighted_mean.R -> tests/testthat/test-weighted_mean.R
 
-# Muster: Beschreibende Testnamen
+# Pattern: descriptive test names
 test_that("weighted_mean returns NA when na.rm = FALSE and input contains NA", {
   result <- weighted_mean(c(1, NA), c(1, 1), na.rm = FALSE)
   expect_true(is.na(result))
 })
 
-# Muster: Warnungen testen
+# Pattern: testing warnings
 test_that("deprecated_function emits deprecation warning", {
   expect_warning(deprecated_function(), "deprecated")
 })

--- a/i18n/de/skills/write-vignette/SKILL.md
+++ b/i18n/de/skills/write-vignette/SKILL.md
@@ -153,10 +153,10 @@ optionalpkg::special_function()
 Fuer zeitaufwendige Berechnungen Ergebnisse vorausberechnen und speichern:
 
 ```r
-# Vorberechnete Ergebnisse in vignettes/ speichern
+# Save pre-computed results to vignettes/
 saveRDS(expensive_result, "vignettes/precomputed.rds")
 
-# In der Vignette laden
+# Load in vignette
 {r load-precomputed}
 result <- readRDS("precomputed.rds")
 ```
@@ -168,10 +168,10 @@ result <- readRDS("precomputed.rds")
 ### Schritt 5: Vignette bauen und testen
 
 ```r
-# Einzelne Vignette bauen
+# Build single vignette
 devtools::build_vignettes()
 
-# Bauen und pruefen (erkennt Vignetten-Probleme)
+# Build and check (catches vignette issues)
 devtools::check()
 ```
 

--- a/i18n/es/skills/analyze-codebase-workflow/SKILL.md
+++ b/i18n/es/skills/analyze-codebase-workflow/SKILL.md
@@ -53,11 +53,11 @@ Identifica los archivos fuente y sus lenguajes para entender qué puede analizar
 ```r
 library(putior)
 
-# Listar todos los lenguajes soportados y sus extensiones
+# List all supported languages and their extensions
 list_supported_languages()
-list_supported_languages(detection_only = TRUE)  # Solo lenguajes con auto-detección
+list_supported_languages(detection_only = TRUE)  # Only languages with auto-detection
 
-# Obtener extensiones soportadas
+# Get supported extensions
 exts <- get_supported_extensions()
 ```
 
@@ -77,12 +77,12 @@ find /path/to/repo -type f | sed 's/.*\.//' | sort | uniq -c | sort -rn | head -
 Para cada lenguaje detectado, verifica la disponibilidad de patrones de auto-detección.
 
 ```r
-# Verificar qué lenguajes tienen patrones de auto-detección (18 lenguajes, 902 patrones)
+# Check which languages have auto-detection patterns (18 languages, 902 patterns)
 detection_langs <- list_supported_languages(detection_only = TRUE)
 cat("Languages with auto-detection:\n")
 print(detection_langs)
 
-# Obtener conteos de patrones para lenguajes específicos encontrados en el repositorio
+# Get pattern counts for specific languages found in the repo
 for (lang in c("r", "python", "javascript", "sql", "dockerfile", "makefile")) {
   patterns <- get_detection_patterns(lang)
   cat(sprintf("%s: %d input, %d output, %d dependency patterns\n",
@@ -103,14 +103,14 @@ for (lang in c("r", "python", "javascript", "sql", "dockerfile", "makefile")) {
 Ejecuta `put_auto()` en el directorio objetivo para descubrir elementos del flujo de trabajo.
 
 ```r
-# Auto-detección completa
+# Full auto-detection
 workflow <- put_auto("./src/",
   detect_inputs = TRUE,
   detect_outputs = TRUE,
   detect_dependencies = TRUE
 )
 
-# Excluir scripts de compilación y ayudantes de prueba del escaneo
+# Exclude build scripts and test helpers from scanning
 workflow <- put_auto("./src/",
   detect_inputs = TRUE,
   detect_outputs = TRUE,
@@ -118,17 +118,17 @@ workflow <- put_auto("./src/",
   exclude = c("build-", "test_helper")
 )
 
-# Ver los nodos del flujo de trabajo detectados
+# View detected workflow nodes
 print(workflow)
 
-# Verificar el conteo de nodos
+# Check node count
 cat(sprintf("Detected %d workflow nodes\n", nrow(workflow)))
 ```
 
 Para repositorios grandes, analiza subdirectorios de forma incremental:
 
 ```r
-# Analizar subdirectorios específicos
+# Analyze specific subdirectories
 etl_workflow <- put_auto("./src/etl/")
 api_workflow <- put_auto("./src/api/")
 ```
@@ -142,13 +142,13 @@ api_workflow <- put_auto("./src/api/")
 Visualiza el flujo de trabajo auto-detectado para evaluar la cobertura e identificar brechas.
 
 ```r
-# Generar diagrama del flujo de trabajo auto-detectado
+# Generate diagram from auto-detected workflow
 cat(put_diagram(workflow, theme = "github"))
 
-# Con información del archivo fuente para trazabilidad
+# With source file info for traceability
 cat(put_diagram(workflow, show_source_info = TRUE))
 
-# Guardar en archivo para revisión
+# Save to file for review
 writeLines(put_diagram(workflow, theme = "github"), "workflow-auto.md")
 ```
 
@@ -161,13 +161,13 @@ writeLines(put_diagram(workflow, theme = "github"), "workflow-auto.md")
 Genera un plan estructurado que documente qué se encontró y qué necesita anotación manual.
 
 ```r
-# Generar sugerencias de anotación
+# Generate annotation suggestions
 put_generate("./src/", style = "single")
 
-# Para estilo multilínea (más legible para flujos de trabajo complejos)
+# For multiline style (more readable for complex workflows)
 put_generate("./src/", style = "multiline")
 
-# Copiar sugerencias al portapapeles para fácil pegado
+# Copy suggestions to clipboard for easy pasting
 put_generate("./src/", output = "clipboard")
 ```
 

--- a/i18n/es/skills/build-shiny-module/SKILL.md
+++ b/i18n/es/skills/build-shiny-module/SKILL.md
@@ -65,8 +65,8 @@ UI: controles de filtro (selectInput, sliderInput, dateRangeInput)
 ```r
 #' Data Filter Module UI
 #'
-#' @param id ID del espacio de nombres del módulo
-#' @return Un tagList de controles de filtro
+#' @param id Module namespace ID
+#' @return A tagList of filter controls
 #' @export
 dataFilterUI <- function(id) {
   ns <- NS(id)
@@ -98,22 +98,22 @@ Reglas clave:
 ```r
 #' Data Filter Module Server
 #'
-#' @param id ID del espacio de nombres del módulo
-#' @param data Expresión reactiva que devuelve un data frame
-#' @param columns Vector de caracteres de nombres de columnas filtrables
-#' @return Expresión reactiva que devuelve el data frame filtrado
+#' @param id Module namespace ID
+#' @param data Reactive expression returning a data frame
+#' @param columns Character vector of filterable column names
+#' @return Reactive expression returning the filtered data frame
 #' @export
 dataFilterServer <- function(id, data, columns) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
-    # Actualizar opciones de columna cuando cambian los datos
+    # Update column choices when data changes
     observeEvent(data(), {
       available <- intersect(columns, names(data()))
       updateSelectInput(session, "column", choices = available)
     })
 
-    # Control de filtro dinámico basado en la columna seleccionada
+    # Dynamic filter control based on selected column
     output$filter_control <- renderUI({
       req(input$column)
       col_data <- data()[[input$column]]
@@ -137,7 +137,7 @@ dataFilterServer <- function(id, data, columns) {
       }
     })
 
-    # Devolver datos filtrados como reactivo
+    # Return filtered data as a reactive
     filtered <- eventReactive(input$apply, {
       req(input$column)
       col <- input$column
@@ -173,7 +173,7 @@ Reglas clave:
 ### Paso 4: Conectar el Módulo a la App Principal
 
 ```r
-# En app_ui.R o ui
+# In app_ui.R or ui
 ui <- page_sidebar(
   title = "Analysis App",
   sidebar = sidebar(
@@ -184,19 +184,19 @@ ui <- page_sidebar(
   )
 )
 
-# En app_server.R o server
+# In app_server.R or server
 server <- function(input, output, session) {
-  # Fuente de datos en bruto
+  # Raw data source
   raw_data <- reactive({ mtcars })
 
-  # Llamar al módulo — capturar su valor de retorno
+  # Call module — capture its return value
   filtered_data <- dataFilterServer(
     "filter1",
     data = raw_data,
     columns = c("cyl", "mpg", "hp", "wt")
   )
 
-  # Usar el reactivo devuelto por el módulo
+  # Use the module's returned reactive
   output$table <- DT::renderDataTable({
     filtered_data()
   })
@@ -222,7 +222,7 @@ analysisUI <- function(id) {
 
 analysisServer <- function(id, data) {
   moduleServer(id, function(input, output, session) {
-    # Llamar al módulo interno con ID con espacio de nombres
+    # Call inner module with namespaced ID
     filtered <- dataFilterServer("filter", data = data, columns = names(data()))
 
     output$plot <- renderPlot({
@@ -244,7 +244,7 @@ Regla clave: En la UI, anida con `ns("inner_id")`. En el server, llama con solo 
 ### Paso 6: Probar el Módulo en Aislamiento
 
 ```r
-# App de prueba rápida para el módulo
+# Quick test app for the module
 if (interactive()) {
   shiny::shinyApp(
     ui = fluidPage(

--- a/i18n/es/skills/create-r-package/SKILL.md
+++ b/i18n/es/skills/create-r-package/SKILL.md
@@ -186,10 +186,10 @@ Crear `CLAUDE.md` en la raíz del proyecto con instrucciones específicas del pr
 ## Ejemplos
 
 ```r
-# Creación mínima
+# Minimal creation
 usethis::create_package("myanalysis")
 
-# Configuración completa en una sesión
+# Full setup in one session
 usethis::create_package("myanalysis")
 usethis::use_mit_license()
 usethis::use_testthat(edition = 3)

--- a/i18n/es/skills/deploy-shiny-app/SKILL.md
+++ b/i18n/es/skills/deploy-shiny-app/SKILL.md
@@ -49,13 +49,13 @@ Desplegar una aplicación Shiny en shinyapps.io, Posit Connect o un contenedor D
 Asegúrate de que la app sea autocontenida y desplegable:
 
 ```r
-# Verificar dependencias faltantes
+# Check for missing dependencies
 rsconnect::appDependencies("path/to/app")
 
-# Para apps golem, asegúrate de que DESCRIPTION liste todos los Imports
+# For golem apps, ensure DESCRIPTION lists all Imports
 devtools::check()
 
-# Verificar que la app se ejecuta limpiamente
+# Verify the app runs cleanly
 shiny::runApp("path/to/app")
 ```
 
@@ -71,14 +71,14 @@ Verifica que estos archivos existen:
 ### Paso 2a: Desplegar en shinyapps.io
 
 ```r
-# Configuración de cuenta (una vez)
+# One-time account setup
 rsconnect::setAccountInfo(
   name = "your-account",
   token = Sys.getenv("SHINYAPPS_TOKEN"),
   secret = Sys.getenv("SHINYAPPS_SECRET")
 )
 
-# Desplegar
+# Deploy
 rsconnect::deployApp(
   appDir = "path/to/app",
   appName = "my-app",
@@ -103,20 +103,20 @@ SHINYAPPS_SECRET=your_secret_here
 ### Paso 2b: Desplegar en Posit Connect
 
 ```r
-# Registrar servidor (una vez)
+# Register server (one-time)
 rsconnect::addServer(
   url = "https://connect.example.com",
   name = "production"
 )
 
-# Autenticar (una vez)
+# Authenticate (one-time)
 rsconnect::connectApiUser(
   account = "your-username",
   server = "production",
   apiKey = Sys.getenv("CONNECT_API_KEY")
 )
 
-# Desplegar
+# Deploy
 rsconnect::deployApp(
   appDir = "path/to/app",
   appName = "my-app",
@@ -189,11 +189,11 @@ docker run -p 3838:3838 myapp:latest
 ### Paso 3: Verificar el Despliegue
 
 ```r
-# Verificar que la URL desplegada responde
+# Check the deployed URL responds
 response <- httr::GET("https://your-app-url/")
-httr::status_code(response)  # Debe ser 200
+httr::status_code(response)  # Should be 200
 
-# Para Docker
+# For Docker
 response <- httr::GET("http://localhost:3838/")
 httr::status_code(response)
 ```
@@ -217,7 +217,7 @@ Monitoriza a través del panel en `https://www.shinyapps.io/admin/#/applications
 #### Posit Connect
 
 ```r
-# Verificar el estado del despliegue via API
+# Check deployment status via API
 connectapi::connect(
   server = "https://connect.example.com",
   api_key = Sys.getenv("CONNECT_API_KEY")

--- a/i18n/es/skills/design-shiny-ui/SKILL.md
+++ b/i18n/es/skills/design-shiny-ui/SKILL.md
@@ -51,14 +51,14 @@ Diseñar interfaces de aplicaciones Shiny responsivas y accesibles usando temas 
 bslib proporciona varios constructores de página:
 
 ```r
-# Layout sidebar — el más común para apps de datos
+# Sidebar layout — most common for data apps
 ui <- page_sidebar(
   title = "My App",
   sidebar = sidebar("Controls here"),
   "Main content here"
 )
 
-# Layout navbar — para apps de múltiples páginas
+# Navbar layout — for multi-page apps
 ui <- page_navbar(
   title = "My App",
   nav_panel("Tab 1", "Content 1"),
@@ -67,7 +67,7 @@ ui <- page_navbar(
   nav_item(actionButton("help", "Help"))
 )
 
-# Layout fillable — el contenido llena el espacio disponible
+# Fillable layout — content fills available space
 ui <- page_fillable(
   card(
     full_screen = TRUE,
@@ -75,7 +75,7 @@ ui <- page_fillable(
   )
 )
 
-# Layout dashboard — cuadrícula de cajas de valor y tarjetas
+# Dashboard layout — grid of value boxes and cards
 ui <- page_sidebar(
   title = "Dashboard",
   sidebar = sidebar(open = "closed", "Filters"),
@@ -101,11 +101,11 @@ ui <- page_sidebar(
 ```r
 my_theme <- bslib::bs_theme(
   version = 5,                      # Bootstrap 5
-  bootswatch = "flatly",            # Tema preestablecido opcional
-  bg = "#ffffff",                   # Color de fondo
-  fg = "#2c3e50",                   # Color de primer plano (texto)
-  primary = "#2c3e50",              # Color primario de marca
-  secondary = "#95a5a6",            # Color secundario
+  bootswatch = "flatly",            # Optional preset theme
+  bg = "#ffffff",                   # Background color
+  fg = "#2c3e50",                   # Foreground (text) color
+  primary = "#2c3e50",              # Primary brand color
+  secondary = "#95a5a6",            # Secondary color
   success = "#18bc9c",
   info = "#3498db",
   warning = "#f39c12",
@@ -148,7 +148,7 @@ ui <- page_sidebar(
     actionButton("refresh", "Refresh", class = "btn-primary w-100")
   ),
 
-  # Fila KPI — sin relleno
+  # KPI row — non-filling
   layout_columns(
     fill = FALSE,
     col_widths = c(4, 4, 4),
@@ -172,7 +172,7 @@ ui <- page_sidebar(
     )
   ),
 
-  # Fila de contenido principal
+  # Main content row
   layout_columns(
     col_widths = c(8, 4),
     card(
@@ -222,8 +222,8 @@ server <- function(input, output, session) {
     )
   })
 
-  # Paneles condicionales (sin viaje de ida y vuelta al servidor)
-  # En UI:
+  # Conditional panels (no server round-trip)
+  # In UI:
   # conditionalPanel(
   #   condition = "input.show_advanced == true",
   #   numericInput("alpha", "Alpha", 0.05)
@@ -240,7 +240,7 @@ server <- function(input, output, session) {
 Para estilos más allá de las variables del tema bslib:
 
 ```r
-# CSS en línea
+# Inline CSS
 ui <- page_sidebar(
   theme = my_theme,
   tags$head(tags$style(HTML("
@@ -251,7 +251,7 @@ ui <- page_sidebar(
   # ...
 )
 
-# Archivo CSS externo (coloca en directorio www/)
+# External CSS file (place in www/ directory)
 ui <- page_sidebar(
   theme = my_theme,
   tags$head(tags$link(rel = "stylesheet", href = "custom.css")),
@@ -273,31 +273,31 @@ my_theme <- bslib::bs_theme(version = 5) |>
 ### Paso 6: Garantizar la Accesibilidad
 
 ```r
-# Añadir etiquetas ARIA a las entradas
+# Add ARIA labels to inputs
 selectInput("category", "Category",
   choices = c("A", "B", "C")
 ) |> tagAppendAttributes(`aria-describedby` = "category-help")
 
-# Añadir texto alternativo a los gráficos
+# Add alt text to plots
 output$plot <- renderPlot({
   plot(data(), main = "Distribution of Values")
 }, alt = "Histogram showing the distribution of selected values")
 
-# Asegurar suficiente contraste de color en el tema
+# Ensure sufficient color contrast in theme
 my_theme <- bslib::bs_theme(
   version = 5,
-  bg = "#ffffff",      # Fondo blanco
-  fg = "#212529"       # Texto oscuro — ratio de contraste 15.4:1
+  bg = "#ffffff",      # White background
+  fg = "#212529"       # Dark text — 15.4:1 contrast ratio
 )
 
-# Usar HTML semántico
+# Use semantic HTML
 tags$main(
   role = "main",
   tags$h1("Dashboard"),
   tags$section(
     `aria-label` = "Key Performance Indicators",
     layout_columns(
-      # cajas de valor...
+      # value boxes...
     )
   )
 )

--- a/i18n/es/skills/fail-early-pattern/SKILL.md
+++ b/i18n/es/skills/fail-early-pattern/SKILL.md
@@ -71,21 +71,21 @@ Validar las entradas al inicio de cada función pública, antes de que comience 
 
 ```r
 calculate_summary <- function(data, method = c("mean", "median", "trim"), trim_pct = 0.1) {
-  # Guarda: verificación de tipo
+  # Guard: type check
   if (!is.data.frame(data)) {
     stop("'data' must be a data frame, not ", class(data)[[1]], call. = FALSE)
   }
-  # Guarda: no vacío
+  # Guard: non-empty
   if (nrow(data) == 0L) {
     stop("'data' must have at least one row", call. = FALSE)
   }
-  # Guarda: coincidencia de argumentos
+  # Guard: argument matching
   method <- match.arg(method)
-  # Guarda: verificación de rango
+  # Guard: range check
   if (!is.numeric(trim_pct) || trim_pct < 0 || trim_pct > 0.5) {
     stop("'trim_pct' must be a number between 0 and 0.5, got: ", trim_pct, call. = FALSE)
   }
-  # --- Todas las guardas pasaron, comenzar trabajo real ---
+  # --- All guards passed, begin real work ---
   # ...
 }
 ```
@@ -139,16 +139,16 @@ Cada mensaje de error debe responder cuatro preguntas:
 **Buenos mensajes:**
 
 ```r
-# Qué + Por qué (esperado vs. real)
+# What + Why (expected vs. actual)
 stop("'n' must be a positive integer, got: ", n, call. = FALSE)
 
-# Qué + Por qué + Cómo solucionarlo
+# What + Why + How to fix
 cli::cli_abort(c(
   "{.arg config_path} does not exist: {.file {config_path}}",
   "i" = "Create it with {.run create_config({.file {config_path}})}."
 ))
 
-# Qué + contexto
+# What + context
 cli::cli_abort(c(
   "Column {.val {col_name}} not found in {.arg data}.",
   "i" = "Available columns: {.val {names(data)}}"
@@ -158,9 +158,9 @@ cli::cli_abort(c(
 **Malos mensajes:**
 
 ```r
-stop("Error")                    # ¿Qué falló? No hay idea
-stop("Invalid input")           # ¿Qué entrada? ¿Qué tiene de malo?
-stop(paste("Error in step", i)) # Sin información accionable
+stop("Error")                    # What failed? No idea
+stop("Invalid input")           # Which input? What's wrong with it?
+stop(paste("Error in step", i)) # No actionable information
 ```
 
 **Esperado:** Los mensajes de error se documentan por sí mismos — un desarrollador que ve el error por primera vez puede diagnosticarlo y solucionarlo sin leer el código fuente.
@@ -174,7 +174,7 @@ Usar `stop()` (o `cli::cli_abort()`) cuando la función no puede producir un res
 **Regla general:** Si un usuario pudiera obtener silenciosamente una respuesta incorrecta, eso es un `stop()`, no un `warning()`.
 
 ```r
-# CORRECTO: stop cuando el resultado sería incorrecto
+# CORRECT: stop when result would be wrong
 read_config <- function(path) {
   if (!file.exists(path)) {
     stop("Config file not found: ", path, call. = FALSE)
@@ -182,13 +182,13 @@ read_config <- function(path) {
   yaml::read_yaml(path)
 }
 
-# CORRECTO: advertir cuando el resultado aún es utilizable
+# CORRECT: warn when result is still usable
 summarize_data <- function(data) {
   if (any(is.na(data$value))) {
     warning(sum(is.na(data$value)), " NA values dropped from 'value' column", call. = FALSE)
     data <- data[!is.na(data$value), ]
   }
-  # continuar con datos válidos
+  # proceed with valid data
 }
 ```
 
@@ -201,7 +201,7 @@ summarize_data <- function(data) {
 Para condiciones que "nunca deben suceder" en código correcto, usar aserciones. Estas detectan errores del programador durante el desarrollo:
 
 ```r
-# R: stopifnot para invariantes internos
+# R: stopifnot for internal invariants
 process_chunk <- function(chunk, total_size) {
   stopifnot(
     is.list(chunk),
@@ -211,7 +211,7 @@ process_chunk <- function(chunk, total_size) {
   # ...
 }
 
-# R: aserción explícita con contexto
+# R: explicit assertion with context
 merge_results <- function(left, right) {
   if (ncol(left) != ncol(right)) {
     stop("Internal error: column count mismatch (", ncol(left), " vs ", ncol(right),
@@ -232,13 +232,13 @@ Identificar y corregir estos anti-patrones comunes:
 **Anti-patrón 1: tryCatch vacío (consumir errores silenciosamente)**
 
 ```r
-# ANTES: El error desaparece silenciosamente
+# BEFORE: Error silently disappears
 result <- tryCatch(
   parse_data(input),
   error = function(e) NULL
 )
 
-# DESPUÉS: Registrar, relanzar o devolver un error tipado
+# AFTER: Log, re-throw, or return a typed error
 result <- tryCatch(
   parse_data(input),
   error = function(e) {
@@ -250,13 +250,13 @@ result <- tryCatch(
 **Anti-patrón 2: Valores por defecto enmascarando entradas incorrectas**
 
 ```r
-# ANTES: El llamador nunca sabe que su entrada fue ignorada
+# BEFORE: Caller never knows their input was ignored
 process <- function(x = 10) {
-  if (!is.numeric(x)) x <- 10  # reemplaza silenciosamente la entrada incorrecta
+  if (!is.numeric(x)) x <- 10  # silently replaces bad input
   x * 2
 }
 
-# DESPUÉS: Informar al llamador sobre el problema
+# AFTER: Tell the caller about the problem
 process <- function(x = 10) {
   if (!is.numeric(x)) {
     stop("'x' must be numeric, got ", class(x)[[1]], call. = FALSE)
@@ -268,10 +268,10 @@ process <- function(x = 10) {
 **Anti-patrón 3: suppressWarnings como solución**
 
 ```r
-# ANTES: Ocultar el síntoma en lugar de corregir la causa
+# BEFORE: Hiding the symptom instead of fixing the cause
 result <- suppressWarnings(as.numeric(user_input))
 
-# DESPUÉS: Validar explícitamente, manejar el caso esperado
+# AFTER: Validate explicitly, handle the expected case
 if (!grepl("^-?\\d+\\.?\\d*$", user_input)) {
   stop("Expected a number, got: '", user_input, "'", call. = FALSE)
 }
@@ -281,20 +281,20 @@ result <- as.numeric(user_input)
 **Anti-patrón 4: Manejadores de excepción que capturan todo**
 
 ```r
-# ANTES: Cada error tratado igual
+# BEFORE: Every error treated the same
 tryCatch(
   complex_operation(),
   error = function(e) message("Something went wrong")
 )
 
-# DESPUÉS: Manejar condiciones específicas, dejar que las inesperadas se propaguen
+# AFTER: Handle specific conditions, let unexpected ones propagate
 tryCatch(
   complex_operation(),
   custom_validation_error = function(e) {
     cli::cli_warn("Validation issue: {e$message}")
     fallback_value
   }
-  # Los errores inesperados se propagan naturalmente
+  # Unexpected errors propagate naturally
 )
 ```
 
@@ -307,12 +307,12 @@ tryCatch(
 Ejecutar el conjunto de pruebas para confirmar que las rutas de error funcionan correctamente:
 
 ```r
-# Verificar que se desencadenan los mensajes de error
+# Verify error messages are triggered
 testthat::expect_error(calculate_summary("not_a_df"), "must be a data frame")
 testthat::expect_error(calculate_summary(data.frame()), "at least one row")
 testthat::expect_error(calculate_summary(mtcars, trim_pct = 2), "between 0 and 0.5")
 
-# Verificar que las entradas válidas aún funcionan
+# Verify valid inputs still work
 testthat::expect_no_error(calculate_summary(mtcars, method = "mean"))
 ```
 

--- a/i18n/es/skills/install-putior/SKILL.md
+++ b/i18n/es/skills/install-putior/SKILL.md
@@ -50,7 +50,7 @@ Confirma que R está disponible y cumple el requisito de versión mínima.
 
 ```r
 R.Version()$version.string
-# Debe ser >= 4.1.0
+# Must be >= 4.1.0
 ```
 
 ```bash
@@ -67,10 +67,10 @@ R.Version()$version.string
 Instala desde CRAN (estable) o GitHub (desarrollo).
 
 ```r
-# CRAN (recomendado)
+# CRAN (recommended)
 install.packages("putior")
 
-# Versión de desarrollo de GitHub (si se necesitan las últimas funcionalidades)
+# GitHub dev version (if latest features needed)
 remotes::install_github("pjt222/putior")
 ```
 
@@ -83,18 +83,18 @@ remotes::install_github("pjt222/putior")
 Instala los paquetes opcionales según la funcionalidad requerida.
 
 ```r
-# Integración del servidor MCP (para acceso del asistente de IA)
+# MCP server integration (for AI assistant access)
 remotes::install_github("posit-dev/mcptools")
 install.packages("ellmer")
 
-# Sandbox interactivo
+# Interactive sandbox
 install.packages("shiny")
 install.packages("shinyAce")
 
-# Registro estructurado
+# Structured logging
 install.packages("logger")
 
-# Servidor ACP (comunicación agente a agente)
+# ACP server (agent-to-agent communication)
 install.packages("plumber2")
 ```
 
@@ -109,10 +109,10 @@ Ejecuta el pipeline básico para confirmar que todo funciona.
 ```r
 library(putior)
 
-# Verificar la versión del paquete
+# Check package version
 packageVersion("putior")
 
-# Verificar que las funciones principales están disponibles
+# Verify core functions are available
 stopifnot(
   is.function(put),
   is.function(put_auto),
@@ -122,7 +122,7 @@ stopifnot(
   is.function(put_theme)
 )
 
-# Probar el pipeline básico con un archivo temporal
+# Test basic pipeline with a temp file
 tmp <- tempfile(fileext = ".R")
 writeLines("# put id:'test', label:'Hello putior'", tmp)
 cat(put_diagram(put(tmp)))

--- a/i18n/es/skills/manage-renv-dependencies/SKILL.md
+++ b/i18n/es/skills/manage-renv-dependencies/SKILL.md
@@ -90,13 +90,13 @@ renv::restore()
 ### Paso 4: Actualizar Dependencias
 
 ```r
-# Actualizar un paquete específico
+# Update a specific package
 renv::update("dplyr")
 
-# Actualizar todos los paquetes
+# Update all packages
 renv::update()
 
-# Crear snapshot tras las actualizaciones
+# Snapshot after updates
 renv::snapshot()
 ```
 

--- a/i18n/es/skills/optimize-shiny-performance/SKILL.md
+++ b/i18n/es/skills/optimize-shiny-performance/SKILL.md
@@ -48,12 +48,12 @@ Perfilar, diagnosticar y optimizar el rendimiento de aplicaciones Shiny mediante
 ### Paso 1: Perfilar la Aplicación
 
 ```r
-# Perfilar con profvis
+# Profile with profvis
 profvis::profvis({
   shiny::runApp("path/to/app", display.mode = "normal")
 })
 
-# O perfilar operaciones específicas
+# Or profile specific operations
 profvis::profvis({
   result <- expensive_computation(data)
 })
@@ -68,10 +68,10 @@ Identifica los principales cuellos de botella:
 Usa el registro reactivo para análisis del grafo reactivo:
 
 ```r
-# Habilitar el registro reactivo
+# Enable reactive logging
 options(shiny.reactlog = TRUE)
 shiny::runApp("path/to/app")
-# Presiona Ctrl+F3 en el navegador para ver el grafo reactivo
+# Press Ctrl+F3 in the browser to view the reactive graph
 ```
 
 **Esperado:** Identificación clara de los 2-3 mayores cuellos de botella.
@@ -83,17 +83,17 @@ shiny::runApp("path/to/app")
 Reduce las invalidaciones reactivas innecesarias:
 
 ```r
-# MAL: Recalcula con CUALQUIER cambio de entrada
+# BAD: Recomputes on ANY input change
 output$plot <- renderPlot({
-  data <- load_data()  # Se ejecuta cada vez
+  data <- load_data()  # Runs every time
   filtered <- data[data$category == input$category, ]
   plot(filtered)
 })
 
-# BIEN: Aislar la carga de datos del filtrado
+# GOOD: Isolate data loading from filtering
 raw_data <- reactive({
   load_data()
-}) |> bindCache()  # Cachear la parte costosa
+}) |> bindCache()  # Cache the expensive part
 
 filtered_data <- reactive({
   raw_data()[raw_data()$category == input$category, ]
@@ -107,9 +107,9 @@ output$plot <- renderPlot({
 Usa `isolate()` para prevenir invalidaciones innecesarias:
 
 ```r
-# Solo recalcula cuando se hace clic en el botón, no con cada cambio de entrada
+# Only recompute when the button is clicked, not on every input change
 output$result <- renderText({
-  input$compute  # Tomar dependencia del botón
+  input$compute  # Take dependency on button
   isolate({
     paste("N =", input$n, "Mean =", mean(rnorm(input$n)))
   })
@@ -119,10 +119,10 @@ output$result <- renderText({
 Usa `debounce()` y `throttle()` para entradas de alta frecuencia:
 
 ```r
-# Debounce de entrada de texto — esperar 500ms después de que el usuario deje de escribir
+# Debounce text input — wait 500ms after user stops typing
 search_text <- reactive(input$search) |> debounce(500)
 
-# Throttle del slider — actualizar como máximo cada 250ms
+# Throttle slider — update at most every 250ms
 slider_value <- reactive(input$slider) |> throttle(250)
 ```
 
@@ -149,7 +149,7 @@ output$table <- renderDT({
 #### memoise para Funciones
 
 ```r
-# Cachear resultados de funciones costosas
+# Cache expensive function results
 load_reference_data <- memoise::memoise(
   function(dataset_name) {
     readr::read_csv(paste0("data/", dataset_name, ".csv"))
@@ -161,13 +161,13 @@ load_reference_data <- memoise::memoise(
 #### Pre-computación de Datos a Nivel de App
 
 ```r
-# En global.R o fuera de la función server — computado una vez al iniciar la app
+# In global.R or outside server function — computed once at app startup
 reference_data <- readr::read_csv("data/reference.csv")
 model <- readRDS("models/trained_model.rds")
 
 server <- function(input, output, session) {
-  # reference_data y model están disponibles para todas las sesiones
-  # sin volver a cargar
+  # reference_data and model are available to all sessions
+  # without reloading
 }
 ```
 
@@ -181,20 +181,20 @@ Usa `ExtendedTask` (Shiny >= 1.8.1) para computaciones de larga duración:
 
 ```r
 server <- function(input, output, session) {
-  # Definir la tarea extendida
+  # Define the extended task
   analysis_task <- ExtendedTask$new(function(data, params) {
     promises::future_promise({
-      # Esto se ejecuta en un proceso en segundo plano
+      # This runs in a background process
       run_heavy_analysis(data, params)
     })
   }) |> bind_task_button("run_analysis")
 
-  # Activar la tarea
+  # Trigger the task
   observeEvent(input$run_analysis, {
     analysis_task$invoke(dataset(), input$params)
   })
 
-  # Usar el resultado
+  # Use the result
   output$result <- renderTable({
     analysis_task$result()
   })
@@ -211,7 +211,7 @@ plan(multisession, workers = 4)
 server <- function(input, output, session) {
   result <- eventReactive(input$compute, {
     future_promise({
-      Sys.sleep(5)  # Simular computación larga
+      Sys.sleep(5)  # Simulate long computation
       expensive_analysis(isolate(input$params))
     })
   })
@@ -231,12 +231,12 @@ server <- function(input, output, session) {
 Reduce la sobrecarga de renderizado:
 
 ```r
-# Usar plotly para gráficos interactivos en lugar de volver a renderizar
+# Use plotly for interactive plots instead of re-rendering
 output$plot <- plotly::renderPlotly({
   plotly::plot_ly(filtered_data(), x = ~x, y = ~y, type = "scatter")
 })
 
-# Usar DT del lado del servidor para tablas grandes
+# Use server-side DT for large tables
 output$table <- DT::renderDataTable({
   DT::datatable(large_data(), server = TRUE, options = list(
     pageLength = 25,
@@ -244,7 +244,7 @@ output$table <- DT::renderDataTable({
   ))
 })
 
-# UI condicional para evitar renderizar elementos ocultos
+# Conditional UI to avoid rendering hidden elements
 output$details <- renderUI({
   req(input$show_details)
   expensive_details_ui()
@@ -258,7 +258,7 @@ output$details <- renderUI({
 ### Paso 6: Validar las Mejoras de Rendimiento
 
 ```r
-# Benchmarking antes/después
+# Before/after benchmarking
 system.time({
   shiny::testServer(myModuleServer, args = list(...), {
     session$setInputs(category = "A")
@@ -266,7 +266,7 @@ system.time({
   })
 })
 
-# Pruebas de carga con shinyloadtest
+# Load testing with shinyloadtest
 shinyloadtest::record_session("http://localhost:3838")
 shinyloadtest::shinycannon(
   "recording.log",

--- a/i18n/es/skills/release-package-version/SKILL.md
+++ b/i18n/es/skills/release-package-version/SKILL.md
@@ -59,7 +59,7 @@ Seguir el versionado semántico:
 ### Paso 2: Actualizar la Versión
 
 ```r
-usethis::use_version("minor")  # o "patch" o "major"
+usethis::use_version("minor")  # or "patch" or "major"
 ```
 
 Esto actualiza el campo `Version` en DESCRIPTION y añade un encabezado a NEWS.md.

--- a/i18n/es/skills/scaffold-shiny-app/SKILL.md
+++ b/i18n/es/skills/scaffold-shiny-app/SKILL.md
@@ -155,16 +155,16 @@ shinyApp(ui, server)
 #### Golem/Vanilla
 
 ```r
-# Inicializar renv
+# Initialize renv
 renv::init()
 
-# Añadir dependencias principales
+# Add core dependencies
 usethis::use_package("shiny")
 usethis::use_package("bslib")
-usethis::use_package("DT")         # si se usan tablas de datos
-usethis::use_package("plotly")     # si se usan gráficos interactivos
+usethis::use_package("DT")         # if using data tables
+usethis::use_package("plotly")     # if using interactive plots
 
-# Capturar estado
+# Snapshot
 renv::snapshot()
 ```
 

--- a/i18n/es/skills/security-audit-codebase/SKILL.md
+++ b/i18n/es/skills/security-audit-codebase/SKILL.md
@@ -104,8 +104,8 @@ safety check
 **R**:
 
 ```r
-# Verificar vulnerabilidades conocidas en paquetes
-# No hay herramienta integrada, pero verificar las fuentes de los paquetes
+# Check for known vulnerabilities in packages
+# No built-in tool, but verify package sources
 renv::status()
 ```
 

--- a/i18n/es/skills/serialize-data-formats/SKILL.md
+++ b/i18n/es/skills/serialize-data-formats/SKILL.md
@@ -230,7 +230,7 @@ library(arrow)
 df <- data.frame(sensor_id = rep("s-01", 1000), value = rnorm(1000))
 arrow::write_parquet(df, "measurements.parquet")
 
-# Read (with column selection -- only reads selected columns from disk)
+# Read (with column selection — only reads selected columns from disk)
 df_back <- arrow::read_parquet("measurements.parquet", col_select = c("value"))
 ```
 

--- a/i18n/es/skills/submit-to-cran/SKILL.md
+++ b/i18n/es/skills/submit-to-cran/SKILL.md
@@ -144,10 +144,10 @@ Para actualizaciones, incluir:
 ### Paso 8: Verificación Final Previa al Envío
 
 ```r
-# Una última verificación
+# One last check
 devtools::check()
 
-# Verificar el tarball compilado
+# Verify the built tarball
 devtools::build()
 ```
 
@@ -174,10 +174,10 @@ Alternativamente, enviar manualmente en https://cran.r-project.org/submit.html s
 Tras la aceptación:
 
 ```r
-# Etiquetar la versión
+# Tag the release
 usethis::use_github_release()
 
-# Incrementar a versión de desarrollo
+# Bump to development version
 usethis::use_dev_version()
 ```
 
@@ -209,13 +209,13 @@ usethis::use_dev_version()
 ## Ejemplos
 
 ```r
-# Flujo completo previo al envío
+# Full pre-submission workflow
 devtools::spell_check()
 urlchecker::url_check()
 devtools::check()
 devtools::check_win_devel()
 rhub::rhub_check()
-# Esperar resultados...
+# Wait for results...
 devtools::release()
 ```
 

--- a/i18n/es/skills/test-shiny-app/SKILL.md
+++ b/i18n/es/skills/test-shiny-app/SKILL.md
@@ -50,10 +50,10 @@ Configurar tests completos para aplicaciones Shiny usando shinytest2 (extremo a 
 ```r
 install.packages("shinytest2")
 
-# Para apps golem, añadir como dependencia de Suggests
+# For golem apps, add as a Suggests dependency
 usethis::use_package("shinytest2", type = "Suggests")
 
-# Configurar infraestructura testthat si no está presente
+# Set up testthat infrastructure if not present
 usethis::use_testthat(edition = 3)
 ```
 
@@ -71,12 +71,12 @@ test_that("dashboard module filters data correctly", {
     data = reactive(iris),
     columns = c("Species", "Sepal.Length")
   ), {
-    # Establecer entradas
+    # Set inputs
     session$setInputs(column = "Species")
     session$setInputs(value_select = "setosa")
     session$setInputs(apply = 1)
 
-    # Verificar salida
+    # Check output
     result <- filtered()
     expect_equal(nrow(result), 50)
     expect_true(all(result$Species == "setosa"))
@@ -88,7 +88,7 @@ test_that("dashboard module handles empty data", {
     data = reactive(iris[0, ]),
     columns = c("Species")
   ), {
-    # El módulo no debe dar error con datos vacíos
+    # Module should not error on empty data
     expect_no_error(session$setInputs(column = "Species"))
   })
 })
@@ -111,7 +111,7 @@ Crea `tests/testthat/test-app-e2e.R`:
 
 ```r
 test_that("app loads and displays initial state", {
-  # Para apps golem
+  # For golem apps
   app <- AppDriver$new(
     app_dir = system.file(package = "myapp"),
     name = "initial-load",
@@ -120,10 +120,10 @@ test_that("app loads and displays initial state", {
   )
   on.exit(app$stop(), add = TRUE)
 
-  # Esperar a que la app cargue
+  # Wait for app to load
   app$wait_for_idle(timeout = 10000)
 
-  # Verificar que los elementos clave existen
+  # Check that key elements exist
   app$expect_values()
 })
 
@@ -134,14 +134,14 @@ test_that("filter interaction updates the table", {
   )
   on.exit(app$stop(), add = TRUE)
 
-  # Interactuar con la app
+  # Interact with the app
   app$set_inputs(`filter1-column` = "cyl")
   app$wait_for_idle()
 
   app$set_inputs(`filter1-apply` = "click")
   app$wait_for_idle()
 
-  # Tomar snapshot de los valores de salida
+  # Snapshot the output values
   app$expect_values(output = "table")
 })
 ```
@@ -174,10 +174,10 @@ Esto abre la app en un navegador con un panel de grabación. Interactúa con la 
 Para tests basados en snapshots, gestiona los valores esperados:
 
 ```r
-# Aceptar snapshots nuevos/modificados después de revisión
+# Accept new/changed snapshots after review
 testthat::snapshot_accept("test-app-e2e")
 
-# Revisar diferencias en snapshots
+# Review snapshot differences
 testthat::snapshot_review("test-app-e2e")
 ```
 

--- a/i18n/es/skills/write-testthat-tests/SKILL.md
+++ b/i18n/es/skills/write-testthat-tests/SKILL.md
@@ -123,7 +123,7 @@ test_that("weighted_mean handles edge cases", {
 Crear `tests/testthat/fixtures/` para datos de prueba:
 
 ```r
-# tests/testthat/helper.R (cargado automáticamente)
+# tests/testthat/helper.R (loaded automatically)
 create_test_data <- function() {
   data.frame(
     x = c(1, 2, 3, NA, 5),
@@ -133,7 +133,7 @@ create_test_data <- function() {
 ```
 
 ```r
-# En el archivo de prueba
+# In test file
 test_that("process_data works with grouped data", {
   test_data <- create_test_data()
   result <- process_data(test_data)
@@ -215,14 +215,14 @@ test_that("parallel computation works", {
 ### Paso 9: Ejecutar Pruebas y Verificar Cobertura
 
 ```r
-# Ejecutar todas las pruebas
+# Run all tests
 devtools::test()
 
-# Ejecutar archivo de prueba específico
-devtools::test_active_file()  # en RStudio
+# Run specific test file
+devtools::test_active_file()  # in RStudio
 testthat::test_file("tests/testthat/test-function_name.R")
 
-# Verificar cobertura
+# Check coverage
 covr::package_coverage()
 covr::report()
 ```
@@ -252,16 +252,16 @@ covr::report()
 ## Ejemplos
 
 ```r
-# Patrón: el archivo de prueba refleja el archivo R/
+# Pattern: test file mirrors R/ file
 # R/weighted_mean.R -> tests/testthat/test-weighted_mean.R
 
-# Patrón: nombres de prueba descriptivos
+# Pattern: descriptive test names
 test_that("weighted_mean returns NA when na.rm = FALSE and input contains NA", {
   result <- weighted_mean(c(1, NA), c(1, 1), na.rm = FALSE)
   expect_true(is.na(result))
 })
 
-# Patrón: probar advertencias
+# Pattern: testing warnings
 test_that("deprecated_function emits deprecation warning", {
   expect_warning(deprecated_function(), "deprecated")
 })

--- a/i18n/es/skills/write-vignette/SKILL.md
+++ b/i18n/es/skills/write-vignette/SKILL.md
@@ -152,10 +152,10 @@ optionalpkg::special_function()
 Para cálculos de larga duración, precomputar y guardar los resultados:
 
 ```r
-# Guardar resultados precomputados en vignettes/
+# Save pre-computed results to vignettes/
 saveRDS(expensive_result, "vignettes/precomputed.rds")
 
-# Cargar en la viñeta
+# Load in vignette
 {r load-precomputed}
 result <- readRDS("precomputed.rds")
 ```
@@ -167,10 +167,10 @@ result <- readRDS("precomputed.rds")
 ### Paso 5: Compilar y Probar la Viñeta
 
 ```r
-# Compilar una única viñeta
+# Build single vignette
 devtools::build_vignettes()
 
-# Compilar y verificar (detecta problemas de viñeta)
+# Build and check (catches vignette issues)
 devtools::check()
 ```
 

--- a/i18n/ja/skills/add-puzzle-type/SKILL.md
+++ b/i18n/ja/skills/add-puzzle-type/SKILL.md
@@ -51,11 +51,11 @@ jigsawRのすべてのパイプライン統合ポイントにまたがる新し�
 #' Generate <type> puzzle pieces (internal)
 #' @noRd
 generate_<type>_pieces_internal <- function(params, seed) {
-  # 1. RNG状態の初期化
-  # 2. ピースジオメトリの生成
-  # 3. エッジパスの構築（SVGパスデータ）
-  # 4. 隣接関係の計算
-  # 5. リストを返す: pieces, edges, adjacency, metadata
+  # 1. Initialize RNG state
+  # 2. Generate piece geometries
+  # 3. Build edge paths (SVG path data)
+  # 4. Compute adjacency
+  # 5. Return list: pieces, edges, adjacency, metadata
 }
 ```
 
@@ -75,7 +75,7 @@ generate_<type>_pieces_internal <- function(params, seed) {
 4. ファイル名プレフィックスマッピングを追加（例：`"<type>"` -> `"<type>_"`）
 
 ```r
-# valid_typesに追加
+# In valid_types
 valid_types <- c("rectangular", "hexagonal", "concentric", "voronoi", "snic", "<type>")
 ```
 
@@ -91,7 +91,7 @@ valid_types <- c("rectangular", "hexagonal", "concentric", "voronoi", "snic", "<
 2. タイプがPILES記法をサポートする場合、フュージョン処理を追加
 
 ```r
-# switch/dispatchに追加
+# In the switch/dispatch
 "<type>" = generate_<type>_pieces_internal(params, seed)
 ```
 

--- a/i18n/ja/skills/build-shiny-module/SKILL.md
+++ b/i18n/ja/skills/build-shiny-module/SKILL.md
@@ -105,13 +105,13 @@ dataFilterServer <- function(id, data, columns) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
-    # データが変わったときに列の選択肢を更新
+    # Update column choices when data changes
     observeEvent(data(), {
       available <- intersect(columns, names(data()))
       updateSelectInput(session, "column", choices = available)
     })
 
-    # 選択した列に基づくダイナミックフィルターコントロール
+    # Dynamic filter control based on selected column
     output$filter_control <- renderUI({
       req(input$column)
       col_data <- data()[[input$column]]
@@ -135,7 +135,7 @@ dataFilterServer <- function(id, data, columns) {
       }
     })
 
-    # フィルタリングされたデータをリアクティブとして返す
+    # Return filtered data as a reactive
     filtered <- eventReactive(input$apply, {
       req(input$column)
       col <- input$column
@@ -171,7 +171,7 @@ dataFilterServer <- function(id, data, columns) {
 ### ステップ4: 親アプリへのモジュールの接続
 
 ```r
-# app_ui.RまたはuiにてM
+# In app_ui.R or ui
 ui <- page_sidebar(
   title = "Analysis App",
   sidebar = sidebar(
@@ -182,19 +182,19 @@ ui <- page_sidebar(
   )
 )
 
-# app_server.RまたはserverにてMJ
+# In app_server.R or server
 server <- function(input, output, session) {
-  # 生データソース
+  # Raw data source
   raw_data <- reactive({ mtcars })
 
-  # モジュールを呼び出す — 戻り値をキャプチャ
+  # Call module — capture its return value
   filtered_data <- dataFilterServer(
     "filter1",
     data = raw_data,
     columns = c("cyl", "mpg", "hp", "wt")
   )
 
-  # モジュールが返したリアクティブを使用
+  # Use the module's returned reactive
   output$table <- DT::renderDataTable({
     filtered_data()
   })
@@ -220,7 +220,7 @@ analysisUI <- function(id) {
 
 analysisServer <- function(id, data) {
   moduleServer(id, function(input, output, session) {
-    # 名前空間化されたIDで内部モジュールを呼び出す
+    # Call inner module with namespaced ID
     filtered <- dataFilterServer("filter", data = data, columns = names(data()))
 
     output$plot <- renderPlot({
@@ -242,7 +242,7 @@ analysisServer <- function(id, data) {
 ### ステップ6: モジュールを分離してテスト
 
 ```r
-# モジュールのクイックテストアプリ
+# Quick test app for the module
 if (interactive()) {
   shiny::shinyApp(
     ui = fluidPage(

--- a/i18n/ja/skills/create-r-package/SKILL.md
+++ b/i18n/ja/skills/create-r-package/SKILL.md
@@ -185,10 +185,10 @@ NULL
 ## 使用例
 
 ```r
-# 最小構成での作成
+# Minimal creation
 usethis::create_package("myanalysis")
 
-# 1セッションでのフルセットアップ
+# Full setup in one session
 usethis::create_package("myanalysis")
 usethis::use_mit_license()
 usethis::use_testthat(edition = 3)

--- a/i18n/ja/skills/deploy-shiny-app/SKILL.md
+++ b/i18n/ja/skills/deploy-shiny-app/SKILL.md
@@ -49,13 +49,13 @@ ShinyアプリケーションをShinyapps.io、Posit Connect、またはDocker�
 アプリが自己完結型でデプロイ可能であることを確認します：
 
 ```r
-# 欠けている依存関係を確認
+# Check for missing dependencies
 rsconnect::appDependencies("path/to/app")
 
-# golemアプリの場合、DESCRIPTIONにすべてのImportsがリストされているか確認
+# For golem apps, ensure DESCRIPTION lists all Imports
 devtools::check()
 
-# アプリがクリーンに実行されることを確認
+# Verify the app runs cleanly
 shiny::runApp("path/to/app")
 ```
 
@@ -71,14 +71,14 @@ shiny::runApp("path/to/app")
 ### ステップ2a: shinyapps.ioへのデプロイ
 
 ```r
-# 一回限りのアカウントセットアップ
+# One-time account setup
 rsconnect::setAccountInfo(
   name = "your-account",
   token = Sys.getenv("SHINYAPPS_TOKEN"),
   secret = Sys.getenv("SHINYAPPS_SECRET")
 )
 
-# デプロイ
+# Deploy
 rsconnect::deployApp(
   appDir = "path/to/app",
   appName = "my-app",
@@ -103,20 +103,20 @@ SHINYAPPS_SECRET=your_secret_here
 ### ステップ2b: Posit Connectへのデプロイ
 
 ```r
-# サーバーの登録（一回限り）
+# Register server (one-time)
 rsconnect::addServer(
   url = "https://connect.example.com",
   name = "production"
 )
 
-# 認証（一回限り）
+# Authenticate (one-time)
 rsconnect::connectApiUser(
   account = "your-username",
   server = "production",
   apiKey = Sys.getenv("CONNECT_API_KEY")
 )
 
-# デプロイ
+# Deploy
 rsconnect::deployApp(
   appDir = "path/to/app",
   appName = "my-app",
@@ -189,11 +189,11 @@ docker run -p 3838:3838 myapp:latest
 ### ステップ3: デプロイメントの確認
 
 ```r
-# デプロイされたURLが応答するか確認
+# Check the deployed URL responds
 response <- httr::GET("https://your-app-url/")
-httr::status_code(response)  # 200であるべき
+httr::status_code(response)  # Should be 200
 
-# Dockerの場合
+# For Docker
 response <- httr::GET("http://localhost:3838/")
 httr::status_code(response)
 ```
@@ -217,7 +217,7 @@ httr::status_code(response)
 #### Posit Connect
 
 ```r
-# API経由でデプロイメントの状態を確認
+# Check deployment status via API
 connectapi::connect(
   server = "https://connect.example.com",
   api_key = Sys.getenv("CONNECT_API_KEY")

--- a/i18n/ja/skills/design-shiny-ui/SKILL.md
+++ b/i18n/ja/skills/design-shiny-ui/SKILL.md
@@ -50,14 +50,14 @@ bslibのテーマ設定、モダンなレイアウトプリミティブ、カス
 bslibはいくつかのページコンストラクターを提供します：
 
 ```r
-# サイドバーレイアウト — データアプリに最も一般的
+# Sidebar layout — most common for data apps
 ui <- page_sidebar(
   title = "My App",
   sidebar = sidebar("Controls here"),
   "Main content here"
 )
 
-# Navbarレイアウト — 複数ページアプリに
+# Navbar layout — for multi-page apps
 ui <- page_navbar(
   title = "My App",
   nav_panel("Tab 1", "Content 1"),
@@ -66,7 +66,7 @@ ui <- page_navbar(
   nav_item(actionButton("help", "Help"))
 )
 
-# Fillableレイアウト — コンテンツが利用可能なスペースを埋める
+# Fillable layout — content fills available space
 ui <- page_fillable(
   card(
     full_screen = TRUE,
@@ -74,7 +74,7 @@ ui <- page_fillable(
   )
 )
 
-# ダッシュボードレイアウト — バリューボックスとカードのグリッド
+# Dashboard layout — grid of value boxes and cards
 ui <- page_sidebar(
   title = "Dashboard",
   sidebar = sidebar(open = "closed", "Filters"),
@@ -100,11 +100,11 @@ ui <- page_sidebar(
 ```r
 my_theme <- bslib::bs_theme(
   version = 5,                      # Bootstrap 5
-  bootswatch = "flatly",            # オプションのプリセットテーマ
-  bg = "#ffffff",                   # 背景色
-  fg = "#2c3e50",                   # 前景（テキスト）色
-  primary = "#2c3e50",              # プライマリブランドカラー
-  secondary = "#95a5a6",            # セカンダリカラー
+  bootswatch = "flatly",            # Optional preset theme
+  bg = "#ffffff",                   # Background color
+  fg = "#2c3e50",                   # Foreground (text) color
+  primary = "#2c3e50",              # Primary brand color
+  secondary = "#95a5a6",            # Secondary color
   success = "#18bc9c",
   info = "#3498db",
   warning = "#f39c12",
@@ -147,7 +147,7 @@ ui <- page_sidebar(
     actionButton("refresh", "Refresh", class = "btn-primary w-100")
   ),
 
-  # KPI行 — 非フィリング
+  # KPI row — non-filling
   layout_columns(
     fill = FALSE,
     col_widths = c(4, 4, 4),
@@ -171,7 +171,7 @@ ui <- page_sidebar(
     )
   ),
 
-  # メインコンテンツ行
+  # Main content row
   layout_columns(
     col_widths = c(8, 4),
     card(
@@ -221,8 +221,8 @@ server <- function(input, output, session) {
     )
   })
 
-  # 条件付きパネル（サーバーラウンドトリップなし）
-  # UI内：
+  # Conditional panels (no server round-trip)
+  # In UI:
   # conditionalPanel(
   #   condition = "input.show_advanced == true",
   #   numericInput("alpha", "Alpha", 0.05)
@@ -239,7 +239,7 @@ server <- function(input, output, session) {
 bslibのテーマ変数を超えたスタイルのために：
 
 ```r
-# インラインCSS
+# Inline CSS
 ui <- page_sidebar(
   theme = my_theme,
   tags$head(tags$style(HTML("
@@ -250,7 +250,7 @@ ui <- page_sidebar(
   # ...
 )
 
-# 外部CSSファイル（www/ディレクトリに配置）
+# External CSS file (place in www/ directory)
 ui <- page_sidebar(
   theme = my_theme,
   tags$head(tags$link(rel = "stylesheet", href = "custom.css")),
@@ -272,31 +272,31 @@ my_theme <- bslib::bs_theme(version = 5) |>
 ### ステップ6: アクセシビリティの確保
 
 ```r
-# 入力にARIAラベルを追加
+# Add ARIA labels to inputs
 selectInput("category", "Category",
   choices = c("A", "B", "C")
 ) |> tagAppendAttributes(`aria-describedby` = "category-help")
 
-# プロットにaltテキストを追加
+# Add alt text to plots
 output$plot <- renderPlot({
   plot(data(), main = "Distribution of Values")
 }, alt = "Histogram showing the distribution of selected values")
 
-# テーマで十分な色のコントラストを確保
+# Ensure sufficient color contrast in theme
 my_theme <- bslib::bs_theme(
   version = 5,
-  bg = "#ffffff",      # 白い背景
-  fg = "#212529"       # 暗いテキスト — 15.4:1のコントラスト比
+  bg = "#ffffff",      # White background
+  fg = "#212529"       # Dark text — 15.4:1 contrast ratio
 )
 
-# セマンティックHTMLを使用
+# Use semantic HTML
 tags$main(
   role = "main",
   tags$h1("Dashboard"),
   tags$section(
     `aria-label` = "Key Performance Indicators",
     layout_columns(
-      # バリューボックス...
+      # value boxes...
     )
   )
 )

--- a/i18n/ja/skills/fail-early-pattern/SKILL.md
+++ b/i18n/ja/skills/fail-early-pattern/SKILL.md
@@ -157,9 +157,9 @@ cli::cli_abort(c(
 **悪いメッセージ:**
 
 ```r
-stop("Error")                    # 何が失敗した? わからない
-stop("Invalid input")           # どの入力? 何が問題?
-stop(paste("Error in step", i)) # 実行可能な情報なし
+stop("Error")                    # What failed? No idea
+stop("Invalid input")           # Which input? What's wrong with it?
+stop(paste("Error in step", i)) # No actionable information
 ```
 
 **期待結果：** エラーメッセージが自己文書化されている — エラーを初めて見た開発者がソースコードを読まずに診断して修正できる。

--- a/i18n/ja/skills/manage-renv-dependencies/SKILL.md
+++ b/i18n/ja/skills/manage-renv-dependencies/SKILL.md
@@ -89,13 +89,13 @@ renv::restore()
 ### ステップ4: 依存関係の更新
 
 ```r
-# 特定のパッケージを更新
+# Update a specific package
 renv::update("dplyr")
 
-# すべてのパッケージを更新
+# Update all packages
 renv::update()
 
-# 更新後にスナップショットを作成
+# Snapshot after updates
 renv::snapshot()
 ```
 

--- a/i18n/ja/skills/optimize-shiny-performance/SKILL.md
+++ b/i18n/ja/skills/optimize-shiny-performance/SKILL.md
@@ -47,12 +47,12 @@ metadata:
 ### ステップ1: アプリケーションのプロファイリング
 
 ```r
-# profvisでプロファイル
+# Profile with profvis
 profvis::profvis({
   shiny::runApp("path/to/app", display.mode = "normal")
 })
 
-# または特定の操作をプロファイル
+# Or profile specific operations
 profvis::profvis({
   result <- expensive_computation(data)
 })
@@ -67,10 +67,10 @@ profvis::profvis({
 リアクティブグラフ分析にリアクティブログを使用します：
 
 ```r
-# リアクティブログを有効化
+# Enable reactive logging
 options(shiny.reactlog = TRUE)
 shiny::runApp("path/to/app")
-# ブラウザでCtrl+F3を押してリアクティブグラフを表示
+# Press Ctrl+F3 in the browser to view the reactive graph
 ```
 
 **期待結果：** 2〜3の最大のボトルネックが明確に特定されます。
@@ -82,17 +82,17 @@ shiny::runApp("path/to/app")
 不要なリアクティブの無効化を減らします：
 
 ```r
-# 悪い例: 任意の入力変更で再計算される
+# BAD: Recomputes on ANY input change
 output$plot <- renderPlot({
-  data <- load_data()  # 毎回実行される
+  data <- load_data()  # Runs every time
   filtered <- data[data$category == input$category, ]
   plot(filtered)
 })
 
-# 良い例: データ読み込みをフィルタリングから分離する
+# GOOD: Isolate data loading from filtering
 raw_data <- reactive({
   load_data()
-}) |> bindCache()  # 高価な部分をキャッシュ
+}) |> bindCache()  # Cache the expensive part
 
 filtered_data <- reactive({
   raw_data()[raw_data()$category == input$category, ]
@@ -106,9 +106,9 @@ output$plot <- renderPlot({
 不要な無効化を防ぐために`isolate()`を使用します：
 
 ```r
-# すべての入力変更ではなく、ボタンがクリックされたときのみ再計算
+# Only recompute when the button is clicked, not on every input change
 output$result <- renderText({
-  input$compute  # ボタンへの依存関係を取得
+  input$compute  # Take dependency on button
   isolate({
     paste("N =", input$n, "Mean =", mean(rnorm(input$n)))
   })
@@ -118,10 +118,10 @@ output$result <- renderText({
 高頻度の入力には`debounce()`と`throttle()`を使用します：
 
 ```r
-# テキスト入力をデバウンス — ユーザーが入力を止めてから500ms待つ
+# Debounce text input — wait 500ms after user stops typing
 search_text <- reactive(input$search) |> debounce(500)
 
-# スライダーをスロットル — 最大250msごとに更新
+# Throttle slider — update at most every 250ms
 slider_value <- reactive(input$slider) |> throttle(250)
 ```
 
@@ -148,7 +148,7 @@ output$table <- renderDT({
 #### 関数用のmemoise
 
 ```r
-# 高価な関数結果をキャッシュ
+# Cache expensive function results
 load_reference_data <- memoise::memoise(
   function(dataset_name) {
     readr::read_csv(paste0("data/", dataset_name, ".csv"))
@@ -160,13 +160,13 @@ load_reference_data <- memoise::memoise(
 #### アプリレベルのデータ事前計算
 
 ```r
-# global.Rまたはサーバー関数の外 — アプリ起動時に一度だけ計算される
+# In global.R or outside server function — computed once at app startup
 reference_data <- readr::read_csv("data/reference.csv")
 model <- readRDS("models/trained_model.rds")
 
 server <- function(input, output, session) {
-  # reference_dataとmodelはすべてのセッションで利用可能
-  # 再読み込みなし
+  # reference_data and model are available to all sessions
+  # without reloading
 }
 ```
 
@@ -180,20 +180,20 @@ server <- function(input, output, session) {
 
 ```r
 server <- function(input, output, session) {
-  # 拡張タスクを定義
+  # Define the extended task
   analysis_task <- ExtendedTask$new(function(data, params) {
     promises::future_promise({
-      # これはバックグラウンドプロセスで実行される
+      # This runs in a background process
       run_heavy_analysis(data, params)
     })
   }) |> bind_task_button("run_analysis")
 
-  # タスクをトリガー
+  # Trigger the task
   observeEvent(input$run_analysis, {
     analysis_task$invoke(dataset(), input$params)
   })
 
-  # 結果を使用
+  # Use the result
   output$result <- renderTable({
     analysis_task$result()
   })
@@ -210,7 +210,7 @@ plan(multisession, workers = 4)
 server <- function(input, output, session) {
   result <- eventReactive(input$compute, {
     future_promise({
-      Sys.sleep(5)  # 長時間計算をシミュレート
+      Sys.sleep(5)  # Simulate long computation
       expensive_analysis(isolate(input$params))
     })
   })
@@ -230,12 +230,12 @@ server <- function(input, output, session) {
 レンダリングのオーバーヘッドを削減します：
 
 ```r
-# 再レンダリングの代わりにplotlyをインタラクティブプロットに使用
+# Use plotly for interactive plots instead of re-rendering
 output$plot <- plotly::renderPlotly({
   plotly::plot_ly(filtered_data(), x = ~x, y = ~y, type = "scatter")
 })
 
-# 大きなテーブルにはサーバーサイドDTを使用
+# Use server-side DT for large tables
 output$table <- DT::renderDataTable({
   DT::datatable(large_data(), server = TRUE, options = list(
     pageLength = 25,
@@ -243,7 +243,7 @@ output$table <- DT::renderDataTable({
   ))
 })
 
-# 非表示要素のレンダリングを避けるための条件付きUI
+# Conditional UI to avoid rendering hidden elements
 output$details <- renderUI({
   req(input$show_details)
   expensive_details_ui()
@@ -257,7 +257,7 @@ output$details <- renderUI({
 ### ステップ6: パフォーマンス改善の検証
 
 ```r
-# ビフォー/アフターのベンチマーク
+# Before/after benchmarking
 system.time({
   shiny::testServer(myModuleServer, args = list(...), {
     session$setInputs(category = "A")
@@ -265,7 +265,7 @@ system.time({
   })
 })
 
-# shinyloadtestによる負荷テスト
+# Load testing with shinyloadtest
 shinyloadtest::record_session("http://localhost:3838")
 shinyloadtest::shinycannon(
   "recording.log",

--- a/i18n/ja/skills/release-package-version/SKILL.md
+++ b/i18n/ja/skills/release-package-version/SKILL.md
@@ -57,7 +57,7 @@ Rパッケージの完全なバージョンリリースサイクルを実行す�
 ### ステップ2: バージョンの更新
 
 ```r
-usethis::use_version("minor")  # または"patch"または"major"
+usethis::use_version("minor")  # or "patch" or "major"
 ```
 
 これによりDESCRIPTIONの`Version`フィールドが更新され、NEWS.mdに見出しが追加される。

--- a/i18n/ja/skills/scaffold-shiny-app/SKILL.md
+++ b/i18n/ja/skills/scaffold-shiny-app/SKILL.md
@@ -155,16 +155,16 @@ shinyApp(ui, server)
 #### Golem/Vanilla
 
 ```r
-# renvの初期化
+# Initialize renv
 renv::init()
 
-# コア依存関係の追加
+# Add core dependencies
 usethis::use_package("shiny")
 usethis::use_package("bslib")
-usethis::use_package("DT")         # データテーブルを使用する場合
-usethis::use_package("plotly")     # インタラクティブプロットを使用する場合
+usethis::use_package("DT")         # if using data tables
+usethis::use_package("plotly")     # if using interactive plots
 
-# スナップショット
+# Snapshot
 renv::snapshot()
 ```
 

--- a/i18n/ja/skills/security-audit-codebase/SKILL.md
+++ b/i18n/ja/skills/security-audit-codebase/SKILL.md
@@ -102,8 +102,8 @@ safety check
 **R**:
 
 ```r
-# パッケージの既知の脆弱性を確認
-# 組み込みツールはないが、パッケージソースを検証
+# Check for known vulnerabilities in packages
+# No built-in tool, but verify package sources
 renv::status()
 ```
 

--- a/i18n/ja/skills/serialize-data-formats/SKILL.md
+++ b/i18n/ja/skills/serialize-data-formats/SKILL.md
@@ -103,14 +103,14 @@ data = json.loads(json_str)
 ```
 
 ```r
-# R: jsonliteによるJSON
+# R: JSON with jsonlite
 library(jsonlite)
 
-# シリアライズ
+# Serialize
 df <- data.frame(sensor_id = "sensor-01", value = 23.5, unit = "celsius")
 json_str <- jsonlite::toJSON(df, auto_unbox = TRUE, pretty = TRUE)
 
-# デシリアライズ
+# Deserialize
 df_back <- jsonlite::fromJSON(json_str)
 ```
 
@@ -222,14 +222,14 @@ df_subset = table_back.to_pandas()
 ```
 
 ```r
-# R: arrowによるParquet
+# R: Parquet with arrow
 library(arrow)
 
-# 書き込み
+# Write
 df <- data.frame(sensor_id = rep("s-01", 1000), value = rnorm(1000))
 arrow::write_parquet(df, "measurements.parquet")
 
-# 読み込み（カラム選択付き — 選択されたカラムのみディスクから読み込む）
+# Read (with column selection — only reads selected columns from disk)
 df_back <- arrow::read_parquet("measurements.parquet", col_select = c("value"))
 ```
 

--- a/i18n/ja/skills/submit-to-cran/SKILL.md
+++ b/i18n/ja/skills/submit-to-cran/SKILL.md
@@ -143,10 +143,10 @@ There are currently no downstream dependencies for this package.
 ### ステップ8: 最終事前チェック
 
 ```r
-# 最後のチェック
+# One last check
 devtools::check()
 
-# ビルドされたtarballを確認
+# Verify the built tarball
 devtools::build()
 ```
 
@@ -173,10 +173,10 @@ devtools::release()
 承認後：
 
 ```r
-# リリースをタグ付け
+# Tag the release
 usethis::use_github_release()
 
-# 開発バージョンにバンプ
+# Bump to development version
 usethis::use_dev_version()
 ```
 
@@ -208,13 +208,13 @@ usethis::use_dev_version()
 ## 例
 
 ```r
-# 投稿前の完全なワークフロー
+# Full pre-submission workflow
 devtools::spell_check()
 urlchecker::url_check()
 devtools::check()
 devtools::check_win_devel()
 rhub::rhub_check()
-# 結果を待つ...
+# Wait for results...
 devtools::release()
 ```
 

--- a/i18n/ja/skills/test-shiny-app/SKILL.md
+++ b/i18n/ja/skills/test-shiny-app/SKILL.md
@@ -50,10 +50,10 @@ shinytest2（エンドツーエンド）とtestServer()（ユニットテスト�
 ```r
 install.packages("shinytest2")
 
-# golemアプリの場合、Suggests依存関係として追加
+# For golem apps, add as a Suggests dependency
 usethis::use_package("shinytest2", type = "Suggests")
 
-# testthatインフラがない場合はセットアップ
+# Set up testthat infrastructure if not present
 usethis::use_testthat(edition = 3)
 ```
 
@@ -71,12 +71,12 @@ test_that("dashboard module filters data correctly", {
     data = reactive(iris),
     columns = c("Species", "Sepal.Length")
   ), {
-    # 入力を設定
+    # Set inputs
     session$setInputs(column = "Species")
     session$setInputs(value_select = "setosa")
     session$setInputs(apply = 1)
 
-    # 出力を確認
+    # Check output
     result <- filtered()
     expect_equal(nrow(result), 50)
     expect_true(all(result$Species == "setosa"))
@@ -88,7 +88,7 @@ test_that("dashboard module handles empty data", {
     data = reactive(iris[0, ]),
     columns = c("Species")
   ), {
-    # モジュールは空のデータでエラーを出してはいけない
+    # Module should not error on empty data
     expect_no_error(session$setInputs(column = "Species"))
   })
 })
@@ -111,7 +111,7 @@ test_that("dashboard module handles empty data", {
 
 ```r
 test_that("app loads and displays initial state", {
-  # golemアプリの場合
+  # For golem apps
   app <- AppDriver$new(
     app_dir = system.file(package = "myapp"),
     name = "initial-load",
@@ -120,10 +120,10 @@ test_that("app loads and displays initial state", {
   )
   on.exit(app$stop(), add = TRUE)
 
-  # アプリが読み込まれるのを待つ
+  # Wait for app to load
   app$wait_for_idle(timeout = 10000)
 
-  # 主要な要素が存在するか確認
+  # Check that key elements exist
   app$expect_values()
 })
 
@@ -134,14 +134,14 @@ test_that("filter interaction updates the table", {
   )
   on.exit(app$stop(), add = TRUE)
 
-  # アプリと対話する
+  # Interact with the app
   app$set_inputs(`filter1-column` = "cyl")
   app$wait_for_idle()
 
   app$set_inputs(`filter1-apply` = "click")
   app$wait_for_idle()
 
-  # 出力値のスナップショット
+  # Snapshot the output values
   app$expect_values(output = "table")
 })
 ```
@@ -174,10 +174,10 @@ shinytest2::record_test("path/to/app")
 スナップショットベースのテストの場合、期待値を管理します：
 
 ```r
-# レビュー後に新しい/変更されたスナップショットを受け入れる
+# Accept new/changed snapshots after review
 testthat::snapshot_accept("test-app-e2e")
 
-# スナップショットの差異をレビュー
+# Review snapshot differences
 testthat::snapshot_review("test-app-e2e")
 ```
 

--- a/i18n/ja/skills/validate-piles-notation/SKILL.md
+++ b/i18n/ja/skills/validate-piles-notation/SKILL.md
@@ -47,7 +47,7 @@ metadata:
 ```r
 library(jigsawR)
 result <- validate_piles_syntax("1-2-3,4-5")
-# 有効な場合はTRUEを返し、無効な場合はエラーメッセージを返す
+# Returns TRUE if valid, error message if invalid
 ```
 
 一般的な構文エラーを確認する:
@@ -63,13 +63,13 @@ result <- validate_piles_syntax("1-2-3,4-5")
 
 ```r
 groups <- parse_piles("1-2-3,4-5")
-# 返却値: list(c(1, 2, 3), c(4, 5))
+# Returns: list(c(1, 2, 3), c(4, 5))
 ```
 
 範囲を含む文字列の場合:
 ```r
 groups <- parse_piles("1:6,7-8")
-# 返却値: list(c(1, 2, 3, 4, 5, 6), c(7, 8))
+# Returns: list(c(1, 2, 3, 4, 5, 6), c(7, 8))
 ```
 
 **期待結果:** 整数ベクトルのリスト（フュージョングループごとに1つ）。正しいピースIDとグループ境界を持つ。
@@ -93,10 +93,10 @@ groups <- parse_piles("1:6,7-8")
 パズル結果オブジェクトが利用可能な場合、以下を確認する:
 
 ```r
-# まずパズルを生成
+# Generate the puzzle first
 puzzle <- generate_puzzle(type = "hexagonal", grid = c(3), size = c(200))
 
-# パズルコンテキストで解析（キーワードを解決）
+# Parse with puzzle context (resolves keywords)
 groups <- parse_fusion("center,ring1", puzzle)
 ```
 
@@ -117,10 +117,10 @@ groups <- parse_fusion("center,ring1", puzzle)
 original <- "1-2-3,4-5"
 groups <- parse_piles(original)
 roundtrip <- to_piles(groups)
-# roundtripはoriginalと等しい（または正規化された等価物）はず
+# roundtrip should equal original (or canonical equivalent)
 
 groups2 <- parse_piles(roundtrip)
-identical(groups, groups2)  # TRUEでなければならない
+identical(groups, groups2)  # Must be TRUE
 ```
 
 **期待結果:** ラウンドトリップが同一のグループリストを生成し、`parse_piles()`と`to_piles()`が逆関数であることを確認する。

--- a/i18n/ja/skills/write-testthat-tests/SKILL.md
+++ b/i18n/ja/skills/write-testthat-tests/SKILL.md
@@ -95,19 +95,19 @@ test_that("weighted_mean validates input", {
 
 ```r
 test_that("weighted_mean handles edge cases", {
-  # 空の入力
+  # Empty input
   expect_error(weighted_mean(numeric(0), numeric(0)))
 
-  # 単一の値
+  # Single value
   expect_equal(weighted_mean(5, 1), 5)
 
-  # ゼロの重み
+  # Zero weights
   expect_true(is.nan(weighted_mean(1:3, c(0, 0, 0))))
 
-  # 非常に大きな値
+  # Very large values
   expect_equal(weighted_mean(c(1e15, 1e15), c(1, 1)), 1e15)
 
-  # 負の重み
+  # Negative weights
   expect_error(weighted_mean(1:3, c(-1, 1, 1)))
 })
 ```
@@ -121,7 +121,7 @@ test_that("weighted_mean handles edge cases", {
 テストデータ用に`tests/testthat/fixtures/`を作成する：
 
 ```r
-# tests/testthat/helper.R（自動的に読み込まれる）
+# tests/testthat/helper.R (loaded automatically)
 create_test_data <- function() {
   data.frame(
     x = c(1, 2, 3, NA, 5),
@@ -131,7 +131,7 @@ create_test_data <- function() {
 ```
 
 ```r
-# テストファイル内
+# In test file
 test_that("process_data works with grouped data", {
   test_data <- create_test_data()
   result <- process_data(test_data)
@@ -213,14 +213,14 @@ test_that("parallel computation works", {
 ### ステップ9: テストの実行とカバレッジの確認
 
 ```r
-# すべてのテストを実行
+# Run all tests
 devtools::test()
 
-# 特定のテストファイルを実行
-devtools::test_active_file()  # RStudioで
+# Run specific test file
+devtools::test_active_file()  # in RStudio
 testthat::test_file("tests/testthat/test-function_name.R")
 
-# カバレッジを確認
+# Check coverage
 covr::package_coverage()
 covr::report()
 ```
@@ -250,16 +250,16 @@ covr::report()
 ## 例
 
 ```r
-# パターン：テストファイルはR/ファイルを反映する
+# Pattern: test file mirrors R/ file
 # R/weighted_mean.R -> tests/testthat/test-weighted_mean.R
 
-# パターン：説明的なテスト名
+# Pattern: descriptive test names
 test_that("weighted_mean returns NA when na.rm = FALSE and input contains NA", {
   result <- weighted_mean(c(1, NA), c(1, 1), na.rm = FALSE)
   expect_true(is.na(result))
 })
 
-# パターン：警告のテスト
+# Pattern: testing warnings
 test_that("deprecated_function emits deprecation warning", {
   expect_warning(deprecated_function(), "deprecated")
 })

--- a/i18n/ja/skills/write-vignette/SKILL.md
+++ b/i18n/ja/skills/write-vignette/SKILL.md
@@ -150,10 +150,10 @@ optionalpkg::special_function()
 長時間実行される計算の場合、結果を事前計算して保存する：
 
 ```r
-# vignettes/に事前計算済みの結果を保存
+# Save pre-computed results to vignettes/
 saveRDS(expensive_result, "vignettes/precomputed.rds")
 
-# ビネット内で読み込む
+# Load in vignette
 {r load-precomputed}
 result <- readRDS("precomputed.rds")
 ```
@@ -165,10 +165,10 @@ result <- readRDS("precomputed.rds")
 ### ステップ5: ビネットのビルドとテスト
 
 ```r
-# 単一のビネットをビルド
+# Build single vignette
 devtools::build_vignettes()
 
-# ビルドとチェック（ビネットの問題を検出）
+# Build and check (catches vignette issues)
 devtools::check()
 ```
 

--- a/i18n/wenyan-lite/skills/generate-statistical-tables/SKILL.md
+++ b/i18n/wenyan-lite/skills/generate-statistical-tables/SKILL.md
@@ -120,7 +120,7 @@ library(gt)
 cor_matrix <- cor(data[, c("var1", "var2", "var3", "var4")],
                   use = "pairwise.complete.obs")
 
-# 格式化下三角
+# Format lower triangle
 cor_matrix[upper.tri(cor_matrix)] <- NA
 
 as.data.frame(cor_matrix) |>
@@ -164,16 +164,16 @@ tbl_anova <- broom::tidy(aov_result) |>
 ### 步驟六：存表
 
 ```r
-# 存為 HTML
+# Save as HTML
 gtsave(my_table, "table1.html")
 
-# 存為 Word
+# Save as Word
 gtsave(my_table, "table1.docx")
 
-# 存為 PNG 圖
+# Save as PNG image
 gtsave(my_table, "table1.png")
 
-# 為 LaTeX/PDF（kableExtra）
+# For LaTeX/PDF (kableExtra)
 kableExtra::save_kable(kable_table, "table1.pdf")
 ```
 

--- a/i18n/wenyan-lite/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/wenyan-lite/skills/generate-workflow-diagram/SKILL.md
@@ -51,16 +51,16 @@ metadata:
 ```r
 library(putior)
 
-# 自手動註解
+# From manual annotations
 workflow <- put("./src/")
 
-# 自手動註解，排除特定檔
+# From manual annotations, excluding specific files
 workflow <- put("./src/", exclude = c("build-workflow\\.R$", "test_"))
 
-# 僅自動偵測
+# From auto-detection only
 workflow <- put_auto("./src/")
 
-# 合併（手動 + 自動）
+# From merged (manual + auto)
 workflow <- put_merge("./src/", merge_strategy = "supplement")
 ```
 
@@ -85,21 +85,21 @@ workflow <- put_merge("./src/", merge_strategy = "supplement")
 擇合目標讀者之主題。
 
 ```r
-# 列所有可用主題
+# List all available themes
 get_diagram_themes()
 
-# 標準主題
-# "light"   — 預設，明色
-# "dark"    — 暗模式環境
-# "auto"    — GitHub 自適應實色
-# "minimal" — 灰階，宜列印
-# "github"  — 為 GitHub README 優化
+# Standard themes
+# "light"   — Default, bright colors
+# "dark"    — For dark mode environments
+# "auto"    — GitHub-adaptive with solid colors
+# "minimal" — Grayscale, print-friendly
+# "github"  — Optimized for GitHub README files
 
-# 色盲安全主題（viridis 家族）
-# "viridis" — 紫→藍→綠→黃，通用可及性
-# "magma"   — 紫→紅→黃，列印高對比
-# "plasma"  — 紫→粉→橙→黃，簡報
-# "cividis" — 藍→灰→黃，最大可及性（無紅綠）
+# Colorblind-safe themes (viridis family)
+# "viridis" — Purple→Blue→Green→Yellow, general accessibility
+# "magma"   — Purple→Red→Yellow, high contrast for print
+# "plasma"  — Purple→Pink→Orange→Yellow, presentations
+# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
 
 附加參數：
@@ -118,7 +118,7 @@ get_diagram_themes()
 若九內建主題不配專案調色盤，以 `put_theme()` 建自訂主題。
 
 ```r
-# 建自訂調色盤——未指定類型繼承自基主題
+# Create custom palette — unspecified types inherit from base theme
 cyberpunk <- put_theme(
   base = "dark",
   input    = c(fill = "#1a1a2e", stroke = "#00ff88", color = "#00ff88"),
@@ -127,7 +127,7 @@ cyberpunk <- put_theme(
   decision = c(fill = "#1a1a2e", stroke = "#ffaa33", color = "#ffaa33")
 )
 
-# 用 palette 參數（覆蓋 theme）
+# Use the palette parameter (overrides theme when provided)
 mermaid_content <- put_diagram(workflow, palette = cyberpunk, output = "raw")
 writeLines(mermaid_content, "workflow.mmd")
 ```
@@ -153,26 +153,26 @@ mermaid_content <- paste(c(lines, custom_defs), collapse = "\n")
 以所欲輸出模式產圖。
 
 ```r
-# 印至主控台（預設）
+# Print to console (default)
 cat(put_diagram(workflow, theme = "github"))
 
-# 存至檔
+# Save to file
 writeLines(put_diagram(workflow, theme = "github"), "docs/workflow.md")
 
-# 取原始字串以嵌入
+# Get raw string for embedding
 mermaid_code <- put_diagram(workflow, output = "raw", theme = "github")
 
-# 附源檔資訊（示每節點來自何檔）
+# With source file info (shows which file each node comes from)
 cat(put_diagram(workflow, theme = "github", show_source_info = TRUE))
 
-# 附可點節點（VS Code、RStudio 或 file:// 協定）
+# With clickable nodes (for VS Code, RStudio, or file:// protocol)
 cat(put_diagram(workflow,
   theme = "github",
   enable_clicks = TRUE,
-  click_protocol = "vscode"  # 或 "rstudio"、"file"
+  click_protocol = "vscode"  # or "rstudio", "file"
 ))
 
-# 全特徵
+# Full-featured
 cat(put_diagram(workflow,
   theme = "viridis",
   show_source_info = TRUE,
@@ -202,13 +202,13 @@ flowchart TD
 
 **Quarto 文件（經 knit_child 之原生 mermaid 段）：**
 ```r
-# 段一：生代碼（可見、可摺）
+# Chunk 1: Generate code (visible, foldable)
 workflow <- put("./src/")
 mermaid_code <- put_diagram(workflow, output = "raw", theme = "github")
 ```
 
 ```r
-# 段二：輸出為原生 mermaid 段（隱藏）
+# Chunk 2: Output as native mermaid chunk (hidden)
 #| output: asis
 #| echo: false
 mermaid_chunk <- paste0("```{mermaid}\n", mermaid_code, "\n```")

--- a/i18n/wenyan-ultra/skills/scaffold-shiny-app/SKILL.md
+++ b/i18n/wenyan-ultra/skills/scaffold-shiny-app/SKILL.md
@@ -144,13 +144,16 @@ shinyApp(ui, server)
 #### Golem/素
 
 ```r
+# Initialize renv
 renv::init()
 
+# Add core dependencies
 usethis::use_package("shiny")
 usethis::use_package("bslib")
-usethis::use_package("DT")
-usethis::use_package("plotly")
+usethis::use_package("DT")         # if using data tables
+usethis::use_package("plotly")     # if using interactive plots
 
+# Snapshot
 renv::snapshot()
 ```
 
@@ -159,6 +162,7 @@ renv::snapshot()
 依管於 `dependencies.R`：
 
 ```r
+# dependencies.R
 library(shiny)
 library(bslib)
 library(DT)
@@ -235,8 +239,13 @@ dashboardServer <- function(id) {
 ### 五：行應
 
 ```r
+# Golem
 golem::run_dev()
+
+# Rhino
 shiny::runApp()
+
+# Vanilla
 shiny::runApp("app.R")
 ```
 

--- a/i18n/wenyan-ultra/skills/security-audit-codebase/SKILL.md
+++ b/i18n/wenyan-ultra/skills/security-audit-codebase/SKILL.md
@@ -103,6 +103,8 @@ safety check
 **R**：
 
 ```r
+# Check for known vulnerabilities in packages
+# No built-in tool, but verify package sources
 renv::status()
 ```
 

--- a/i18n/wenyan-ultra/skills/serialize-data-formats/SKILL.md
+++ b/i18n/wenyan-ultra/skills/serialize-data-formats/SKILL.md
@@ -101,11 +101,14 @@ data = json.loads(json_str)
 ```
 
 ```r
+# R: JSON with jsonlite
 library(jsonlite)
 
+# Serialize
 df <- data.frame(sensor_id = "sensor-01", value = 23.5, unit = "celsius")
 json_str <- jsonlite::toJSON(df, auto_unbox = TRUE, pretty = TRUE)
 
+# Deserialize
 df_back <- jsonlite::fromJSON(json_str)
 ```
 
@@ -212,11 +215,14 @@ df_subset = table_back.to_pandas()
 ```
 
 ```r
+# R: Parquet with arrow
 library(arrow)
 
+# Write
 df <- data.frame(sensor_id = rep("s-01", 1000), value = rnorm(1000))
 arrow::write_parquet(df, "measurements.parquet")
 
+# Read (with column selection — only reads selected columns from disk)
 df_back <- arrow::read_parquet("measurements.parquet", col_select = c("value"))
 ```
 

--- a/i18n/zh-CN/skills/create-r-package/SKILL.md
+++ b/i18n/zh-CN/skills/create-r-package/SKILL.md
@@ -184,10 +184,10 @@ NULL
 ## 示例
 
 ```r
-# 最简创建
+# Minimal creation
 usethis::create_package("myanalysis")
 
-# 在一个会话中完成全部设置
+# Full setup in one session
 usethis::create_package("myanalysis")
 usethis::use_mit_license()
 usethis::use_testthat(edition = 3)

--- a/i18n/zh-CN/skills/fail-early-pattern/SKILL.md
+++ b/i18n/zh-CN/skills/fail-early-pattern/SKILL.md
@@ -67,21 +67,21 @@ metadata:
 
 ```r
 calculate_summary <- function(data, method = c("mean", "median", "trim"), trim_pct = 0.1) {
-  # 守卫：类型检查
+  # Guard: type check
   if (!is.data.frame(data)) {
     stop("'data' must be a data frame, not ", class(data)[[1]], call. = FALSE)
   }
-  # 守卫：非空
+  # Guard: non-empty
   if (nrow(data) == 0L) {
     stop("'data' must have at least one row", call. = FALSE)
   }
-  # 守卫：参数匹配
+  # Guard: argument matching
   method <- match.arg(method)
-  # 守卫：范围检查
+  # Guard: range check
   if (!is.numeric(trim_pct) || trim_pct < 0 || trim_pct > 0.5) {
     stop("'trim_pct' must be a number between 0 and 0.5, got: ", trim_pct, call. = FALSE)
   }
-  # --- 所有守卫通过，开始实际工作 ---
+  # --- All guards passed, begin real work ---
   # ...
 }
 ```
@@ -135,16 +135,16 @@ function calculateSummary(data: DataFrame, method: Method, trimPct: number): Sum
 **好的消息：**
 
 ```r
-# 什么 + 为什么（期望 vs. 实际）
+# What + Why (expected vs. actual)
 stop("'n' must be a positive integer, got: ", n, call. = FALSE)
 
-# 什么 + 为什么 + 如何修复
+# What + Why + How to fix
 cli::cli_abort(c(
   "{.arg config_path} does not exist: {.file {config_path}}",
   "i" = "Create it with {.run create_config({.file {config_path}})}."
 ))
 
-# 什么 + 上下文
+# What + context
 cli::cli_abort(c(
   "Column {.val {col_name}} not found in {.arg data}.",
   "i" = "Available columns: {.val {names(data)}}"
@@ -154,9 +154,9 @@ cli::cli_abort(c(
 **差的消息：**
 
 ```r
-stop("Error")                    # 什么失败了？完全不知道
-stop("Invalid input")           # 哪个输入？有什么问题？
-stop(paste("Error in step", i)) # 没有可操作的信息
+stop("Error")                    # What failed? No idea
+stop("Invalid input")           # Which input? What's wrong with it?
+stop(paste("Error in step", i)) # No actionable information
 ```
 
 **预期结果：** 错误消息是自文档化的——第一次看到错误的开发者无需阅读源代码就能诊断和修复。
@@ -170,7 +170,7 @@ stop(paste("Error in step", i)) # 没有可操作的信息
 **经验法则：** 若用户可能静默地得到错误答案，那就是 `stop()`，而非 `warning()`。
 
 ```r
-# 正确：结果会错时使用 stop
+# CORRECT: stop when result would be wrong
 read_config <- function(path) {
   if (!file.exists(path)) {
     stop("Config file not found: ", path, call. = FALSE)
@@ -178,13 +178,13 @@ read_config <- function(path) {
   yaml::read_yaml(path)
 }
 
-# 正确：结果仍可用时使用 warn
+# CORRECT: warn when result is still usable
 summarize_data <- function(data) {
   if (any(is.na(data$value))) {
     warning(sum(is.na(data$value)), " NA values dropped from 'value' column", call. = FALSE)
     data <- data[!is.na(data$value), ]
   }
-  # 继续处理有效数据
+  # proceed with valid data
 }
 ```
 
@@ -197,7 +197,7 @@ summarize_data <- function(data) {
 对于"正确代码中不应该发生"的条件，使用断言。这些可以在开发期间捕获程序员错误：
 
 ```r
-# R：使用 stopifnot 处理内部不变量
+# R: stopifnot for internal invariants
 process_chunk <- function(chunk, total_size) {
   stopifnot(
     is.list(chunk),
@@ -207,7 +207,7 @@ process_chunk <- function(chunk, total_size) {
   # ...
 }
 
-# R：带上下文的显式断言
+# R: explicit assertion with context
 merge_results <- function(left, right) {
   if (ncol(left) != ncol(right)) {
     stop("Internal error: column count mismatch (", ncol(left), " vs ", ncol(right),
@@ -228,13 +228,13 @@ merge_results <- function(left, right) {
 **反模式 1：空的 tryCatch（吞噬错误）**
 
 ```r
-# 之前：错误静默消失
+# BEFORE: Error silently disappears
 result <- tryCatch(
   parse_data(input),
   error = function(e) NULL
 )
 
-# 之后：记录日志、重新抛出或返回类型化错误
+# AFTER: Log, re-throw, or return a typed error
 result <- tryCatch(
   parse_data(input),
   error = function(e) {
@@ -246,13 +246,13 @@ result <- tryCatch(
 **反模式 2：用默认值掩盖错误输入**
 
 ```r
-# 之前：调用者永远不知道其输入被忽略了
+# BEFORE: Caller never knows their input was ignored
 process <- function(x = 10) {
-  if (!is.numeric(x)) x <- 10  # 静默替换错误输入
+  if (!is.numeric(x)) x <- 10  # silently replaces bad input
   x * 2
 }
 
-# 之后：告知调用者问题所在
+# AFTER: Tell the caller about the problem
 process <- function(x = 10) {
   if (!is.numeric(x)) {
     stop("'x' must be numeric, got ", class(x)[[1]], call. = FALSE)
@@ -264,10 +264,10 @@ process <- function(x = 10) {
 **反模式 3：将 suppressWarnings 当作修复方法**
 
 ```r
-# 之前：掩盖症状而不是修复原因
+# BEFORE: Hiding the symptom instead of fixing the cause
 result <- suppressWarnings(as.numeric(user_input))
 
-# 之后：显式验证，处理预期情况
+# AFTER: Validate explicitly, handle the expected case
 if (!grepl("^-?\\d+\\.?\\d*$", user_input)) {
   stop("Expected a number, got: '", user_input, "'", call. = FALSE)
 }
@@ -277,20 +277,20 @@ result <- as.numeric(user_input)
 **反模式 4：通用异常处理器**
 
 ```r
-# 之前：所有错误都一样处理
+# BEFORE: Every error treated the same
 tryCatch(
   complex_operation(),
   error = function(e) message("Something went wrong")
 )
 
-# 之后：处理特定条件，让意外的传播
+# AFTER: Handle specific conditions, let unexpected ones propagate
 tryCatch(
   complex_operation(),
   custom_validation_error = function(e) {
     cli::cli_warn("Validation issue: {e$message}")
     fallback_value
   }
-  # 意外错误自然传播
+  # Unexpected errors propagate naturally
 )
 ```
 
@@ -303,12 +303,12 @@ tryCatch(
 运行测试套件以确认错误路径正常工作：
 
 ```r
-# 验证错误消息被触发
+# Verify error messages are triggered
 testthat::expect_error(calculate_summary("not_a_df"), "must be a data frame")
 testthat::expect_error(calculate_summary(data.frame()), "at least one row")
 testthat::expect_error(calculate_summary(mtcars, trim_pct = 2), "between 0 and 0.5")
 
-# 验证有效输入仍然正常工作
+# Verify valid inputs still work
 testthat::expect_no_error(calculate_summary(mtcars, method = "mean"))
 ```
 

--- a/i18n/zh-CN/skills/manage-renv-dependencies/SKILL.md
+++ b/i18n/zh-CN/skills/manage-renv-dependencies/SKILL.md
@@ -88,13 +88,13 @@ renv::restore()
 ### 第 4 步：更新依赖
 
 ```r
-# 更新特定包
+# Update a specific package
 renv::update("dplyr")
 
-# 更新所有包
+# Update all packages
 renv::update()
 
-# 更新后创建快照
+# Snapshot after updates
 renv::snapshot()
 ```
 

--- a/i18n/zh-CN/skills/release-package-version/SKILL.md
+++ b/i18n/zh-CN/skills/release-package-version/SKILL.md
@@ -56,7 +56,7 @@ metadata:
 ### 第 2 步：更新版本
 
 ```r
-usethis::use_version("minor")  # 或 "patch" 或 "major"
+usethis::use_version("minor")  # or "patch" or "major"
 ```
 
 此命令更新 DESCRIPTION 中的 `Version` 字段并在 NEWS.md 中添加标题。

--- a/i18n/zh-CN/skills/security-audit-codebase/SKILL.md
+++ b/i18n/zh-CN/skills/security-audit-codebase/SKILL.md
@@ -101,8 +101,8 @@ safety check
 **R**：
 
 ```r
-# 检查包的已知漏洞
-# 无内置工具，但可验证包来源
+# Check for known vulnerabilities in packages
+# No built-in tool, but verify package sources
 renv::status()
 ```
 

--- a/i18n/zh-CN/skills/submit-to-cran/SKILL.md
+++ b/i18n/zh-CN/skills/submit-to-cran/SKILL.md
@@ -142,10 +142,10 @@ There are currently no downstream dependencies for this package.
 ### 第 8 步：最终预检
 
 ```r
-# 最后一次检查
+# One last check
 devtools::check()
 
-# 验证构建的 tarball
+# Verify the built tarball
 devtools::build()
 ```
 
@@ -172,10 +172,10 @@ devtools::release()
 获得接受后：
 
 ```r
-# 打标签创建发布版本
+# Tag the release
 usethis::use_github_release()
 
-# 切换至开发版本
+# Bump to development version
 usethis::use_dev_version()
 ```
 
@@ -207,13 +207,13 @@ usethis::use_dev_version()
 ## 示例
 
 ```r
-# 完整的提交前工作流
+# Full pre-submission workflow
 devtools::spell_check()
 urlchecker::url_check()
 devtools::check()
 devtools::check_win_devel()
 rhub::rhub_check()
-# 等待结果...
+# Wait for results...
 devtools::release()
 ```
 

--- a/i18n/zh-CN/skills/validate-piles-notation/SKILL.md
+++ b/i18n/zh-CN/skills/validate-piles-notation/SKILL.md
@@ -45,7 +45,7 @@ metadata:
 ```r
 library(jigsawR)
 result <- validate_piles_syntax("1-2-3,4-5")
-# 有效返回 TRUE，无效返回错误消息
+# Returns TRUE if valid, error message if invalid
 ```
 
 检查常见语法错误：
@@ -61,13 +61,13 @@ result <- validate_piles_syntax("1-2-3,4-5")
 
 ```r
 groups <- parse_piles("1-2-3,4-5")
-# 返回：list(c(1, 2, 3), c(4, 5))
+# Returns: list(c(1, 2, 3), c(4, 5))
 ```
 
 对于包含范围的字符串：
 ```r
 groups <- parse_piles("1:6,7-8")
-# 返回：list(c(1, 2, 3, 4, 5, 6), c(7, 8))
+# Returns: list(c(1, 2, 3, 4, 5, 6), c(7, 8))
 ```
 
 **预期结果：** 整数向量列表，每个融合组一个，碎片 ID 和组边界正确。
@@ -91,10 +91,10 @@ groups <- parse_piles("1:6,7-8")
 如果有拼图结果对象可用，验证：
 
 ```r
-# 首先生成拼图
+# Generate the puzzle first
 puzzle <- generate_puzzle(type = "hexagonal", grid = c(3), size = c(200))
 
-# 使用拼图上下文解析（解析关键字）
+# Parse with puzzle context (resolves keywords)
 groups <- parse_fusion("center,ring1", puzzle)
 ```
 
@@ -115,10 +115,10 @@ groups <- parse_fusion("center,ring1", puzzle)
 original <- "1-2-3,4-5"
 groups <- parse_piles(original)
 roundtrip <- to_piles(groups)
-# roundtrip 应等于 original（或规范等价形式）
+# roundtrip should equal original (or canonical equivalent)
 
 groups2 <- parse_piles(roundtrip)
-identical(groups, groups2)  # 必须为 TRUE
+identical(groups, groups2)  # Must be TRUE
 ```
 
 **预期结果：** 往返产生相同的组列表，确认 `parse_piles()` 和 `to_piles()` 互为逆操作。

--- a/i18n/zh-CN/skills/write-testthat-tests/SKILL.md
+++ b/i18n/zh-CN/skills/write-testthat-tests/SKILL.md
@@ -94,19 +94,19 @@ test_that("weighted_mean validates input", {
 
 ```r
 test_that("weighted_mean handles edge cases", {
-  # 空输入
+  # Empty input
   expect_error(weighted_mean(numeric(0), numeric(0)))
 
-  # 单一值
+  # Single value
   expect_equal(weighted_mean(5, 1), 5)
 
-  # 零权重
+  # Zero weights
   expect_true(is.nan(weighted_mean(1:3, c(0, 0, 0))))
 
-  # 极大值
+  # Very large values
   expect_equal(weighted_mean(c(1e15, 1e15), c(1, 1)), 1e15)
 
-  # 负权重
+  # Negative weights
   expect_error(weighted_mean(1:3, c(-1, 1, 1)))
 })
 ```
@@ -120,7 +120,7 @@ test_that("weighted_mean handles edge cases", {
 创建 `tests/testthat/fixtures/` 存放测试数据：
 
 ```r
-# tests/testthat/helper.R（自动加载）
+# tests/testthat/helper.R (loaded automatically)
 create_test_data <- function() {
   data.frame(
     x = c(1, 2, 3, NA, 5),
@@ -130,7 +130,7 @@ create_test_data <- function() {
 ```
 
 ```r
-# 在测试文件中
+# In test file
 test_that("process_data works with grouped data", {
   test_data <- create_test_data()
   result <- process_data(test_data)
@@ -212,14 +212,14 @@ test_that("parallel computation works", {
 ### 第 9 步：运行测试并检查覆盖率
 
 ```r
-# 运行所有测试
+# Run all tests
 devtools::test()
 
-# 运行特定测试文件
-devtools::test_active_file()  # 在 RStudio 中
+# Run specific test file
+devtools::test_active_file()  # in RStudio
 testthat::test_file("tests/testthat/test-function_name.R")
 
-# 检查覆盖率
+# Check coverage
 covr::package_coverage()
 covr::report()
 ```
@@ -249,16 +249,16 @@ covr::report()
 ## 示例
 
 ```r
-# 模式：测试文件与 R/ 文件对应
+# Pattern: test file mirrors R/ file
 # R/weighted_mean.R -> tests/testthat/test-weighted_mean.R
 
-# 模式：描述性测试名称
+# Pattern: descriptive test names
 test_that("weighted_mean returns NA when na.rm = FALSE and input contains NA", {
   result <- weighted_mean(c(1, NA), c(1, 1), na.rm = FALSE)
   expect_true(is.na(result))
 })
 
-# 模式：测试警告
+# Pattern: testing warnings
 test_that("deprecated_function emits deprecation warning", {
   expect_warning(deprecated_function(), "deprecated")
 })

--- a/i18n/zh-CN/skills/write-vignette/SKILL.md
+++ b/i18n/zh-CN/skills/write-vignette/SKILL.md
@@ -149,10 +149,10 @@ optionalpkg::special_function()
 对于耗时计算，预计算并保存结果：
 
 ```r
-# 将预计算结果保存至 vignettes/
+# Save pre-computed results to vignettes/
 saveRDS(expensive_result, "vignettes/precomputed.rds")
 
-# 在 vignette 中加载
+# Load in vignette
 {r load-precomputed}
 result <- readRDS("precomputed.rds")
 ```
@@ -164,10 +164,10 @@ result <- readRDS("precomputed.rds")
 ### 第 5 步：构建并测试 Vignette
 
 ```r
-# 构建单个 vignette
+# Build single vignette
 devtools::build_vignettes()
 
-# 构建并检查（可捕获 vignette 问题）
+# Build and check (catches vignette issues)
 devtools::check()
 ```
 


### PR DESCRIPTION
Third tag-scoped batch of the #477 fence-parity backlog, after `yaml`+`json` (#495)
and `bash` (#496). Restores **218 frozen `r` fences across 65 translated SKILL.md
files** to the body appearing in the paired English source at each file's
`source_commit`.

Produced by `npm run normalize:i18n-fences -- --tag r --write`, then reverting the
two carve-outs below. No hand edits.

## Measured, not remembered

`node scripts/check-i18n-fence-parity.js --json`, before and after, on this branch:

| tag | before | after | delta |
|---|---:|---:|---:|
| r | 320 | 102 | **−218** |
| every other tag | 366 | 366 | 0 |
| **total findings** | **686** | **468** | **−218** |

`fencesCompared` holds at 22,998 and `filesCompared` at 3,644 across both runs — no
fence was created or destroyed, only bodies replaced.

The 102 remaining `r` findings partition exactly:

| | findings | files |
|---|---:|---:|
| `skills/`, ordinal mapping unsound — normalizer skips | 62 | 14 |
| `agents`/`teams`/`guides` mirrors — normalizer does not cover | 16 | — |
| carved out as regulated | 16 | 5 |
| `de/design-shiny-ui`, excluded as a content fork | 8 | 1 |
| **total** | **102** | |

## The finding: a content fork that passed the soundness guard

Filed as **#498**. `i18n/de/skills/design-shiny-ui/SKILL.md` is excluded from this
batch because the normalizer's ordinal-mapping guard passed on it *wrongly*.

Both files carry 8 `r` fences with an identical tag sequence, so the fence-count and
tag-sequence precondition held. The steps do not correspond:

| # | English | German |
|---|---|---|
| 5 | Add Custom CSS/SCSS (Optional) | **Zugänglichkeit sicherstellen** |
| 6 | Ensure Accessibility | **Theme über Apps hinweg wiederverwenden** |

German Schritt 5 is English Step 6. Ordinal mapping therefore gave every fence the
body of a different step — Schritt 1 ("bslib installieren") received English Step 1's
page-layout variants, and the accessibility step received CSS plumbing while its
untouched prose still promised ARIA labels and keyboard navigation.

`check-i18n-fence-parity.js --locale de --id design-shiny-ui` reports
`OK: every gated code fence matches an English source revision` on that corrupted
state. That is correct per the rule as written: it asks whether a body matches *some*
English fence, never the *corresponding* one. Neither existing gate can see this
class.

**Nothing broken shipped.** Both merged batches were re-checked with a
code-token-containment measure:

| batch | files | suspects |
|---|---:|---|
| #495 `yaml`+`json` | 76 | 1, **false positive** |
| #496 `bash` | 153 | 0 |
| this batch | 66 | 1, real — excluded |

The batch-1 hit (`de/prepare-print-model`, 0.30) is faithful: all 8 steps correspond
one-for-one, every config key unchanged, only German parenthetical annotations
reverted to English. It scores low because the code-token regex is tuned for R
identifiers and finds little to measure in a YAML-ish config block. Recorded in #498
as a constraint on any implementation.

## Carve-out: regulated content

Keyed on `domain: compliance`, the same rule as #496 — and the regulated set is
**larger than the roster carried forward from that PR**:

| file | r fences |
|---|---:|
| `zh-CN/implement-audit-trail` | 5 |
| `zh-CN/validate-statistical-output` | 6 |
| `zh-CN/setup-gxp-r-project` | 2 |
| `wenyan-ultra/setup-gxp-r-project` | 2 |
| `zh-CN/write-validation-documentation` | 1 |

`validate-statistical-output` and `write-validation-documentation` were in no
hand-written list. Deriving the carve-out from what the corpus declares, rather than
from a remembered set, is what found them.

This batch is where the line #477 flags actually lives: `zh-CN/implement-audit-trail`
logs `ifelse(match, "通过", "失败")` where English logs `"PASS"`/`"FAIL"` — the
recorded value of a 21 CFR Part 11 audit record. Untouched here, parked for a
dedicated PR with a named reviewer covering all 22 findings across those five files
in one review.

Verification was of the invariant rather than the action: every changed file's skill
domain was scanned for a compliance leak, not just the five reverted. Clean.

## #476 needs no hand-reverts

`write-vignette` is the only affected skill in the plan, across 4 locales. Its runaway
`text` fence opens at the line meant to close the vignette template (English L96, 31
body lines; L103–134 in `de`), and both divergent `r` fences sit past it at L155 and
L170. Verified per locale with `extractFences`, not by filename.

## Review

Five locale-sharded agents read the real diff, every finding put to an adversarial
refuter told to default to refuted. **28 raw findings, 4 survived — all four in
`de/design-shiny-ui`**, and all four are resolved by excluding it. Refuted: 14
`instruction-lost`, 3 `semantic-value-change`, 2 each `wrong-restoration` /
`prose-contradicts-fence` / `other`, 1 `artifact-removed`.

The reviewers carried an `r`-specific category the `bash` batch did not need —
**semantic-value-change** — because R code is data-bearing: a translated factor level,
`labels=` vector or `write.csv` value reverting to English changes what a downstream
join or report matches on. All three such claims were refuted on inspection.

Mechanical checks, both at 0 on the final tree:

- **placeholder drift** (the substitution-pair check that caught #496's defect) — 0.
  Proven able to fire first by replaying #496's known defect through it
  (`9f187397~1 → 9f187397`), which yields 3 findings including both `paketname` sites.
  A zero from an unvalidated filter is what let that defect through last time.
- **fence realignment** (#498's measure) — 0 suspects after the exclusion.

The fan-out ran under `guard:snapshot` / `guard:verify`; the repo was `unchanged at
b74cc3ed` when the agents finished.

## Gates

- `npm run test:scripts` — 58/58
- `npm run validate:line-endings` — clean
- `node scripts/check-content-style.js --added` — 0 blocking errors
- no translated SKILL.md over the 500-line limit
- translation staleness unchanged (neither English sources nor `source_commit` touched)

Advances #477 toward dropping `--warn`. Files #498.
