### PR TITLE
fix(i18n): restore dockerfile code fences to their English source (#477 batch 5)

### DIFF
--- a/i18n/de/skills/containerize-mcp-server/SKILL.md
+++ b/i18n/de/skills/containerize-mcp-server/SKILL.md
@@ -48,7 +48,7 @@ Einen R-MCP-Server in einen Docker-Container fuer portables Deployment verpacken
 ```dockerfile
 FROM rocker/r-ver:4.5.0
 
-# Systemabhaengigkeiten installieren
+# Install system dependencies
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libssl-dev \
@@ -59,26 +59,26 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# R-Pakete installieren
+# Install R packages
 RUN R -e "install.packages(c( \
     'remotes', \
     'ellmer' \
     ), repos='https://cloud.r-project.org/')"
 
-# mcptools installieren
+# Install mcptools
 RUN R -e "remotes::install_github('posit-dev/mcptools')"
 
-# Arbeitsverzeichnis setzen
+# Set working directory
 WORKDIR /workspace
 
-# MCP-Server-Ports freigeben
+# Expose MCP server ports
 EXPOSE 3000 3001 3002
 
-# Umgebungsvariablen
+# Environment variables
 ENV R_LIBS_USER=/workspace/renv/library
 ENV RENV_PATHS_CACHE=/workspace/renv/cache
 
-# Standard: MCP-Server starten
+# Default: start MCP server
 CMD ["R", "-e", "mcptools::mcp_server()"]
 ```
 

--- a/i18n/de/skills/create-multistage-dockerfile/SKILL.md
+++ b/i18n/de/skills/create-multistage-dockerfile/SKILL.md
@@ -58,19 +58,19 @@ Multi-Stage-Dockerfiles erstellen, die minimale Produktions-Images erzeugen, ind
 Das Kernmuster: In einem grossen Image bauen, Artefakte in ein schlankes Image kopieren.
 
 ```dockerfile
-# ---- Build-Phase ----
+# ---- Build Stage ----
 FROM <build-image> AS builder
 WORKDIR /src
-COPY <abhaengigkeits-manifest> .
-RUN <abhaengigkeiten-installieren>
+COPY <dependency-manifest> .
+RUN <install-dependencies>
 COPY . .
-RUN <build-befehl>
+RUN <build-command>
 
-# ---- Laufzeit-Phase ----
-FROM <laufzeit-image>
-COPY --from=builder /src/<artefakt> /<ziel>
+# ---- Runtime Stage ----
+FROM <runtime-image>
+COPY --from=builder /src/<artifact> /<dest>
 EXPOSE <port>
-CMD [<einstiegspunkt>]
+CMD [<entrypoint>]
 ```
 
 ### Schritt 3: Sprachspezifische Muster anwenden

--- a/i18n/de/skills/create-r-dockerfile/SKILL.md
+++ b/i18n/de/skills/create-r-dockerfile/SKILL.md
@@ -62,18 +62,18 @@ Erstelle ein Dockerfile fuer R-Projekte mit rocker-Basisimages und ordnungsgemae
 ```dockerfile
 FROM rocker/r-ver:4.5.0
 
-# Systemabhaengigkeiten installieren
-# Nach Zweck gruppiert fuer Uebersichtlichkeit
+# Install system dependencies
+# Group by purpose for clarity
 RUN apt-get update && apt-get install -y \
     # HTTP/SSL
     libcurl4-openssl-dev \
     libssl-dev \
-    # XML-Verarbeitung
+    # XML processing
     libxml2-dev \
-    # Git-Integration
+    # Git integration
     libgit2-dev \
     libssh2-1-dev \
-    # Grafik
+    # Graphics
     libfontconfig1-dev \
     libharfbuzz-dev \
     libfribidi-dev \
@@ -81,33 +81,33 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libtiff5-dev \
     libjpeg-dev \
-    # Hilfsprogramme
+    # Utilities
     git \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# R-Pakete installieren
-# Reihenfolge: am wenigsten aenderbare zuerst fuer Cache-Effizienz
+# Install R packages
+# Order: least-changing first for cache efficiency
 RUN R -e "install.packages(c( \
     'remotes', \
     'devtools', \
     'renv' \
     ), repos='https://cloud.r-project.org/')"
 
-# Arbeitsverzeichnis setzen
+# Set working directory
 WORKDIR /workspace
 
-# Zuerst renv-Dateien kopieren (Cache-Layer)
+# Copy renv files first (cache layer)
 COPY renv.lock renv.lock
 COPY renv/activate.R renv/activate.R
 
-# Pakete aus Lockfile wiederherstellen
+# Restore packages from lockfile
 RUN R -e "renv::restore()"
 
-# Projektdateien kopieren
+# Copy project files
 COPY . .
 
-# Standardbefehl
+# Default command
 CMD ["R"]
 ```
 
@@ -149,13 +149,13 @@ docker run --rm -it r-project:latest R -e "sessionInfo()"
 Fuer Produktions-Deployments Multi-Stage-Builds verwenden:
 
 ```dockerfile
-# Build-Phase
+# Build stage
 FROM rocker/r-ver:4.5.0 AS builder
 RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev
 COPY renv.lock .
 RUN R -e "install.packages('renv'); renv::restore()"
 
-# Laufzeit-Phase
+# Runtime stage
 FROM rocker/r-ver:4.5.0
 COPY --from=builder /usr/local/lib/R/site-library /usr/local/lib/R/site-library
 COPY . /app

--- a/i18n/de/skills/optimize-docker-build-cache/SKILL.md
+++ b/i18n/de/skills/optimize-docker-build-cache/SKILL.md
@@ -47,21 +47,21 @@ Docker-Buildzeiten durch effektives Layer-Caching und Build-Optimierung reduzier
 Am wenigsten aenderbare Layer zuerst platzieren:
 
 ```dockerfile
-# 1. Basisimage (aendert sich selten)
+# 1. Base image (rarely changes)
 FROM rocker/r-ver:4.5.0
 
-# 2. Systemabhaengigkeiten (aendern sich gelegentlich)
+# 2. System dependencies (change occasionally)
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. Nur Abhaengigkeitsdateien (aendern sich bei Deps-Aenderungen)
+# 3. Dependency files only (change when deps change)
 COPY renv.lock renv.lock
 COPY renv/activate.R renv/activate.R
 RUN R -e "renv::restore()"
 
-# 4. Quellcode (aendert sich haeufig)
+# 4. Source code (changes frequently)
 COPY . .
 ```
 
@@ -105,14 +105,14 @@ COPY . .
 Build-Abhaengigkeiten von Laufzeitabhaengigkeiten trennen:
 
 ```dockerfile
-# Build-Phase - enthaelt Entwicklungstools
+# Build stage - includes dev tools
 FROM rocker/r-ver:4.5.0 AS builder
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev libssl-dev build-essential
 COPY renv.lock .
 RUN R -e "install.packages('renv'); renv::restore()"
 
-# Laufzeit-Phase - minimales Image
+# Runtime stage - minimal image
 FROM rocker/r-ver:4.5.0
 RUN apt-get update && apt-get install -y \
     libcurl4 libssl3 \
@@ -203,11 +203,11 @@ BuildKit ermoeglicht:
 ### Schritt 7: Cache-Mounts fuer Paketmanager verwenden
 
 ```dockerfile
-# R-Pakete mit persistentem Cache
+# R packages with persistent cache
 RUN --mount=type=cache,target=/usr/local/lib/R/site-library \
     R -e "install.packages('dplyr')"
 
-# npm mit persistentem Cache
+# npm with persistent cache
 RUN --mount=type=cache,target=/root/.npm \
     npm ci
 ```

--- a/i18n/es/skills/deploy-shiny-app/SKILL.md
+++ b/i18n/es/skills/deploy-shiny-app/SKILL.md
@@ -136,26 +136,26 @@ Crea un `Dockerfile`:
 ```dockerfile
 FROM rocker/shiny-verse:4.4.0
 
-# Instalar dependencias del sistema
+# Install system dependencies
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libssl-dev \
     libxml2-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Instalar paquetes R
+# Install R packages
 RUN R -e "install.packages(c('shiny', 'bslib', 'DT', 'plotly'))"
 
-# Copiar la app
+# Copy app
 COPY . /srv/shiny-server/myapp/
 
-# Configurar Shiny Server
+# Configure Shiny Server
 COPY shiny-server.conf /etc/shiny-server/shiny-server.conf
 
-# Exponer puerto
+# Expose port
 EXPOSE 3838
 
-# Ejecutar
+# Run
 CMD ["/usr/bin/shiny-server"]
 ```
 

--- a/i18n/ja/skills/containerize-mcp-server/SKILL.md
+++ b/i18n/ja/skills/containerize-mcp-server/SKILL.md
@@ -47,7 +47,7 @@ R MCPサーバーをDockerコンテナにパッケージ化し、ポータブル
 ```dockerfile
 FROM rocker/r-ver:4.5.0
 
-# システム依存関係のインストール
+# Install system dependencies
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libssl-dev \
@@ -58,26 +58,26 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Rパッケージのインストール
+# Install R packages
 RUN R -e "install.packages(c( \
     'remotes', \
     'ellmer' \
     ), repos='https://cloud.r-project.org/')"
 
-# mcptoolsのインストール
+# Install mcptools
 RUN R -e "remotes::install_github('posit-dev/mcptools')"
 
-# 作業ディレクトリの設定
+# Set working directory
 WORKDIR /workspace
 
-# MCPサーバーポートの公開
+# Expose MCP server ports
 EXPOSE 3000 3001 3002
 
-# 環境変数
+# Environment variables
 ENV R_LIBS_USER=/workspace/renv/library
 ENV RENV_PATHS_CACHE=/workspace/renv/cache
 
-# デフォルト: MCPサーバーの起動
+# Default: start MCP server
 CMD ["R", "-e", "mcptools::mcp_server()"]
 ```
 

--- a/i18n/ja/skills/create-multistage-dockerfile/SKILL.md
+++ b/i18n/ja/skills/create-multistage-dockerfile/SKILL.md
@@ -57,7 +57,7 @@ translation_date: 2026-03-16
 コアパターン：大きなイメージでビルドし、成果物をスリムなイメージにコピーする。
 
 ```dockerfile
-# ---- ビルドステージ ----
+# ---- Build Stage ----
 FROM <build-image> AS builder
 WORKDIR /src
 COPY <dependency-manifest> .
@@ -65,7 +65,7 @@ RUN <install-dependencies>
 COPY . .
 RUN <build-command>
 
-# ---- ランタイムステージ ----
+# ---- Runtime Stage ----
 FROM <runtime-image>
 COPY --from=builder /src/<artifact> /<dest>
 EXPOSE <port>

--- a/i18n/ja/skills/create-r-dockerfile/SKILL.md
+++ b/i18n/ja/skills/create-r-dockerfile/SKILL.md
@@ -59,18 +59,18 @@ rockerベースイメージを使用し、適切な依存関係管理を行うR�
 ```dockerfile
 FROM rocker/r-ver:4.5.0
 
-# システム依存関係のインストール
-# 目的別にグループ化して明確にする
+# Install system dependencies
+# Group by purpose for clarity
 RUN apt-get update && apt-get install -y \
     # HTTP/SSL
     libcurl4-openssl-dev \
     libssl-dev \
-    # XML処理
+    # XML processing
     libxml2-dev \
-    # Git統合
+    # Git integration
     libgit2-dev \
     libssh2-1-dev \
-    # グラフィックス
+    # Graphics
     libfontconfig1-dev \
     libharfbuzz-dev \
     libfribidi-dev \
@@ -78,33 +78,33 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     libtiff5-dev \
     libjpeg-dev \
-    # ユーティリティ
+    # Utilities
     git \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Rパッケージのインストール
-# 順序: キャッシュ効率のため変更頻度の低いものから
+# Install R packages
+# Order: least-changing first for cache efficiency
 RUN R -e "install.packages(c( \
     'remotes', \
     'devtools', \
     'renv' \
     ), repos='https://cloud.r-project.org/')"
 
-# 作業ディレクトリの設定
+# Set working directory
 WORKDIR /workspace
 
-# renvファイルを先にコピー（キャッシュレイヤー）
+# Copy renv files first (cache layer)
 COPY renv.lock renv.lock
 COPY renv/activate.R renv/activate.R
 
-# ロックファイルからパッケージを復元
+# Restore packages from lockfile
 RUN R -e "renv::restore()"
 
-# プロジェクトファイルをコピー
+# Copy project files
 COPY . .
 
-# デフォルトコマンド
+# Default command
 CMD ["R"]
 ```
 
@@ -146,13 +146,13 @@ docker run --rm -it r-project:latest R -e "sessionInfo()"
 本番デプロイにはマルチステージビルドを使用する：
 
 ```dockerfile
-# ビルドステージ
+# Build stage
 FROM rocker/r-ver:4.5.0 AS builder
 RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev
 COPY renv.lock .
 RUN R -e "install.packages('renv'); renv::restore()"
 
-# ランタイムステージ
+# Runtime stage
 FROM rocker/r-ver:4.5.0
 COPY --from=builder /usr/local/lib/R/site-library /usr/local/lib/R/site-library
 COPY . /app

--- a/i18n/ja/skills/deploy-shiny-app/SKILL.md
+++ b/i18n/ja/skills/deploy-shiny-app/SKILL.md
@@ -136,26 +136,26 @@ rsconnect::deployApp(
 ```dockerfile
 FROM rocker/shiny-verse:4.4.0
 
-# システム依存関係のインストール
+# Install system dependencies
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libssl-dev \
     libxml2-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Rパッケージのインストール
+# Install R packages
 RUN R -e "install.packages(c('shiny', 'bslib', 'DT', 'plotly'))"
 
-# アプリをコピー
+# Copy app
 COPY . /srv/shiny-server/myapp/
 
-# Shiny Serverの設定
+# Configure Shiny Server
 COPY shiny-server.conf /etc/shiny-server/shiny-server.conf
 
-# ポートを公開
+# Expose port
 EXPOSE 3838
 
-# 実行
+# Run
 CMD ["/usr/bin/shiny-server"]
 ```
 

--- a/i18n/ja/skills/optimize-docker-build-cache/SKILL.md
+++ b/i18n/ja/skills/optimize-docker-build-cache/SKILL.md
@@ -46,21 +46,21 @@ translation_date: 2026-03-16
 変更頻度の低いレイヤーを先に配置する：
 
 ```dockerfile
-# 1. ベースイメージ（ほとんど変更されない）
+# 1. Base image (rarely changes)
 FROM rocker/r-ver:4.5.0
 
-# 2. システム依存関係（たまに変更される）
+# 2. System dependencies (change occasionally)
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. 依存関係ファイルのみ（依存関係変更時に変わる）
+# 3. Dependency files only (change when deps change)
 COPY renv.lock renv.lock
 COPY renv/activate.R renv/activate.R
 RUN R -e "renv::restore()"
 
-# 4. ソースコード（頻繁に変更される）
+# 4. Source code (changes frequently)
 COPY . .
 ```
 
@@ -104,14 +104,14 @@ COPY . .
 ビルド依存関係とランタイムを分離する：
 
 ```dockerfile
-# ビルドステージ - 開発ツールを含む
+# Build stage - includes dev tools
 FROM rocker/r-ver:4.5.0 AS builder
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev libssl-dev build-essential
 COPY renv.lock .
 RUN R -e "install.packages('renv'); renv::restore()"
 
-# ランタイムステージ - 最小限のイメージ
+# Runtime stage - minimal image
 FROM rocker/r-ver:4.5.0
 RUN apt-get update && apt-get install -y \
     libcurl4 libssl3 \
@@ -202,11 +202,11 @@ BuildKitが有効にするもの：
 ### ステップ7: パッケージマネージャー用キャッシュマウントの使用
 
 ```dockerfile
-# 永続キャッシュ付きRパッケージ
+# R packages with persistent cache
 RUN --mount=type=cache,target=/usr/local/lib/R/site-library \
     R -e "install.packages('dplyr')"
 
-# 永続キャッシュ付きnpm
+# npm with persistent cache
 RUN --mount=type=cache,target=/root/.npm \
     npm ci
 ```


### PR DESCRIPTION
Fifth tag-scoped batch of the #477 fence-parity backlog, after `yaml`+`json` (#495), `bash` (#496), `r` (#499) and `python` (#503). Restores **16 frozen `dockerfile` fences across 10 translated SKILL.md files** to the body appearing in the paired English source at each file's `source_commit`.

## Measured

| | before | after | delta |
|---|---:|---:|---:|
| dockerfile | 37 | 21 | **−16** |
| every other tag | 345 | 345 | 0 |
| **total findings** | **382** | **366** | **−16** |

`fencesCompared` holds at 22,998 — no fence created or destroyed.

Only 16 of the 37 `dockerfile` findings are normalizer-reachable. The other 21 are ordinal-unsound or live in the `agents`/`teams`/`guides` mirrors, both tracked in the parked-set register (#501).

## Carve-outs

None apply. No `domain: compliance` file and no #476-affected skill appears in this plan — verified by scanning every changed file's declared domain, not by consulting a list.

## Checks — full coverage this time

| check | result |
|---|---|
| fork / step-misalignment containment (#498) | 0 suspects |
| **empty-token audit** | **0 detector-blind fences (16/16 measured)** |
| placeholder drift (#497) | 0 |
| review: 2 locale-sharded agents + adversarial refuters | **0 raw findings** |
| heading-count correspondence, all 10 files | matches English |

The empty-token audit is new since #503 and is the reason this batch's zero means more than that one's did. The containment measure returns 1 when a fence yields no code tokens, so an unparseable fence scores a silent perfect; on #503 that hid 8 of 86 fences behind an apparent "0 suspects". Here all 16 fences yielded measurable tokens, so the fork detector's zero genuinely spans the batch.

Heading-count correspondence is included as a second, independent signal, with the caveat that it is weak on its own — `de/design-shiny-ui` had matching counts in #498 and was still a fork. Containment is the load-bearing check; the counts merely agree with it.

The fan-out ran under `guard:snapshot` / `guard:verify`; repo `unchanged at 507f39eb`.

## Gates

- `npm run validate:line-endings` — clean
- `node scripts/check-content-style.js --added` — 0 blocking errors
- no translated SKILL.md over the 500-line limit

Advances #477 toward dropping `--warn`. Parked-set register: #501.