### PR TITLE
fix(i18n): restore python code fences to their English source (#477 batch 4)

### DIFF
--- a/i18n/caveman-ultra/skills/instrument-distributed-tracing/SKILL.md
+++ b/i18n/caveman-ultra/skills/instrument-distributed-tracing/SKILL.md
@@ -152,7 +152,7 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Go w/ Gin**:
@@ -215,7 +215,7 @@ tracer = trace.get_tracer(__name__)
 
 def process_order(order_id):
     # Create a span for the entire operation
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Go manual spans**:
@@ -259,7 +259,7 @@ from opentelemetry import trace
 from opentelemetry.propagate import inject
 
 tracer = trace.get_tracer(__name__)
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 ```go
@@ -281,7 +281,7 @@ from kafka import KafkaProducer
 
 producer = KafkaProducer(bootstrap_servers=['kafka:9092'])
 
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 ```python
@@ -338,7 +338,7 @@ from opentelemetry.sdk.trace.sampling import (
     TraceIdRatioBased,
     StaticSampler,
     Decision
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Tail-based sampling w/ Tempo**:
@@ -396,7 +396,7 @@ from opentelemetry import trace
 # Custom log formatter with trace context
 class TraceFormatter(logging.Formatter):
     def format(self, record):
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Gen metrics from traces** (Tempo):

--- a/i18n/caveman-ultra/skills/label-training-data/SKILL.md
+++ b/i18n/caveman-ultra/skills/label-training-data/SKILL.md
@@ -111,7 +111,7 @@ Label Studio configuration templates for common tasks.
 # Text Classification (single label)
 TEXT_CLASSIFICATION = """
 <View>
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete implementation)
 ```
 
 → Interface configured w/ appropriate controls for task type, data imported, interface accessible to annotators.
@@ -131,7 +131,7 @@ from typing import List, Dict
 from sklearn.cluster import KMeans
 import numpy as np
 
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete implementation)
 ```
 
 → Data formatted for Label Studio import, sampling prioritizes informative examples, tasks include metadata for tracking.
@@ -151,7 +151,7 @@ from typing import Dict, List, Tuple
 import logging
 
 logging.basicConfig(level=logging.INFO)
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete implementation)
 ```
 
 → IAA measured (Cohen's Kappa > 0.6 = moderate, >0.8 = good), difficult tasks ID'd for review, annotator perf tracked.
@@ -171,7 +171,7 @@ from typing import List, Dict
 import logging
 
 logger = logging.getLogger(__name__)
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete implementation)
 ```
 
 → Annotations exported training-ready format, label distribution balanced / documented, data quality validated before training.
@@ -191,7 +191,7 @@ from datetime import datetime
 from prepare_data import DataSampler, prepare_label_studio_format
 from export_labels import LabelStudioExporter, convert_to_training_format
 import pandas as pd
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete implementation)
 ```
 
 → Active learning selects informative examples auto, batches prep weekly, model retrained when sufficient new labels avail.

--- a/i18n/de/skills/render-blender-output/SKILL.md
+++ b/i18n/de/skills/render-blender-output/SKILL.md
@@ -60,23 +60,23 @@ Render-Engine und Grundparameter festlegen:
 import bpy
 
 def setup_cycles_engine():
-    """Cycles-Render-Engine konfigurieren."""
+    """Configure Cycles render engine."""
     scene = bpy.context.scene
     scene.render.engine = 'CYCLES'
 
-    # Geraeteeinstellungen
-    scene.cycles.device = 'GPU'  # oder 'CPU'
+    # Device settings
+    scene.cycles.device = 'GPU'  # or 'CPU'
 
     # Sampling
-    scene.cycles.samples = 128
+    scene.cycles.samples = 128  # Viewport: fewer samples
     scene.cycles.use_adaptive_sampling = True
     scene.cycles.adaptive_threshold = 0.01
 
-    # Entrauschen
+    # Denoising
     scene.cycles.use_denoising = True
-    scene.cycles.denoiser = 'OPTIX'  # oder 'OPENIMAGEDENOISE', 'NLM'
+    scene.cycles.denoiser = 'OPTIX'  # or 'OPENIMAGEDENOISE', 'NLM'
 
-    # Lichtpfade
+    # Light paths
     scene.cycles.max_bounces = 12
     scene.cycles.diffuse_bounces = 4
     scene.cycles.glossy_bounces = 4
@@ -84,25 +84,25 @@ def setup_cycles_engine():
     scene.cycles.volume_bounces = 0
 
 def setup_eevee_engine():
-    """EEVEE-Render-Engine konfigurieren."""
+    """Configure EEVEE render engine."""
     scene = bpy.context.scene
     scene.render.engine = 'BLENDER_EEVEE'
 
     # Sampling
     scene.eevee.taa_render_samples = 64
 
-    # Effekte
+    # Effects
     scene.eevee.use_bloom = True
     scene.eevee.bloom_threshold = 0.8
     scene.eevee.bloom_intensity = 0.1
 
-    scene.eevee.use_gtao = True  # Umgebungsverdeckung
+    scene.eevee.use_gtao = True  # Ambient occlusion
     scene.eevee.gtao_distance = 0.2
 
-    scene.eevee.use_ssr = True  # Bildschirmraum-Reflexionen
+    scene.eevee.use_ssr = True  # Screen space reflections
     scene.eevee.ssr_quality = 0.5
 
-    # Schatten
+    # Shadows
     scene.eevee.shadow_cube_size = '1024'
     scene.eevee.shadow_cascade_size = '1024'
 ```
@@ -116,30 +116,30 @@ Ausgabedimensionen und Dateiformat konfigurieren:
 
 ```python
 def configure_output(width=1920, height=1080, file_format='PNG', color_depth='16'):
-    """Ausgabeaufloesung und -format festlegen."""
+    """Set output resolution and format."""
     scene = bpy.context.scene
 
-    # Aufloesung
+    # Resolution
     scene.render.resolution_x = width
     scene.render.resolution_y = height
     scene.render.resolution_percentage = 100
 
-    # Seitenverhaeltnis
+    # Aspect ratio
     scene.render.pixel_aspect_x = 1.0
     scene.render.pixel_aspect_y = 1.0
 
-    # Dateiformat
+    # File format
     scene.render.image_settings.file_format = file_format
 
     if file_format == 'PNG':
         scene.render.image_settings.color_mode = 'RGBA'
-        scene.render.image_settings.color_depth = color_depth  # '8' oder '16'
+        scene.render.image_settings.color_depth = color_depth  # '8' or '16'
         scene.render.image_settings.compression = 15  # 0-100
 
     elif file_format == 'OPEN_EXR':
         scene.render.image_settings.color_mode = 'RGBA'
-        scene.render.image_settings.color_depth = '32'  # oder '16'
-        scene.render.image_settings.exr_codec = 'ZIP'  # oder 'DWAA', 'PIZ'
+        scene.render.image_settings.color_depth = '32'  # or '16'
+        scene.render.image_settings.exr_codec = 'ZIP'  # or 'DWAA', 'PIZ'
 
     elif file_format == 'JPEG':
         scene.render.image_settings.color_mode = 'RGB'
@@ -150,7 +150,7 @@ def configure_output(width=1920, height=1080, file_format='PNG', color_depth='16
         scene.render.image_settings.color_depth = color_depth
         scene.render.image_settings.tiff_codec = 'DEFLATE'
 
-    # Bildbereich (fuer Animationen)
+    # Frame range (for animations)
     scene.frame_start = 1
     scene.frame_end = 250
     scene.frame_step = 1
@@ -165,7 +165,7 @@ Compositing-Knotengraph einrichten:
 
 ```python
 def setup_compositing():
-    """Compositing-Knoten-Setup erstellen."""
+    """Create compositing node setup."""
     scene = bpy.context.scene
     scene.use_nodes = True
 
@@ -173,20 +173,24 @@ def setup_compositing():
     nodes = tree.nodes
     links = tree.links
 
-    # Standardknoten loeschen
+    # Clear default nodes
     nodes.clear()
 
-    # Render-Ebenen-Eingabe
+    # Render Layers input
     render_layers = nodes.new(type='CompositorNodeRLayers')
     render_layers.location = (-400, 300)
 
-    # Farbkorrektur
+    # Denoise (if not using Cycles denoiser)
+    # denoise = nodes.new(type='CompositorNodeDenoise')
+    # denoise.location = (-200, 300)
+
+    # Color correction
     color_correct = nodes.new(type='CompositorNodeColorCorrection')
     color_correct.location = (0, 300)
     color_correct.master_saturation = 1.1
     color_correct.master_gain = 1.05
 
-    # Glanz-Effekt
+    # Glare effect
     glare = nodes.new(type='CompositorNodeGlare')
     glare.location = (200, 200)
     glare.glare_type = 'FOG_GLOW'
@@ -199,21 +203,21 @@ def setup_compositing():
     lens_distortion.inputs['Dispersion'].default_value = 0.0
     lens_distortion.inputs['Distortion'].default_value = -0.02
 
-    # Mischknoten
+    # Mix nodes
     mix1 = nodes.new(type='CompositorNodeMixRGB')
     mix1.location = (400, 250)
     mix1.blend_type = 'ADD'
     mix1.inputs['Fac'].default_value = 0.3
 
-    # Composite-Ausgabe
+    # Composite output
     composite = nodes.new(type='CompositorNodeComposite')
     composite.location = (600, 300)
 
-    # Betrachter-Ausgabe (fuer Vorschau)
+    # Viewer output (for preview)
     viewer = nodes.new(type='CompositorNodeViewer')
     viewer.location = (600, 100)
 
-    # Knoten verbinden
+    # Link nodes
     links.new(render_layers.outputs['Image'], color_correct.inputs['Image'])
     links.new(color_correct.outputs['Image'], mix1.inputs[1])
     links.new(color_correct.outputs['Image'], glare.inputs['Image'])
@@ -234,21 +238,25 @@ import os
 from pathlib import Path
 
 def set_output_path(base_dir, project_name, use_frame_number=True):
-    """Ausgabedateipfad konfigurieren."""
+    """Configure output file path."""
     scene = bpy.context.scene
 
-    # Ausgabeverzeichnis erstellen
+    # Create output directory
     output_dir = Path(base_dir) / project_name / "renders"
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Dateipfad festlegen
+    # Set filepath
     if use_frame_number:
-        # #### wird durch Bildnummer ersetzt (0001, 0002, usw.)
+        # #### is replaced with frame number (0001, 0002, etc.)
         filename = f"{project_name}_####"
     else:
         filename = project_name
 
     scene.render.filepath = str(output_dir / filename)
+
+    # Optional: Set file extension explicitly
+    # Extension added automatically based on file_format
+    # But can override: scene.render.file_extension = '.png'
 ```
 
 **Erwartet:** Ausgabeverzeichnis erstellt, Dateipfad mit Bildnummerierung konfiguriert
@@ -260,19 +268,19 @@ Render-Paesse fuer Compositing einrichten:
 
 ```python
 def configure_view_layers():
-    """Render-Paesse aktivieren."""
+    """Enable render passes."""
     scene = bpy.context.scene
     view_layer = scene.view_layers['ViewLayer']
 
-    # Paesse aktivieren
+    # Enable passes
     view_layer.use_pass_combined = True
-    view_layer.use_pass_z = True  # Tiefe
+    view_layer.use_pass_z = True  # Depth
     view_layer.use_pass_mist = False
     view_layer.use_pass_normal = True
-    view_layer.use_pass_vector = True  # Bewegungsvektoren
+    view_layer.use_pass_vector = True  # Motion vectors
     view_layer.use_pass_ambient_occlusion = True
 
-    # Cycles-spezifische Paesse
+    # Cycles-specific passes
     cycles = view_layer.cycles
     cycles.use_pass_diffuse_direct = True
     cycles.use_pass_diffuse_indirect = True
@@ -281,7 +289,7 @@ def configure_view_layers():
     cycles.use_pass_emission = True
     cycles.use_pass_environment = True
 
-    # Cryptomatte-Paesse (fuer Postproduktion)
+    # Cryptomatte passes (for post-production)
     cycles.use_pass_crypto_object = True
     cycles.use_pass_crypto_material = True
     cycles.use_pass_crypto_asset = True
@@ -296,33 +304,33 @@ Ueber Python-API oder Kommandozeile rendern:
 
 ```python
 def render_still():
-    """Aktuelles Bild rendern."""
+    """Render current frame."""
     bpy.ops.render.render(write_still=True)
 
 def render_animation():
-    """Animations-Bildbereich rendern."""
+    """Render animation frame range."""
     bpy.ops.render.render(animation=True)
 
 def render_frame(frame_number):
-    """Bestimmtes Bild rendern."""
+    """Render specific frame."""
     scene = bpy.context.scene
     scene.frame_set(frame_number)
     bpy.ops.render.render(write_still=True)
 
-# Kommandozeilen-Rendering (vom Terminal ausfuehren)
-# Einzelbild:
+# Command-line rendering (run from terminal)
+# Single frame:
 # blender scene.blend --background --render-frame 1
 
 # Animation:
 # blender scene.blend --background --render-anim
 
-# Bestimmter Bildbereich:
+# Specific frame range:
 # blender scene.blend --background --frame-start 10 --frame-end 20 --render-anim
 
-# Ausgabepfad ueberschreiben:
+# Override output path:
 # blender scene.blend --background --render-output /tmp/render_#### --render-anim
 
-# Python-Skript verwenden:
+# Use Python script:
 # blender scene.blend --background --python render_script.py
 ```
 
@@ -335,25 +343,25 @@ Aus mehreren Kamerawinkeln rendern:
 
 ```python
 def render_all_cameras(output_dir):
-    """Szene aus allen Kameras rendern."""
+    """Render scene from all cameras."""
     scene = bpy.context.scene
     original_camera = scene.camera
 
     cameras = [obj for obj in bpy.data.objects if obj.type == 'CAMERA']
 
     for camera in cameras:
-        # Aktive Kamera setzen
+        # Set active camera
         scene.camera = camera
 
-        # Ausgabepfad aktualisieren
+        # Update output path
         camera_name = camera.name.replace(' ', '_')
         scene.render.filepath = os.path.join(output_dir, f"{camera_name}_####")
 
-        # Rendern
+        # Render
         bpy.ops.render.render(write_still=True)
-        print(f"Gerendert von Kamera: {camera.name}")
+        print(f"Rendered from camera: {camera.name}")
 
-    # Urspruengliche Kamera wiederherstellen
+    # Restore original camera
     scene.camera = original_camera
 ```
 
@@ -366,11 +374,11 @@ Leistungseinstellungen konfigurieren:
 
 ```python
 def optimize_performance():
-    """Rendereinstellungen fuer Geschwindigkeit optimieren."""
+    """Optimize render settings for speed."""
     scene = bpy.context.scene
 
     if scene.render.engine == 'CYCLES':
-        # Kachelgroesse (GPU: groessere Kacheln, CPU: kleinere Kacheln)
+        # Tile size (GPU: larger tiles, CPU: smaller tiles)
         if scene.cycles.device == 'GPU':
             scene.render.tile_x = 256
             scene.render.tile_y = 256
@@ -378,24 +386,24 @@ def optimize_performance():
             scene.render.tile_x = 32
             scene.render.tile_y = 32
 
-        # Leistungseinstellungen
+        # Performance settings
         scene.cycles.use_adaptive_sampling = True
-        scene.render.use_persistent_data = True  # Szene im Speicher halten
+        scene.render.use_persistent_data = True  # Keep scene in memory
 
-        # Lichtpfad-Komplexitaet fuer Vorschau reduzieren
+        # Reduce light path complexity for preview
         scene.cycles.max_bounces = 4
         scene.cycles.diffuse_bounces = 2
         scene.cycles.glossy_bounces = 2
 
-        # Progressives Verfeinern (fuer Viewport)
+        # Progressive refine (for viewport)
         scene.cycles.use_progressive_refine = True
 
     elif scene.render.engine == 'BLENDER_EEVEE':
-        # Vereinfachungseinstellungen fuer Vorschau
+        # Simplify settings for preview
         scene.render.use_simplify = True
         scene.render.simplify_subdivision = 2
 
-        # Sampling reduzieren
+        # Reduce sampling
         scene.eevee.taa_render_samples = 32
 ```
 

--- a/i18n/de/skills/render-publication-graphic/SKILL.md
+++ b/i18n/de/skills/render-publication-graphic/SKILL.md
@@ -101,27 +101,29 @@ Aufloesung basierend auf Ausgabemedium konfigurieren:
 from PIL import Image
 
 def set_dpi_pillow(image_path, output_path, target_dpi=300):
-    """DPI-Metadaten fuer PNG/TIFF setzen."""
+    """Set DPI metadata for PNG/TIFF."""
     img = Image.open(image_path)
+
+    # Save with DPI metadata
     img.save(output_path, dpi=(target_dpi, target_dpi))
-    print(f"Gespeichert mit {target_dpi} DPI: {output_path}")
+    print(f"Saved with {target_dpi} DPI: {output_path}")
 
 def calculate_dimensions(width_mm, height_mm, dpi=300):
-    """Pixelabmessungen aus physischer Groesse berechnen."""
-    # mm in Zoll umrechnen
+    """Calculate pixel dimensions from physical size."""
+    # Convert mm to inches
     width_inches = width_mm / 25.4
     height_inches = height_mm / 25.4
 
-    # Pixel berechnen
+    # Calculate pixels
     width_px = int(width_inches * dpi)
     height_px = int(height_inches * dpi)
 
     return width_px, height_px
 
-# Beispiel: 180mm breite Abbildung bei 300 DPI
+# Example: 180mm wide figure at 300 DPI
 width, height = calculate_dimensions(180, 120, dpi=300)
-print(f"Erforderliche Aufloesung: {width}x{height} Pixel")
-# Ausgabe: Erforderliche Aufloesung: 2126x1417 Pixel
+print(f"Required resolution: {width}x{height} pixels")
+# Output: Required resolution: 2126x1417 pixels
 ```
 
 ```r
@@ -165,22 +167,32 @@ Geeignetes Farbprofil festlegen:
 from PIL import Image, ImageCms
 
 def convert_to_cmyk(rgb_image_path, cmyk_output_path):
-    """RGB zu CMYK fuer Druck konvertieren."""
+    """Convert RGB to CMYK for print."""
     img = Image.open(rgb_image_path)
+
     if img.mode != 'RGB':
         img = img.convert('RGB')
+
+    # Convert to CMYK
     cmyk_img = img.convert('CMYK')
     cmyk_img.save(cmyk_output_path, format='TIFF', compression='tiff_lzw')
-    print(f"Zu CMYK konvertiert: {cmyk_output_path}")
+    print(f"Converted to CMYK: {cmyk_output_path}")
 
 def apply_srgb_profile(image_path, output_path):
-    """sRGB-Profil fuer Web anwenden."""
+    """Apply sRGB profile for web."""
     img = Image.open(image_path)
+
+    # sRGB profile (embedded in Pillow)
     srgb_profile = ImageCms.createProfile('sRGB')
+
+    # Convert to sRGB
     img_srgb = ImageCms.profileToProfile(
-        img, srgb_profile, srgb_profile,
+        img,
+        srgb_profile,
+        srgb_profile,
         renderingIntent=ImageCms.Intent.PERCEPTUAL
     )
+
     img_srgb.save(output_path)
 ```
 
@@ -204,34 +216,45 @@ Sicherstellen dass Text lesbar und korrekt formatiert ist:
 from PIL import ImageFont
 
 def get_publication_fonts():
-    """Fuer Publikation geeignete Schriften laden."""
+    """Load fonts appropriate for publication."""
+    # Common publication-safe fonts
     fonts = {
         'serif': 'Times New Roman',
         'sans': 'Arial',
         'mono': 'Courier New'
     }
+
     try:
-        # Mit korrekter Groesse fuer DPI laden
-        # Bei 300 DPI: 12pt = 12 * 300/72 = 50 Pixel
+        # Load with proper size for DPI
+        # At 300 DPI, 12pt = 12 * 300/72 = 50 pixels
         base_size_300dpi = 50
+
         font_regular = ImageFont.truetype(f"{fonts['sans']}.ttf", base_size_300dpi)
         font_bold = ImageFont.truetype(f"{fonts['sans']} Bold.ttf", base_size_300dpi)
+
         return {'regular': font_regular, 'bold': font_bold}
     except:
         return {'regular': ImageFont.load_default(), 'bold': ImageFont.load_default()}
 
-# Typografie-Richtlinien
+# Typography guidelines
 typography_specs = {
-    'minimum_font_size': '8pt',  # Lesbar beim Drucken
-    'line_width_min': 0.5,  # Punkte, fuer Druckklarheit
+    'minimum_font_size': '8pt',  # Readable when printed
+    'line_width_min': 0.5,  # Points, for print clarity
     'panel_labels': {
         'font': 'Arial Bold',
         'size': '12pt',
-        'position': 'oben-links',
-        'style': 'A, B, C'  # Oder (a), (b), (c)
+        'position': 'top-left',
+        'style': 'A, B, C'  # Or (a), (b), (c)
     },
-    'axis_labels': {'font': 'Arial', 'size': '10pt'},
-    'legend': {'font': 'Arial', 'size': '9pt', 'position': 'ausserhalb Plotbereich'}
+    'axis_labels': {
+        'font': 'Arial',
+        'size': '10pt'
+    },
+    'legend': {
+        'font': 'Arial',
+        'size': '9pt',
+        'position': 'outside plot area'
+    }
 }
 ```
 
@@ -267,7 +290,7 @@ Format basierend auf Anwendungsfall waehlen:
 
 ```python
 def export_multi_format(source_path, output_base, formats=['png', 'pdf', 'tiff']):
-    """Grafik in mehreren Formaten exportieren."""
+    """Export graphic in multiple formats."""
     from PIL import Image
     import cairosvg
     import os
@@ -275,31 +298,72 @@ def export_multi_format(source_path, output_base, formats=['png', 'pdf', 'tiff']
     base, ext = os.path.splitext(output_base)
 
     if ext.lower() in ['.svg']:
+        # SVG source - convert to rasters
         for fmt in formats:
             output = f"{base}.{fmt}"
+
             if fmt == 'png':
-                cairosvg.svg2png(url=source_path, write_to=output,
-                    output_width=2126, output_height=1417)
+                cairosvg.svg2png(
+                    url=source_path,
+                    write_to=output,
+                    output_width=2126,  # 180mm @ 300 DPI
+                    output_height=1417   # 120mm @ 300 DPI
+                )
             elif fmt == 'pdf':
                 cairosvg.svg2pdf(url=source_path, write_to=output)
             elif fmt == 'tiff':
+                # Convert via PNG intermediate
                 temp_png = f"{base}_temp.png"
                 cairosvg.svg2png(url=source_path, write_to=temp_png)
                 img = Image.open(temp_png)
                 img.save(output, format='TIFF', compression='tiff_lzw')
                 os.remove(temp_png)
+
     else:
+        # Raster source
         img = Image.open(source_path)
+
         for fmt in formats:
             output = f"{base}.{fmt}"
+
             if fmt == 'png':
                 img.save(output, format='PNG', dpi=(300, 300), optimize=True)
             elif fmt == 'tiff':
                 img.save(output, format='TIFF', compression='tiff_lzw', dpi=(300, 300))
             elif fmt == 'pdf':
+                # Use img2pdf or similar for raster-to-PDF
                 img.save(output, format='PDF', resolution=300.0)
 
-    print(f"In Formaten exportiert: {', '.join(formats)}")
+    print(f"Exported in formats: {', '.join(formats)}")
+
+# Format selection guide
+format_guide = {
+    'TIFF': {
+        'use_for': 'Journal submission, archival',
+        'benefits': 'Lossless, supports CMYK, high quality',
+        'compression': 'LZW or ZIP (lossless)'
+    },
+    'PDF': {
+        'use_for': 'Submission, print, archival',
+        'benefits': 'Vector or raster, text searchable, widely accepted',
+        'variants': 'PDF/A (archival), PDF/X (print)'
+    },
+    'PNG': {
+        'use_for': 'Web, presentations, digital',
+        'benefits': 'Lossless, transparency, good compression',
+        'limitation': 'RGB only, larger than JPEG'
+    },
+    'SVG': {
+        'use_for': 'Web, further editing, scalable graphics',
+        'benefits': 'Vector, infinitely scalable, small file size',
+        'limitation': 'Not always accepted by journals'
+    },
+    'EPS': {
+        'use_for': 'Legacy journal requirements',
+        'benefits': 'Vector format accepted by older systems',
+        'limitation': 'Being phased out, use PDF instead'
+    }
+}
 ```
 
 **Erwartet:** Geeignetes Format fuer Publikationskanal
@@ -311,18 +375,18 @@ Web-optimierte Versionen erstellen:
 
 ```python
 def optimize_for_web(input_path, output_path, max_width=1200, quality=85):
-    """Bild fuer Web-Veroeffentlichung optimieren."""
+    """Optimize image for web publication."""
     from PIL import Image
 
     img = Image.open(input_path)
 
-    # Bei Uebergroesse verkleinern
+    # Resize if too large
     if img.width > max_width:
         ratio = max_width / img.width
         new_height = int(img.height * ratio)
         img = img.resize((max_width, new_height), Image.LANCZOS)
 
-    # Bei Bedarf zu RGB konvertieren
+    # Convert to RGB if needed
     if img.mode in ('RGBA', 'LA', 'P'):
         background = Image.new('RGB', img.size, (255, 255, 255))
         if img.mode == 'P':
@@ -330,12 +394,33 @@ def optimize_for_web(input_path, output_path, max_width=1200, quality=85):
         background.paste(img, mask=img.split()[-1] if 'A' in img.mode else None)
         img = background
 
-    # Optimiert speichern
+    # Save optimized
     img.save(output_path, format='JPEG', quality=quality, optimize=True, progressive=True)
 
+    # Check file size
     import os
     file_size_kb = os.path.getsize(output_path) / 1024
-    print(f"Optimiert: {file_size_kb:.1f} KB")
+    print(f"Optimized: {file_size_kb:.1f} KB")
+
+def create_responsive_set(input_path, output_base):
+    """Create multiple resolutions for responsive web."""
+    from PIL import Image
+
+    img = Image.open(input_path)
+    sizes = [
+        (640, '640w'),
+        (1024, '1024w'),
+        (1920, '1920w')
+    ]
+
+    for width, suffix in sizes:
+        if img.width >= width:
+            ratio = width / img.width
+            height = int(img.height * ratio)
+            resized = img.resize((width, height), Image.LANCZOS)
+
+            output = f"{output_base}_{suffix}.jpg"
+            resized.save(output, format='JPEG', quality=85, optimize=True)
 ```
 
 **Erwartet:** Web-optimierte Bilder unter 500KB, responsive Groessen erzeugt
@@ -350,22 +435,26 @@ from PIL import Image
 from PIL.PngImagePlugin import PngInfo
 
 def embed_metadata(image_path, output_path, metadata):
-    """Metadaten in PNG einbetten."""
+    """Embed metadata in PNG."""
     img = Image.open(image_path)
+
+    # Create metadata
     png_info = PngInfo()
     for key, value in metadata.items():
         png_info.add_text(key, str(value))
+
+    # Save with metadata
     img.save(output_path, format='PNG', pnginfo=png_info)
 
-# Beispiel-Metadaten
+# Example metadata
 metadata = {
-    'Title': 'Abbildung 1: Zusammenhang zwischen Gewicht und Kraftstoffeffizienz',
+    'Title': 'Figure 1: Relationship between weight and fuel efficiency',
     'Author': 'Jane Doe',
-    'Description': 'Streudiagramm zeigt negative Korrelation',
+    'Description': 'Scatter plot showing negative correlation',
     'Copyright': 'CC-BY 4.0',
     'Software': 'R 4.3.0, ggplot2 3.4.0',
     'Creation Date': '2026-02-16',
-    'Source': 'mtcars-Datensatz'
+    'Source': 'mtcars dataset'
 }
 
 embed_metadata('figure1.png', 'figure1_with_metadata.png', metadata)

--- a/i18n/de/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/de/skills/rotate-scraping-proxies/SKILL.md
@@ -75,14 +75,14 @@ und ethischen Prüfung abhängig. Das Überspringen dieses Schritts ist die mit
 Abstand größte Schadensquelle.
 
 ```python
-# Vor dem Schreiben jeglichen Codes zu bestätigende Eingaben:
-# 1. Sind die Daten öffentlich (kein Login erforderlich)?
-# 2. Erlaubt robots.txt den Pfad?
-# 3. Verbieten die AGB der Website automatisierten Zugriff? (lesen!)
-# 4. Würden beim Scraping personenbezogene Daten verarbeitet? Wenn ja, welche rechtliche Grundlage?
-# 5. Könnte dieser Zugriff Geo-Lizenzierung, Paywalls oder Authentifizierung umgehen?
-# 6. Gibt es eine öffentliche API oder einen Daten-Dump, der Scraping überflüssig macht?
-# 7. Haben Sie den Website-Betreiber kontaktiert, falls der Umfang groß ist?
+# Inputs to confirm before writing any code:
+# 1. Is the data public (no login required)?
+# 2. Does robots.txt permit the path?
+# 3. Does the site's ToS prohibit automated access? (read it)
+# 4. Would the scraping process personal data? If yes, what is the legal basis?
+# 5. Could this access circumvent geo-licensing, paywalls, or auth?
+# 6. Is there a public API or data dump that would make scraping unnecessary?
+# 7. Have you contacted the site owner if scope is large?
 ```
 
 **Expected:** Jede Frage hat eine verteidigungsfähige schriftliche Antwort.
@@ -140,7 +140,7 @@ import os
 import random
 from scrapling import Fetcher, StealthyFetcher
 
-# Muster A: anbietergesteuerter rotierender Endpoint (eine URL, Anbieter rotiert pro Anfrage)
+# Pattern A: provider-managed rotating endpoint (one URL, provider rotates per request)
 PROXY_URL = os.environ["SCRAPING_PROXY_URL"]  # http://user:pass@gateway.example:7777
 
 fetcher = StealthyFetcher()
@@ -151,8 +151,8 @@ fetcher.configure(
     proxy=PROXY_URL,
 )
 
-# Muster B: expliziter Pool, Rotation selbst durchführen
-POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")  # kommagetrennte URLs
+# Pattern B: explicit pool, rotate yourself
+POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")  # comma-separated URLs
 
 def fetch_with_rotation(url):
     proxy = random.choice(POOL)
@@ -180,14 +180,14 @@ Entscheiden Sie die Rotations-Granularität je nach Arbeitslast und halten
 Sie den Pool dann gesund.
 
 ```python
-# Sticky Session für zustandsbehaftete Abläufe (Login, mehrseitige Checkout-ähnliche Crawls)
-# Die meisten Anbieter stellen eine Session-ID über den Benutzernamen bereit:
+# Sticky session for stateful flows (login, multi-page checkout-like crawls)
+# Most providers expose a session ID via the username:
 #   user-session-abc123:pass@gateway.example:7777
-# Alle Anfragen mit derselben Session-ID verlassen das Netz über dieselbe IP für ca. 10 Min.
+# All requests with the same session ID exit through the same IP for ~10 min.
 
-# Rotation pro Anfrage für anonymes Massen-Scraping (Standard)
+# Per-request rotation for anonymous bulk scraping (default)
 
-# Pool-Zustandsprüfung — vor dem Massendurchlauf aufrufen
+# Pool health check — call before bulk run
 def check_pool(pool, sample_size=5):
     sample = random.sample(pool, min(sample_size, len(pool)))
     alive = []
@@ -202,7 +202,7 @@ def check_pool(pool, sample_size=5):
             pass
     return alive
 
-# Backoff bei transienten Proxy-Fehlern
+# Backoff on transient proxy failures
 def fetch_with_backoff(url, max_attempts=3):
     for attempt in range(max_attempts):
         try:
@@ -267,7 +267,7 @@ for url in target_urls:
         break
     response = fetch_with_backoff(url)
     budget.record(success=response is not None)
-    time.sleep(1)  # Ratenbegrenzung gilt weiterhin, auch bei Rotation
+    time.sleep(1)  # rate limiting still applies even with rotation
 ```
 
 **Expected:** Budget-Obergrenzen greifen, bevor Kosten außer Kontrolle

--- a/i18n/de/skills/script-blender-automation/SKILL.md
+++ b/i18n/de/skills/script-blender-automation/SKILL.md
@@ -60,21 +60,21 @@ import bmesh
 import math
 
 def create_parametric_surface(name, u_res=32, v_res=32):
-    """Parametrische Oberflaeche mit mathematischer Funktion erzeugen."""
+    """Generate parametric surface using mathematical function."""
     mesh = bpy.data.meshes.new(name)
     obj = bpy.data.objects.new(name, mesh)
     bpy.context.collection.objects.link(obj)
 
     bm = bmesh.new()
 
-    # Vertices mit parametrischen Gleichungen erstellen
+    # Create vertices using parametric equations
     verts = []
     for i in range(u_res):
         for j in range(v_res):
             u = (i / (u_res - 1)) * 2 * math.pi
             v = (j / (v_res - 1)) * math.pi
 
-            # Kugel-parametrische Gleichungen
+            # Sphere parametric equations
             x = math.sin(v) * math.cos(u)
             y = math.sin(v) * math.sin(u)
             z = math.cos(v)
@@ -82,7 +82,7 @@ def create_parametric_surface(name, u_res=32, v_res=32):
             vert = bm.verts.new((x, y, z))
             verts.append(vert)
 
-    # Flaechen erstellen
+    # Create faces
     bm.verts.ensure_lookup_table()
     for i in range(u_res - 1):
         for j in range(v_res - 1):
@@ -92,7 +92,7 @@ def create_parametric_surface(name, u_res=32, v_res=32):
             v4 = verts[i * v_res + (j + 1)]
             bm.faces.new([v1, v2, v3, v4])
 
-    # In Netz schreiben
+    # Write to mesh
     bm.to_mesh(mesh)
     bm.free()
 
@@ -108,16 +108,16 @@ Animations-Keyframes und Treiber skripten:
 
 ```python
 def animate_rotation(obj, start_frame=1, end_frame=250, axis='Z', rotations=2):
-    """Objektrotation ueber die Zeit animieren."""
-    # Anfangs-Keyframe setzen
-    obj.rotation_euler[2] = 0  # Z-Achse
+    """Animate object rotation over time."""
+    # Set initial keyframe
+    obj.rotation_euler[2] = 0  # Z axis
     obj.keyframe_insert(data_path="rotation_euler", index=2, frame=start_frame)
 
-    # End-Keyframe setzen
+    # Set end keyframe
     obj.rotation_euler[2] = rotations * 2 * math.pi
     obj.keyframe_insert(data_path="rotation_euler", index=2, frame=end_frame)
 
-    # Interpolation setzen
+    # Set interpolation
     if obj.animation_data and obj.animation_data.action:
         for fcurve in obj.animation_data.action.fcurves:
             if 'rotation_euler' in fcurve.data_path:
@@ -125,11 +125,11 @@ def animate_rotation(obj, start_frame=1, end_frame=250, axis='Z', rotations=2):
                     keyframe.interpolation = 'LINEAR'
 
 def animate_material_property(mat, property_path, values, frames):
-    """Material-Knotenwerte animieren."""
+    """Animate material node values."""
     if not mat.node_tree:
         return
 
-    # Beispiel: Emissionsstaerke animieren
+    # Example: animate emission strength
     nodes = mat.node_tree.nodes
     emission = nodes.get('Emission')
     if emission:
@@ -141,12 +141,12 @@ def animate_material_property(mat, property_path, values, frames):
             )
 
 def create_driver(obj, property_path, expression):
-    """Treiber fuer automatisierte Animation erstellen."""
+    """Create driver for automated animation."""
     driver = obj.driver_add(property_path)
     driver.driver.type = 'SCRIPTED'
     driver.driver.expression = expression
 
-    # Beispiel: Rotation an Bildnummer koppeln
+    # Example: link rotation to frame number
     # expression = "frame / 10"
 ```
 
@@ -162,7 +162,7 @@ import os
 from pathlib import Path
 
 def batch_import_and_render(input_dir, output_dir, file_pattern="*.obj"):
-    """Mehrere Dateien importieren und jeweils rendern."""
+    """Import multiple files and render each."""
     input_path = Path(input_dir)
     output_path = Path(output_dir)
     output_path.mkdir(exist_ok=True)
@@ -170,26 +170,26 @@ def batch_import_and_render(input_dir, output_dir, file_pattern="*.obj"):
     scene = bpy.context.scene
 
     for obj_file in input_path.glob(file_pattern):
-        # Bestehende Objekte loeschen
+        # Clear existing objects
         bpy.ops.object.select_all(action='SELECT')
         bpy.ops.object.delete()
 
-        # Modell importieren
+        # Import model
         bpy.ops.import_scene.obj(filepath=str(obj_file))
 
-        # Kamera und Beleuchtung einrichten (Setup-Funktionen wiederverwenden)
+        # Setup camera and lighting (reuse setup functions)
         setup_camera()
         setup_lighting()
 
-        # Rendern
+        # Render
         output_file = output_path / f"{obj_file.stem}.png"
         scene.render.filepath = str(output_file)
         bpy.ops.render.render(write_still=True)
 
-        print(f"Gerendert: {output_file}")
+        print(f"Rendered: {output_file}")
 
 def batch_material_variation(base_object, colors, output_prefix):
-    """Objekt mit mehreren Materialfarben rendern."""
+    """Render object with multiple material colors."""
     mat = base_object.data.materials[0]
     bsdf = mat.node_tree.nodes.get('Principled BSDF')
 
@@ -197,10 +197,10 @@ def batch_material_variation(base_object, colors, output_prefix):
         return
 
     for i, color in enumerate(colors):
-        # Materialfarbe aktualisieren
+        # Update material color
         bsdf.inputs['Base Color'].default_value = color + (1.0,)
 
-        # Rendern
+        # Render
         bpy.context.scene.render.filepath = f"{output_prefix}_{i:03d}.png"
         bpy.ops.render.render(write_still=True)
 ```
@@ -217,45 +217,45 @@ import bpy
 from bpy.props import FloatProperty, IntProperty
 
 class OBJECT_OT_generate_spiral(bpy.types.Operator):
-    """Spiralkurve generieren"""
+    """Generate a spiral curve"""
     bl_idname = "object.generate_spiral"
-    bl_label = "Spirale generieren"
+    bl_label = "Generate Spiral"
     bl_options = {'REGISTER', 'UNDO'}
 
-    # Operator-Eigenschaften
+    # Operator properties
     radius: FloatProperty(
         name="Radius",
-        description="Spiralradius",
+        description="Spiral radius",
         default=2.0,
         min=0.1,
         max=10.0
     )
 
     turns: IntProperty(
-        name="Windungen",
-        description="Anzahl der Spiralwindungen",
+        name="Turns",
+        description="Number of spiral turns",
         default=5,
         min=1,
         max=20
     )
 
     resolution: IntProperty(
-        name="Aufloesung",
-        description="Punkte pro Windung",
+        name="Resolution",
+        description="Points per turn",
         default=32,
         min=8,
         max=128
     )
 
     def execute(self, context):
-        # Kurve erstellen
+        # Create curve
         curve = bpy.data.curves.new('Spiral', 'CURVE')
         curve.dimensions = '3D'
 
         spline = curve.splines.new('NURBS')
         num_points = self.turns * self.resolution
 
-        spline.points.add(num_points - 1)  # -1 weil ein Punkt existiert
+        spline.points.add(num_points - 1)  # -1 because one point exists
 
         for i in range(num_points):
             t = i / self.resolution
@@ -267,13 +267,13 @@ class OBJECT_OT_generate_spiral(bpy.types.Operator):
 
             spline.points[i].co = (x, y, z, 1.0)
 
-        # Objekt erstellen
+        # Create object
         obj = bpy.data.objects.new('Spiral', curve)
         context.collection.objects.link(obj)
         obj.select_set(True)
         context.view_layer.objects.active = obj
 
-        self.report({'INFO'}, f"Spirale mit {num_points} Punkten generiert")
+        self.report({'INFO'}, f"Generated spiral with {num_points} points")
         return {'FINISHED'}
 
 def register():
@@ -295,9 +295,9 @@ Interaktive modale Operatoren erstellen:
 
 ```python
 class OBJECT_OT_modal_scale(bpy.types.Operator):
-    """Interaktive Skalierung mit Maus"""
+    """Interactive scaling with mouse"""
     bl_idname = "object.modal_scale"
-    bl_label = "Modale Skalierung"
+    bl_label = "Modal Scale"
     bl_options = {'REGISTER', 'UNDO'}
 
     def __init__(self):
@@ -306,19 +306,19 @@ class OBJECT_OT_modal_scale(bpy.types.Operator):
 
     def modal(self, context, event):
         if event.type == 'MOUSEMOVE':
-            # Skalierung basierend auf Mausbewegung berechnen
+            # Calculate scale based on mouse movement
             delta = event.mouse_x - self.initial_mouse_x
             scale = self.initial_scale + (delta / 100.0)
-            scale = max(0.1, scale)  # Mindestskalierung
+            scale = max(0.1, scale)  # Minimum scale
 
-            # Auf aktives Objekt anwenden
+            # Apply to active object
             context.active_object.scale = (scale, scale, scale)
 
         elif event.type == 'LEFTMOUSE':
             return {'FINISHED'}
 
         elif event.type in {'RIGHTMOUSE', 'ESC'}:
-            # Abbrechen - urspruengliche Skalierung wiederherstellen
+            # Cancel - restore initial scale
             context.active_object.scale = (
                 self.initial_scale,
                 self.initial_scale,
@@ -336,7 +336,7 @@ class OBJECT_OT_modal_scale(bpy.types.Operator):
             context.window_manager.modal_handler_add(self)
             return {'RUNNING_MODAL'}
         else:
-            self.report({'WARNING'}, "Kein aktives Objekt")
+            self.report({'WARNING'}, "No active object")
             return {'CANCELLED'}
 ```
 
@@ -349,36 +349,38 @@ Code als installierbares Add-on strukturieren:
 
 ```python
 bl_info = {
-    "name": "Benutzerdefinierte Werkzeuge",
-    "author": "Ihr Name",
+    "name": "Custom Tools",
+    "author": "Your Name",
     "version": (1, 0, 0),
     "blender": (3, 0, 0),
     "location": "View3D > Add > Mesh",
-    "description": "Sammlung benutzerdefinierter Modellierungswerkzeuge",
+    "description": "Collection of custom modeling tools",
     "category": "Add Mesh",
 }
 
 import bpy
 
-# Operator-Klassen importieren
+# Import operator classes
 from .operators import OBJECT_OT_generate_spiral
 
 classes = (
     OBJECT_OT_generate_spiral,
-    # Weitere Klassen hinzufuegen
+    # Add other classes
 )
 
 def menu_func(self, context):
-    """Zum Menue hinzufuegen."""
+    """Add to menu."""
     self.layout.operator(OBJECT_OT_generate_spiral.bl_idname)
 
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
+
     bpy.types.VIEW3D_MT_mesh_add.append(menu_func)
 
 def unregister():
     bpy.types.VIEW3D_MT_mesh_add.remove(menu_func)
+
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
 
@@ -398,28 +400,28 @@ import csv
 import json
 
 def create_from_csv(filepath):
-    """Objekte aus CSV-Daten generieren."""
+    """Generate objects from CSV data."""
     with open(filepath, 'r') as f:
         reader = csv.DictReader(f)
 
         for row in reader:
-            # Daten parsen
+            # Parse data
             name = row['name']
             x, y, z = float(row['x']), float(row['y']), float(row['z'])
             scale = float(row.get('scale', 1.0))
 
-            # Objekt erstellen
+            # Create object
             bpy.ops.mesh.primitive_uv_sphere_add(location=(x, y, z))
             obj = bpy.context.active_object
             obj.name = name
             obj.scale = (scale, scale, scale)
 
 def create_from_json(filepath):
-    """Szene aus JSON-Konfiguration generieren."""
+    """Generate scene from JSON configuration."""
     with open(filepath, 'r') as f:
         config = json.load(f)
 
-    # Objekte verarbeiten
+    # Process objects
     for obj_config in config.get('objects', []):
         obj_type = obj_config['type']
         location = obj_config['location']
@@ -432,7 +434,7 @@ def create_from_json(filepath):
         obj = bpy.context.active_object
         obj.name = obj_config.get('name', 'Object')
 
-        # Material anwenden falls angegeben
+        # Apply material if specified
         if 'material' in obj_config:
             mat_name = obj_config['material']
             mat = bpy.data.materials.get(mat_name)

--- a/i18n/de/skills/serialize-data-formats/SKILL.md
+++ b/i18n/de/skills/serialize-data-formats/SKILL.md
@@ -79,7 +79,7 @@ class Measurement:
     unit: str
     timestamp: datetime
 
-# Benutzerdefinierter Encoder fuer Nicht-Standardtypen
+# Custom encoder for non-standard types
 class CustomEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime):
@@ -91,11 +91,11 @@ class CustomEncoder(json.JSONEncoder):
             return base64.b64encode(obj).decode('ascii')
         return super().default(obj)
 
-# Serialisieren
+# Serialize
 measurement = Measurement("sensor-01", 23.5, "celsius", datetime.now())
 json_str = json.dumps(asdict(measurement), cls=CustomEncoder, indent=2)
 
-# Deserialisieren
+# Deserialize
 data = json.loads(json_str)
 ```
 
@@ -148,16 +148,16 @@ protoc --go_out=. sensors.proto
 from sensors_pb2 import Measurement, MeasurementBatch
 import time
 
-# Serialisieren
+# Serialize
 m = Measurement(
     sensor_id="sensor-01",
     value=23.5,
     unit="celsius",
     timestamp_ms=int(time.time() * 1000)
 )
-binary = m.SerializeToString()  # Kompaktes Binaerformat
+binary = m.SerializeToString()  # Compact binary
 
-# Deserialisieren
+# Deserialize
 m2 = Measurement()
 m2.ParseFromString(binary)
 ```
@@ -171,7 +171,7 @@ m2.ParseFromString(binary)
 import msgpack
 from datetime import datetime
 
-# Benutzerdefiniertes Packen fuer datetime
+# Custom packing for datetime
 def encode_datetime(obj):
     if isinstance(obj, datetime):
         return {"__datetime__": True, "s": obj.isoformat()}
@@ -184,10 +184,10 @@ def decode_datetime(obj):
 
 data = {"sensor_id": "sensor-01", "value": 23.5, "ts": datetime.now()}
 
-# Serialisieren (kleiner als JSON, schneller als JSON)
+# Serialize (smaller than JSON, faster than JSON)
 packed = msgpack.packb(data, default=encode_datetime)
 
-# Deserialisieren
+# Deserialize
 unpacked = msgpack.unpackb(packed, object_hook=decode_datetime, raw=False)
 ```
 
@@ -201,7 +201,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pandas as pd
 
-# Daten erstellen
+# Create data
 df = pd.DataFrame({
     "sensor_id": ["s-01", "s-02", "s-01", "s-03"] * 1000,
     "value": [23.5, 18.2, 24.1, 19.8] * 1000,
@@ -209,11 +209,11 @@ df = pd.DataFrame({
     "timestamp": pd.date_range("2025-01-01", periods=4000, freq="min")
 })
 
-# Parquet schreiben (spaltenbasiert, komprimiert)
+# Write Parquet (columnar, compressed)
 table = pa.Table.from_pandas(df)
 pq.write_table(table, "measurements.parquet", compression="snappy")
 
-# Parquet lesen (kann bestimmte Spalten lesen ohne alle Daten zu laden)
+# Read Parquet (can read specific columns without loading all data)
 table_back = pq.read_table("measurements.parquet", columns=["sensor_id", "value"])
 df_subset = table_back.to_pandas()
 ```

--- a/i18n/es/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/es/skills/rotate-scraping-proxies/SKILL.md
@@ -72,14 +72,14 @@ Condicione todo el flujo de trabajo a una revisión legal y ética documentada.
 Saltarse este paso es, con diferencia, la mayor fuente de daños.
 
 ```python
-# Datos a confirmar antes de escribir una sola linea de codigo:
-# 1. ¿Son publicos los datos (sin requerir login)?
-# 2. ¿Permite robots.txt la ruta?
-# 3. ¿Prohiben los terminos del servicio el acceso automatizado? (leelos)
-# 4. ¿Procesaria el scraping datos personales? Si es asi, ¿cual es la base legal?
-# 5. ¿Podria este acceso eludir licencias geograficas, muros de pago o autenticacion?
-# 6. ¿Existe una API publica o volcado de datos que haga innecesario el scraping?
-# 7. ¿Has contactado con el propietario del sitio si el alcance es grande?
+# Inputs to confirm before writing any code:
+# 1. Is the data public (no login required)?
+# 2. Does robots.txt permit the path?
+# 3. Does the site's ToS prohibit automated access? (read it)
+# 4. Would the scraping process personal data? If yes, what is the legal basis?
+# 5. Could this access circumvent geo-licensing, paywalls, or auth?
+# 6. Is there a public API or data dump that would make scraping unnecessary?
+# 7. Have you contacted the site owner if scope is large?
 ```
 
 **Expected:** Cada pregunta tiene una respuesta escrita defendible. El primer
@@ -135,7 +135,7 @@ import os
 import random
 from scrapling import Fetcher, StealthyFetcher
 
-# Patron A: endpoint rotativo gestionado por el proveedor (una URL, el proveedor rota por peticion)
+# Pattern A: provider-managed rotating endpoint (one URL, provider rotates per request)
 PROXY_URL = os.environ["SCRAPING_PROXY_URL"]  # http://user:pass@gateway.example:7777
 
 fetcher = StealthyFetcher()
@@ -146,8 +146,8 @@ fetcher.configure(
     proxy=PROXY_URL,
 )
 
-# Patron B: pool explicito, tu mismo gestionas la rotacion
-POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")  # URLs separadas por coma
+# Pattern B: explicit pool, rotate yourself
+POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")  # comma-separated URLs
 
 def fetch_with_rotation(url):
     proxy = random.choice(POOL)
@@ -176,14 +176,14 @@ Decida la granularidad de la rotación según la carga de trabajo y luego
 mantenga el pool saludable.
 
 ```python
-# Sesion persistente (sticky) para flujos con estado (login, rastreos tipo checkout multipagina)
-# La mayoria de proveedores expone un session ID a traves del nombre de usuario:
+# Sticky session for stateful flows (login, multi-page checkout-like crawls)
+# Most providers expose a session ID via the username:
 #   user-session-abc123:pass@gateway.example:7777
-# Todas las peticiones con el mismo session ID salen por la misma IP durante ~10 min.
+# All requests with the same session ID exit through the same IP for ~10 min.
 
-# Rotacion por peticion para scraping anonimo masivo (por defecto)
+# Per-request rotation for anonymous bulk scraping (default)
 
-# Comprobacion de salud del pool — ejecutar antes de una ejecucion masiva
+# Pool health check — call before bulk run
 def check_pool(pool, sample_size=5):
     sample = random.sample(pool, min(sample_size, len(pool)))
     alive = []
@@ -198,7 +198,7 @@ def check_pool(pool, sample_size=5):
             pass
     return alive
 
-# Retroceso exponencial ante fallos transitorios del proxy
+# Backoff on transient proxy failures
 def fetch_with_backoff(url, max_attempts=3):
     for attempt in range(max_attempts):
         try:
@@ -263,7 +263,7 @@ for url in target_urls:
         break
     response = fetch_with_backoff(url)
     budget.record(success=response is not None)
-    time.sleep(1)  # la limitacion de velocidad sigue aplicando incluso con rotacion
+    time.sleep(1)  # rate limiting still applies even with rotation
 ```
 
 **Expected:** Los topes del presupuesto se activan antes de que el coste se

--- a/i18n/ja/skills/create-2d-composition/SKILL.md
+++ b/i18n/ja/skills/create-2d-composition/SKILL.md
@@ -234,32 +234,67 @@ import numpy as np
 def create_bar_chart_svg(data, labels, output_path):
     """Generate SVG bar chart from data."""
     dwg = svgwrite.Drawing(output_path, size=('600px', '400px'))
+
+    # Chart area
     margin = 50
     chart_width = 500
     chart_height = 300
     bar_spacing = 10
+
+    # Calculate bar dimensions
     n_bars = len(data)
     bar_width = (chart_width - (n_bars - 1) * bar_spacing) / n_bars
+
+    # Scale data to fit chart
     max_value = max(data)
     scale = chart_height / max_value
 
     # Draw axes
-    dwg.add(dwg.line(start=(margin, margin), end=(margin, margin + chart_height),
-        stroke='black', stroke_width=2))
-    dwg.add(dwg.line(start=(margin, margin + chart_height),
+    dwg.add(dwg.line(
+        start=(margin, margin),
+        end=(margin, margin + chart_height),
+        stroke='black',
+        stroke_width=2
+    ))
+    dwg.add(dwg.line(
+        start=(margin, margin + chart_height),
         end=(margin + chart_width, margin + chart_height),
-        stroke='black', stroke_width=2))
+        stroke='black',
+        stroke_width=2
+    ))
 
+    # Draw bars
     for i, (value, label) in enumerate(zip(data, labels)):
         x = margin + i * (bar_width + bar_spacing)
         bar_height = value * scale
         y = margin + chart_height - bar_height
-        dwg.add(dwg.rect(insert=(x, y), size=(bar_width, bar_height),
-            fill='steelblue', stroke='navy', stroke_width=1))
-        dwg.add(dwg.text(f'{value:.1f}', insert=(x + bar_width/2, y - 5),
-            text_anchor='middle', font_size='10pt', fill='black'))
-        dwg.add(dwg.text(label, insert=(x + bar_width/2, margin + chart_height + 20),
-            text_anchor='middle', font_size='10pt', fill='black'))
+
+        # Bar
+        dwg.add(dwg.rect(
+            insert=(x, y),
+            size=(bar_width, bar_height),
+            fill='steelblue',
+            stroke='navy',
+            stroke_width=1
+        ))
+
+        # Value label
+        dwg.add(dwg.text(
+            f'{value:.1f}',
+            insert=(x + bar_width/2, y - 5),
+            text_anchor='middle',
+            font_size='10pt',
+            fill='black'
+        ))
+
+        # X-axis label
+        dwg.add(dwg.text(
+            label,
+            insert=(x + bar_width/2, margin + chart_height + 20),
+            text_anchor='middle',
+            font_size='10pt',
+            fill='black'
+        ))
 
     dwg.save()
 ```
@@ -278,14 +313,37 @@ def batch_generate_badges(users, template_path, output_dir):
 
     for user in users:
         output_path = os.path.join(output_dir, f"{user['id']}_badge.svg")
+
         dwg = svgwrite.Drawing(output_path, size=('300px', '100px'))
-        dwg.add(dwg.rect(insert=(0, 0), size=('100%', '100%'),
-            fill='#3366cc', rx=10, ry=10))
-        dwg.add(dwg.text(user['name'], insert=(150, 40),
-            text_anchor='middle', font_size='20pt',
-            font_weight='bold', fill='white'))
-        dwg.add(dwg.text(user['role'], insert=(150, 70),
-            text_anchor='middle', font_size='14pt', fill='lightblue'))
+
+        # Background
+        dwg.add(dwg.rect(
+            insert=(0, 0),
+            size=('100%', '100%'),
+            fill='#3366cc',
+            rx=10,
+            ry=10
+        ))
+
+        # User name
+        dwg.add(dwg.text(
+            user['name'],
+            insert=(150, 40),
+            text_anchor='middle',
+            font_size='20pt',
+            font_weight='bold',
+            fill='white'
+        ))
+
+        # User role
+        dwg.add(dwg.text(
+            user['role'],
+            insert=(150, 70),
+            text_anchor='middle',
+            font_size='14pt',
+            fill='lightblue'
+        ))
+
         dwg.save()
         print(f"Generated badge: {output_path}")
 ```
@@ -302,12 +360,20 @@ import cairosvg
 
 def svg_to_png(svg_path, png_path, dpi=300):
     """Convert SVG to PNG with specified DPI."""
+    # Calculate pixel dimensions from DPI
+    # Assuming A4 size as example
     width_inches = 8.27
     height_inches = 11.69
+
     width_px = int(width_inches * dpi)
     height_px = int(height_inches * dpi)
-    cairosvg.svg2png(url=svg_path, write_to=png_path,
-        output_width=width_px, output_height=height_px)
+
+    cairosvg.svg2png(
+        url=svg_path,
+        write_to=png_path,
+        output_width=width_px,
+        output_height=height_px
+    )
     print(f"Converted to PNG: {png_path}")
 
 def svg_to_pdf(svg_path, pdf_path):

--- a/i18n/ja/skills/define-slo-sli-sla/SKILL.md
+++ b/i18n/ja/skills/define-slo-sli-sla/SKILL.md
@@ -401,7 +401,7 @@ import sys
 
 def check_error_budget(service):
     # Query Prometheus for error budget
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 CI/CDパイプラインに統合する：

--- a/i18n/ja/skills/instrument-distributed-tracing/SKILL.md
+++ b/i18n/ja/skills/instrument-distributed-tracing/SKILL.md
@@ -155,7 +155,7 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **GoとGinフレームワーク**：
@@ -218,7 +218,7 @@ tracer = trace.get_tracer(__name__)
 
 def process_order(order_id):
     # Create a span for the entire operation
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Goの手動スパン**：
@@ -262,7 +262,7 @@ from opentelemetry import trace
 from opentelemetry.propagate import inject
 
 tracer = trace.get_tracer(__name__)
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 ```go
@@ -284,7 +284,7 @@ from kafka import KafkaProducer
 
 producer = KafkaProducer(bootstrap_servers=['kafka:9092'])
 
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 ```python
@@ -341,7 +341,7 @@ from opentelemetry.sdk.trace.sampling import (
     TraceIdRatioBased,
     StaticSampler,
     Decision
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Tempoを使用したテールベースサンプリング**：
@@ -399,7 +399,7 @@ from opentelemetry import trace
 # Custom log formatter with trace context
 class TraceFormatter(logging.Formatter):
     def format(self, record):
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **トレースからメトリクスを生成する**（Tempo）：

--- a/i18n/ja/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/ja/skills/rotate-scraping-proxies/SKILL.md
@@ -72,14 +72,14 @@ metadata:
 ゲートします。この手順を飛ばすことが、害の最大の発生源です。
 
 ```python
-# コードを書き始める前に確認すべき入力:
-# 1. データは公開されているか（ログイン不要か）？
-# 2. robots.txt は該当パスを許可しているか？
-# 3. サイトの ToS は自動アクセスを禁止していないか？（実際に読む）
-# 4. 処理対象に個人データは含まれるか？ 含まれる場合、法的根拠は何か？
-# 5. このアクセスは地理ライセンス、有料コンテンツ、認証の回避になり得るか？
-# 6. スクレイピング不要にできる公開 API やデータダンプは存在しないか？
-# 7. 範囲が大きい場合、サイト運営者に連絡したか？
+# Inputs to confirm before writing any code:
+# 1. Is the data public (no login required)?
+# 2. Does robots.txt permit the path?
+# 3. Does the site's ToS prohibit automated access? (read it)
+# 4. Would the scraping process personal data? If yes, what is the legal basis?
+# 5. Could this access circumvent geo-licensing, paywalls, or auth?
+# 6. Is there a public API or data dump that would make scraping unnecessary?
+# 7. Have you contacted the site owner if scope is large?
 ```
 
 **Expected:** すべての質問に、説明可能な書面での回答が揃っている。最初に
@@ -133,7 +133,7 @@ import os
 import random
 from scrapling import Fetcher, StealthyFetcher
 
-# パターン A: プロバイダ管理のローテーティングエンドポイント（単一 URL、プロバイダがリクエストごとに切替）
+# Pattern A: provider-managed rotating endpoint (one URL, provider rotates per request)
 PROXY_URL = os.environ["SCRAPING_PROXY_URL"]  # http://user:pass@gateway.example:7777
 
 fetcher = StealthyFetcher()
@@ -144,8 +144,8 @@ fetcher.configure(
     proxy=PROXY_URL,
 )
 
-# パターン B: 明示的なプールを自分でローテーションする
-POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")  # カンマ区切りの URL
+# Pattern B: explicit pool, rotate yourself
+POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")  # comma-separated URLs
 
 def fetch_with_rotation(url):
     proxy = random.choice(POOL)
@@ -173,14 +173,14 @@ def fetch_with_rotation(url):
 保ちます。
 
 ```python
-# ステートフルなフロー（ログイン、複数ページにまたがるチェックアウト系の巡回）向けのスティッキーセッション。
-# 多くのプロバイダはユーザー名にセッション ID を埋め込む形で公開している:
+# Sticky session for stateful flows (login, multi-page checkout-like crawls)
+# Most providers expose a session ID via the username:
 #   user-session-abc123:pass@gateway.example:7777
-# 同じセッション ID を持つリクエストは、約 10 分間すべて同じ IP を経由する。
+# All requests with the same session ID exit through the same IP for ~10 min.
 
-# 匿名の大量スクレイピングにはリクエスト単位のローテーション（デフォルト）を使う。
+# Per-request rotation for anonymous bulk scraping (default)
 
-# プール健全性チェック — 大規模実行の前に呼び出す
+# Pool health check — call before bulk run
 def check_pool(pool, sample_size=5):
     sample = random.sample(pool, min(sample_size, len(pool)))
     alive = []
@@ -195,7 +195,7 @@ def check_pool(pool, sample_size=5):
             pass
     return alive
 
-# 一時的なプロキシ障害に対するバックオフ
+# Backoff on transient proxy failures
 def fetch_with_backoff(url, max_attempts=3):
     for attempt in range(max_attempts):
         try:
@@ -260,7 +260,7 @@ for url in target_urls:
         break
     response = fetch_with_backoff(url)
     budget.record(success=response is not None)
-    time.sleep(1)  # ローテーションがあってもレート制限は依然として適用する
+    time.sleep(1)  # rate limiting still applies even with rotation
 ```
 
 **Expected:** 予算上限が暴走コストに先んじて発動する。ログにプロキシ

--- a/i18n/ja/skills/serialize-data-formats/SKILL.md
+++ b/i18n/ja/skills/serialize-data-formats/SKILL.md
@@ -82,7 +82,7 @@ class Measurement:
     unit: str
     timestamp: datetime
 
-# 非標準型のカスタムエンコーダ
+# Custom encoder for non-standard types
 class CustomEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime):
@@ -94,11 +94,11 @@ class CustomEncoder(json.JSONEncoder):
             return base64.b64encode(obj).decode('ascii')
         return super().default(obj)
 
-# シリアライズ
+# Serialize
 measurement = Measurement("sensor-01", 23.5, "celsius", datetime.now())
 json_str = json.dumps(asdict(measurement), cls=CustomEncoder, indent=2)
 
-# デシリアライズ
+# Deserialize
 data = json.loads(json_str)
 ```
 
@@ -151,16 +151,16 @@ protoc --go_out=. sensors.proto
 from sensors_pb2 import Measurement, MeasurementBatch
 import time
 
-# シリアライズ
+# Serialize
 m = Measurement(
     sensor_id="sensor-01",
     value=23.5,
     unit="celsius",
     timestamp_ms=int(time.time() * 1000)
 )
-binary = m.SerializeToString()  # コンパクトなバイナリ
+binary = m.SerializeToString()  # Compact binary
 
-# デシリアライズ
+# Deserialize
 m2 = Measurement()
 m2.ParseFromString(binary)
 ```
@@ -174,7 +174,7 @@ m2.ParseFromString(binary)
 import msgpack
 from datetime import datetime
 
-# datetimeのカスタムパッキング
+# Custom packing for datetime
 def encode_datetime(obj):
     if isinstance(obj, datetime):
         return {"__datetime__": True, "s": obj.isoformat()}
@@ -187,10 +187,10 @@ def decode_datetime(obj):
 
 data = {"sensor_id": "sensor-01", "value": 23.5, "ts": datetime.now()}
 
-# シリアライズ（JSONより小さく、JSONより速い）
+# Serialize (smaller than JSON, faster than JSON)
 packed = msgpack.packb(data, default=encode_datetime)
 
-# デシリアライズ
+# Deserialize
 unpacked = msgpack.unpackb(packed, object_hook=decode_datetime, raw=False)
 ```
 
@@ -204,7 +204,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pandas as pd
 
-# データ作成
+# Create data
 df = pd.DataFrame({
     "sensor_id": ["s-01", "s-02", "s-01", "s-03"] * 1000,
     "value": [23.5, 18.2, 24.1, 19.8] * 1000,
@@ -212,11 +212,11 @@ df = pd.DataFrame({
     "timestamp": pd.date_range("2025-01-01", periods=4000, freq="min")
 })
 
-# Parquet書き込み（カラムナ、圧縮）
+# Write Parquet (columnar, compressed)
 table = pa.Table.from_pandas(df)
 pq.write_table(table, "measurements.parquet", compression="snappy")
 
-# Parquet読み込み（全データをロードせずに特定カラムを読み取れる）
+# Read Parquet (can read specific columns without loading all data)
 table_back = pq.read_table("measurements.parquet", columns=["sensor_id", "value"])
 df_subset = table_back.to_pandas()
 ```

--- a/i18n/wenyan-lite/skills/headless-web-scraping/SKILL.md
+++ b/i18n/wenyan-lite/skills/headless-web-scraping/SKILL.md
@@ -51,12 +51,12 @@ Cloudflare 保護站與動態 SPA——提取資料。
 定何 scrapling 抓取器配目標站之防禦。
 
 ```python
-# 決策矩陣：
-# 1. Fetcher        — 靜態 HTML、無 JS、無反爬（最速）
-# 2. StealthyFetcher — Cloudflare/Turnstile、TLS 指紋核
-# 3. DynamicFetcher  — JS 渲染之 SPA、點擊/滾動互動
+# Decision matrix:
+# 1. Fetcher        — static HTML, no JS, no anti-bot (fastest)
+# 2. StealthyFetcher — Cloudflare/Turnstile, TLS fingerprint checks
+# 3. DynamicFetcher  — JS-rendered SPAs, click/scroll interactions
 
-# 快速試探：先 Fetcher，失則升級
+# Quick probe: try Fetcher first, escalate on failure
 from scrapling import Fetcher
 
 fetcher = Fetcher()
@@ -87,7 +87,7 @@ else:
 ```python
 from scrapling import Fetcher, StealthyFetcher, DynamicFetcher
 
-# 層一：以 TLS 指紋假冒之快速 HTTP
+# Tier 1: Fast HTTP with TLS fingerprint impersonation
 fetcher = Fetcher()
 fetcher.configure(
     timeout=30,
@@ -95,21 +95,21 @@ fetcher.configure(
     follow_redirects=True
 )
 
-# 層二：附反偵測之無頭 Chromium
+# Tier 2: Headless Chromium with anti-detection
 fetcher = StealthyFetcher()
 fetcher.configure(
     headless=True,
     timeout=60,
-    network_idle=True  # 待所有網路請求定
+    network_idle=True  # wait for all network requests to settle
 )
 
-# 層三：完全瀏覽器自動化
+# Tier 3: Full browser automation
 fetcher = DynamicFetcher()
 fetcher.configure(
     headless=True,
     timeout=90,
     network_idle=True,
-    wait_selector="div.results"  # 提取前待特定元素
+    wait_selector="div.results"  # wait for specific element before extracting
 )
 ```
 
@@ -125,26 +125,26 @@ fetcher.configure(
 導至目標 URL 並以 CSS 選擇器提取結構化資料。
 
 ```python
-# 抓取頁
+# Fetch the page
 response = fetcher.get("https://example.com/target-page")
 
-# 單元素提取
+# Single element extraction
 title = response.find("h1.page-title")
 if title:
     print(title.get_all_text())
 
-# 多元素
+# Multiple elements
 items = response.find_all("div.result-item")
 for item in items:
     name = item.find("span.name")
     price = item.find("span.price")
     print(f"{name.get_all_text()}: {price.get_all_text()}")
 
-# 取屬性值
+# Get attribute values
 links = response.find_all("a.product-link")
 urls = [link.get("href") for link in links]
 
-# 取元素之原始 HTML 內容
+# Get raw HTML content of an element
 detail_html = response.find("div.description").html_content
 ```
 
@@ -190,7 +190,7 @@ def scrape_with_fallback(url, selector):
             print(f"{tier_name} failed: {error}")
             continue
 
-        # 偵測 CAPTCHA / 挑戰頁
+        # Detect CAPTCHA / challenge pages
         page_text = response.get_all_text().lower()
         if "altcha" in page_text or "proof of work" in page_text:
             print(f"altcha CAPTCHA detected -- cannot automate")
@@ -244,7 +244,7 @@ def scrape_urls(urls, selector, delay=1.0):
         if data:
             results.append(data.get_all_text())
 
-        time.sleep(delay)  # 尊重伺服器
+        time.sleep(delay)  # respect the server
 
     return results
 ```

--- a/i18n/wenyan-ultra/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/wenyan-ultra/skills/rotate-scraping-proxies/SKILL.md
@@ -98,7 +98,8 @@ import os
 import random
 from scrapling import Fetcher, StealthyFetcher
 
-PROXY_URL = os.environ["SCRAPING_PROXY_URL"]
+# Pattern A: provider-managed rotating endpoint (one URL, provider rotates per request)
+PROXY_URL = os.environ["SCRAPING_PROXY_URL"]  # http://user:pass@gateway.example:7777
 
 fetcher = StealthyFetcher()
 fetcher.configure(
@@ -108,7 +109,8 @@ fetcher.configure(
     proxy=PROXY_URL,
 )
 
-POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")
+# Pattern B: explicit pool, rotate yourself
+POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")  # comma-separated URLs
 
 def fetch_with_rotation(url):
     proxy = random.choice(POOL)
@@ -129,6 +131,14 @@ def fetch_with_rotation(url):
 按工選輪粒，繼保池健。
 
 ```python
+# Sticky session for stateful flows (login, multi-page checkout-like crawls)
+# Most providers expose a session ID via the username:
+#   user-session-abc123:pass@gateway.example:7777
+# All requests with the same session ID exit through the same IP for ~10 min.
+
+# Per-request rotation for anonymous bulk scraping (default)
+
+# Pool health check — call before bulk run
 def check_pool(pool, sample_size=5):
     sample = random.sample(pool, min(sample_size, len(pool)))
     alive = []
@@ -143,6 +153,7 @@ def check_pool(pool, sample_size=5):
             pass
     return alive
 
+# Backoff on transient proxy failures
 def fetch_with_backoff(url, max_attempts=3):
     for attempt in range(max_attempts):
         try:
@@ -200,7 +211,7 @@ for url in target_urls:
         break
     response = fetch_with_backoff(url)
     budget.record(success=response is not None)
-    time.sleep(1)
+    time.sleep(1)  # rate limiting still applies even with rotation
 ```
 
 得：限觸先於失控費。日誌示代功率以辨除。

--- a/i18n/wenyan-ultra/skills/script-blender-automation/SKILL.md
+++ b/i18n/wenyan-ultra/skills/script-blender-automation/SKILL.md
@@ -66,12 +66,14 @@ def create_parametric_surface(name, u_res=32, v_res=32):
 
     bm = bmesh.new()
 
+    # Create vertices using parametric equations
     verts = []
     for i in range(u_res):
         for j in range(v_res):
             u = (i / (u_res - 1)) * 2 * math.pi
             v = (j / (v_res - 1)) * math.pi
 
+            # Sphere parametric equations
             x = math.sin(v) * math.cos(u)
             y = math.sin(v) * math.sin(u)
             z = math.cos(v)
@@ -79,6 +81,7 @@ def create_parametric_surface(name, u_res=32, v_res=32):
             vert = bm.verts.new((x, y, z))
             verts.append(vert)
 
+    # Create faces
     bm.verts.ensure_lookup_table()
     for i in range(u_res - 1):
         for j in range(v_res - 1):
@@ -88,6 +91,7 @@ def create_parametric_surface(name, u_res=32, v_res=32):
             v4 = verts[i * v_res + (j + 1)]
             bm.faces.new([v1, v2, v3, v4])
 
+    # Write to mesh
     bm.to_mesh(mesh)
     bm.free()
 
@@ -105,12 +109,15 @@ def create_parametric_surface(name, u_res=32, v_res=32):
 ```python
 def animate_rotation(obj, start_frame=1, end_frame=250, axis='Z', rotations=2):
     """Animate object rotation over time."""
-    obj.rotation_euler[2] = 0
+    # Set initial keyframe
+    obj.rotation_euler[2] = 0  # Z axis
     obj.keyframe_insert(data_path="rotation_euler", index=2, frame=start_frame)
 
+    # Set end keyframe
     obj.rotation_euler[2] = rotations * 2 * math.pi
     obj.keyframe_insert(data_path="rotation_euler", index=2, frame=end_frame)
 
+    # Set interpolation
     if obj.animation_data and obj.animation_data.action:
         for fcurve in obj.animation_data.action.fcurves:
             if 'rotation_euler' in fcurve.data_path:
@@ -122,6 +129,7 @@ def animate_material_property(mat, property_path, values, frames):
     if not mat.node_tree:
         return
 
+    # Example: animate emission strength
     nodes = mat.node_tree.nodes
     emission = nodes.get('Emission')
     if emission:
@@ -137,6 +145,9 @@ def create_driver(obj, property_path, expression):
     driver = obj.driver_add(property_path)
     driver.driver.type = 'SCRIPTED'
     driver.driver.expression = expression
+
+    # Example: link rotation to frame number
+    # expression = "frame / 10"
 ```
 
 得：鍵插、動正回放。
@@ -160,14 +171,18 @@ def batch_import_and_render(input_dir, output_dir, file_pattern="*.obj"):
     scene = bpy.context.scene
 
     for obj_file in input_path.glob(file_pattern):
+        # Clear existing objects
         bpy.ops.object.select_all(action='SELECT')
         bpy.ops.object.delete()
 
+        # Import model
         bpy.ops.import_scene.obj(filepath=str(obj_file))
 
+        # Setup camera and lighting (reuse setup functions)
         setup_camera()
         setup_lighting()
 
+        # Render
         output_file = output_path / f"{obj_file.stem}.png"
         scene.render.filepath = str(output_file)
         bpy.ops.render.render(write_still=True)
@@ -183,8 +198,10 @@ def batch_material_variation(base_object, colors, output_prefix):
         return
 
     for i, color in enumerate(colors):
+        # Update material color
         bsdf.inputs['Base Color'].default_value = color + (1.0,)
 
+        # Render
         bpy.context.scene.render.filepath = f"{output_prefix}_{i:03d}.png"
         bpy.ops.render.render(write_still=True)
 ```
@@ -207,6 +224,7 @@ class OBJECT_OT_generate_spiral(bpy.types.Operator):
     bl_label = "Generate Spiral"
     bl_options = {'REGISTER', 'UNDO'}
 
+    # Operator properties
     radius: FloatProperty(
         name="Radius",
         description="Spiral radius",
@@ -232,13 +250,14 @@ class OBJECT_OT_generate_spiral(bpy.types.Operator):
     )
 
     def execute(self, context):
+        # Create curve
         curve = bpy.data.curves.new('Spiral', 'CURVE')
         curve.dimensions = '3D'
 
         spline = curve.splines.new('NURBS')
         num_points = self.turns * self.resolution
 
-        spline.points.add(num_points - 1)
+        spline.points.add(num_points - 1)  # -1 because one point exists
 
         for i in range(num_points):
             t = i / self.resolution
@@ -250,6 +269,7 @@ class OBJECT_OT_generate_spiral(bpy.types.Operator):
 
             spline.points[i].co = (x, y, z, 1.0)
 
+        # Create object
         obj = bpy.data.objects.new('Spiral', curve)
         context.collection.objects.link(obj)
         obj.select_set(True)
@@ -289,16 +309,19 @@ class OBJECT_OT_modal_scale(bpy.types.Operator):
 
     def modal(self, context, event):
         if event.type == 'MOUSEMOVE':
+            # Calculate scale based on mouse movement
             delta = event.mouse_x - self.initial_mouse_x
             scale = self.initial_scale + (delta / 100.0)
-            scale = max(0.1, scale)
+            scale = max(0.1, scale)  # Minimum scale
 
+            # Apply to active object
             context.active_object.scale = (scale, scale, scale)
 
         elif event.type == 'LEFTMOUSE':
             return {'FINISHED'}
 
         elif event.type in {'RIGHTMOUSE', 'ESC'}:
+            # Cancel - restore initial scale
             context.active_object.scale = (
                 self.initial_scale,
                 self.initial_scale,
@@ -341,10 +364,12 @@ bl_info = {
 
 import bpy
 
+# Import operator classes
 from .operators import OBJECT_OT_generate_spiral
 
 classes = (
     OBJECT_OT_generate_spiral,
+    # Add other classes
 )
 
 def menu_func(self, context):
@@ -385,10 +410,12 @@ def create_from_csv(filepath):
         reader = csv.DictReader(f)
 
         for row in reader:
+            # Parse data
             name = row['name']
             x, y, z = float(row['x']), float(row['y']), float(row['z'])
             scale = float(row.get('scale', 1.0))
 
+            # Create object
             bpy.ops.mesh.primitive_uv_sphere_add(location=(x, y, z))
             obj = bpy.context.active_object
             obj.name = name
@@ -399,6 +426,7 @@ def create_from_json(filepath):
     with open(filepath, 'r') as f:
         config = json.load(f)
 
+    # Process objects
     for obj_config in config.get('objects', []):
         obj_type = obj_config['type']
         location = obj_config['location']
@@ -411,6 +439,7 @@ def create_from_json(filepath):
         obj = bpy.context.active_object
         obj.name = obj_config.get('name', 'Object')
 
+        # Apply material if specified
         if 'material' in obj_config:
             mat_name = obj_config['material']
             mat = bpy.data.materials.get(mat_name)

--- a/i18n/wenyan-ultra/skills/serialize-data-formats/SKILL.md
+++ b/i18n/wenyan-ultra/skills/serialize-data-formats/SKILL.md
@@ -83,6 +83,7 @@ class Measurement:
     unit: str
     timestamp: datetime
 
+# Custom encoder for non-standard types
 class CustomEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime):
@@ -94,9 +95,11 @@ class CustomEncoder(json.JSONEncoder):
             return base64.b64encode(obj).decode('ascii')
         return super().default(obj)
 
+# Serialize
 measurement = Measurement("sensor-01", 23.5, "celsius", datetime.now())
 json_str = json.dumps(asdict(measurement), cls=CustomEncoder, indent=2)
 
+# Deserialize
 data = json.loads(json_str)
 ```
 
@@ -150,14 +153,16 @@ protoc --go_out=. sensors.proto
 from sensors_pb2 import Measurement, MeasurementBatch
 import time
 
+# Serialize
 m = Measurement(
     sensor_id="sensor-01",
     value=23.5,
     unit="celsius",
     timestamp_ms=int(time.time() * 1000)
 )
-binary = m.SerializeToString()
+binary = m.SerializeToString()  # Compact binary
 
+# Deserialize
 m2 = Measurement()
 m2.ParseFromString(binary)
 ```
@@ -172,6 +177,7 @@ m2.ParseFromString(binary)
 import msgpack
 from datetime import datetime
 
+# Custom packing for datetime
 def encode_datetime(obj):
     if isinstance(obj, datetime):
         return {"__datetime__": True, "s": obj.isoformat()}
@@ -184,8 +190,10 @@ def decode_datetime(obj):
 
 data = {"sensor_id": "sensor-01", "value": 23.5, "ts": datetime.now()}
 
+# Serialize (smaller than JSON, faster than JSON)
 packed = msgpack.packb(data, default=encode_datetime)
 
+# Deserialize
 unpacked = msgpack.unpackb(packed, object_hook=decode_datetime, raw=False)
 ```
 
@@ -200,6 +208,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pandas as pd
 
+# Create data
 df = pd.DataFrame({
     "sensor_id": ["s-01", "s-02", "s-01", "s-03"] * 1000,
     "value": [23.5, 18.2, 24.1, 19.8] * 1000,
@@ -207,9 +216,11 @@ df = pd.DataFrame({
     "timestamp": pd.date_range("2025-01-01", periods=4000, freq="min")
 })
 
+# Write Parquet (columnar, compressed)
 table = pa.Table.from_pandas(df)
 pq.write_table(table, "measurements.parquet", compression="snappy")
 
+# Read Parquet (can read specific columns without loading all data)
 table_back = pq.read_table("measurements.parquet", columns=["sensor_id", "value"])
 df_subset = table_back.to_pandas()
 ```
@@ -240,10 +251,12 @@ import pyarrow as pa, pyarrow.parquet as pq
 
 data = [{"id": i, "value": i * 0.1, "label": f"item-{i}"} for i in range(10000)]
 
+# JSON
 start = time.perf_counter()
 json_bytes = json.dumps(data).encode()
 json_time = time.perf_counter() - start
 
+# MessagePack
 start = time.perf_counter()
 msgpack_bytes = msgpack.packb(data)
 msgpack_time = time.perf_counter() - start

--- a/i18n/zh-CN/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/zh-CN/skills/rotate-scraping-proxies/SKILL.md
@@ -61,13 +61,13 @@ metadata:
 
 ```python
 # Inputs to confirm before writing any code:
-# 1. 数据是否公开（无需登录）？
-# 2. robots.txt 是否允许访问该路径？
-# 3. 站点的服务条款是否禁止自动化访问？（请通读）
-# 4. 抓取过程是否会处理个人数据？如果会，法律依据是什么？
-# 5. 此次访问是否会绕过地域授权、付费墙或身份认证？
-# 6. 是否存在公开 API 或数据转储，使抓取变得不必要？
-# 7. 如果范围较大，是否已与站点所有者联系？
+# 1. Is the data public (no login required)?
+# 2. Does robots.txt permit the path?
+# 3. Does the site's ToS prohibit automated access? (read it)
+# 4. Would the scraping process personal data? If yes, what is the legal basis?
+# 5. Could this access circumvent geo-licensing, paywalls, or auth?
+# 6. Is there a public API or data dump that would make scraping unnecessary?
+# 7. Have you contacted the site owner if scope is large?
 ```
 
 **Expected:** 每个问题都有可辩护的书面答案。出现第一个"否"或"未知"
@@ -116,7 +116,7 @@ import os
 import random
 from scrapling import Fetcher, StealthyFetcher
 
-# Pattern A: 服务商托管的轮换入口（单一 URL，服务商按请求内部轮换）
+# Pattern A: provider-managed rotating endpoint (one URL, provider rotates per request)
 PROXY_URL = os.environ["SCRAPING_PROXY_URL"]  # http://user:pass@gateway.example:7777
 
 fetcher = StealthyFetcher()
@@ -127,8 +127,8 @@ fetcher.configure(
     proxy=PROXY_URL,
 )
 
-# Pattern B: 显式代理池，自行轮换
-POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")  # 逗号分隔的 URL 列表
+# Pattern B: explicit pool, rotate yourself
+POOL = os.environ["SCRAPING_PROXY_POOL"].split(",")  # comma-separated URLs
 
 def fetch_with_rotation(url):
     proxy = random.choice(POOL)
@@ -153,14 +153,14 @@ def fetch_with_rotation(url):
 按工作负载确定轮换粒度，然后持续维持代理池的健康。
 
 ```python
-# 有状态流程（登录、类似购物车多页面抓取）使用粘滞会话
-# 多数服务商通过用户名暴露会话 ID：
+# Sticky session for stateful flows (login, multi-page checkout-like crawls)
+# Most providers expose a session ID via the username:
 #   user-session-abc123:pass@gateway.example:7777
-# 使用同一个会话 ID 的所有请求会在约 10 分钟内从同一个 IP 出口。
+# All requests with the same session ID exit through the same IP for ~10 min.
 
-# 匿名批量抓取使用按请求轮换（默认）
+# Per-request rotation for anonymous bulk scraping (default)
 
-# 代理池健康检查——在批量运行前调用
+# Pool health check — call before bulk run
 def check_pool(pool, sample_size=5):
     sample = random.sample(pool, min(sample_size, len(pool)))
     alive = []
@@ -175,7 +175,7 @@ def check_pool(pool, sample_size=5):
             pass
     return alive
 
-# 对瞬时代理故障进行退避重试
+# Backoff on transient proxy failures
 def fetch_with_backoff(url, max_attempts=3):
     for attempt in range(max_attempts):
         try:
@@ -236,7 +236,7 @@ for url in target_urls:
         break
     response = fetch_with_backoff(url)
     budget.record(success=response is not None)
-    time.sleep(1)  # 即便启用了轮换，也仍需保持限速
+    time.sleep(1)  # rate limiting still applies even with rotation
 ```
 
 **Expected:** 预算上限在成本失控前就先触发。日志中记录了每个代理的成功


### PR DESCRIPTION
Fourth tag-scoped batch of the #477 fence-parity backlog, after `yaml`+`json` (#495),
`bash` (#496) and `r` (#499). Restores **86 frozen `python` fences across 18 translated
SKILL.md files** to the body appearing in the paired English source at each file's
`source_commit`.

Produced by `npm run normalize:i18n-fences -- --tag python --write`, then reverting the
carve-out. No hand edits.

## Measured

| | before | after | delta |
|---|---:|---:|---:|
| python | 94 | 8 | **−86** |
| every other tag | 374 | 374 | 0 |
| **total findings** | **468** | **382** | **−86** |

`fencesCompared` holds at 22,998 and `filesCompared` at 3,644 — no fence created or
destroyed, only bodies replaced.

## Carve-out

`i18n/zh-CN/skills/implement-pharma-serialisation/SKILL.md` (3 python fences) declares
`domain: compliance` and is parked for the dedicated named-reviewer PR covering all 23
findings in that set across every tag. Register: #501.

Verified by scanning **every** changed file's declared domain, not by re-reading the
revert list. #476 has no affected file in this plan.

## Checks

| check | result |
|---|---|
| step-misalignment / fork detection (#498) | 0 suspects |
| placeholder drift (#497) | 0 |
| review: 3 locale-sharded agents + adversarial refuters | 8 raw, **0 survived** |

Refuted: 7 `semantic-value-change`, 1 `other`.

The fan-out ran under `guard:snapshot` / `guard:verify`; repo `unchanged at 7fc83ef8`.

## A vacuous pass in the fork detector, and what it exposed

The fork detector's containment measure returns 1 when a fence yields **no code tokens**,
so an unparseable fence scores a silent perfect. Instrumenting it: **8 of 86 changed
fences produced empty token sets**, meaning "0 suspects" actually covered 78. Those 8 are
comment-only fences — genuinely nothing to compare — and were inspected by hand instead.
Recorded as a constraint on #498: any implementation must report the empty-token case
rather than scoring it as a pass.

One of the eight is significant enough to have its own issue. `rotate-scraping-proxies`
Step 1 "Pre-flight Legality and Ethics Check" is a fence that is 100% comments and carries
the whole substance of the step — robots.txt, ToS, GDPR legal basis, geo-licensing
circumvention:

```python
# Inputs to confirm before writing any code:
# 1. Is the data public (no login required)?
...
# 4. Would the scraping process personal data? If yes, what is the legal basis?
```

The German prose says only *"Machen Sie den gesamten Arbeitsablauf von einer
dokumentierten rechtlichen und ethischen Prüfung abhängig"*, and **Expected:** refers to
*"jede Frage"* — seven questions that, after this restore, exist nowhere in German. Before
the batch they did.

**This PR is still correct.** #472 is settled and the fence must be English; reverting it
would restore the German text and reintroduce the parity violation, fixing nothing. What
is missing is the other half of the rule — *"lift the instruction into the step's prose"* —
which no batch has ever performed.

Corpus-wide there are **196 comment-only frozen fences across 106 files** (bash 104, r 60,
python 20, json 10), including content already merged in #496 and #499. Filed as **#502**
with a proposed triage: lift into English prose first so every locale inherits a
translatable home, then re-translate.

## Related

Parked-set register **#501** — created this round, and it corrected a figure from #499:
the regulated set is **23 findings across 6 files**, not 22 across 5.
`implement-pharma-serialisation` has no `r` fences, so it was absent from that batch's
carve-out while belonging to the parked set.

Advances #477 toward dropping `--warn`.
