### PR TITLE
fix(deps): bump mermaid to 11.16.1 in viz to clear 5 security advisories

### DIFF
--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -2583,9 +2583,9 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",


### PR DESCRIPTION
Clears **all five open Dependabot alerts** on the default branch. Every one is `mermaid`, and all five are fixed by the same patch release.

| severity | advisory |
|---|---|
| medium | Architecture diagrams vulnerable to prototype pollution |
| medium | XY Charts vulnerable to an infinite-loop DoS |
| medium | CSS injection applying to sibling elements |
| medium | radar diagrams vulnerable to DoS |
| low | configuration APIs allow prototype pollution |

Vulnerable range is `>= 11.6.0, < 11.16.1`.

## Why this is a one-line change

`viz/package.json` already declares `"mermaid": "^11.16.0"`, which admits `11.16.1`. Only `viz/package-lock.json` was pinning the vulnerable build at `11.16.0`. Applied with:

```bash
cd viz && npm update mermaid --package-lock-only
```

The manifest is untouched and no other dependency moved — the diff is 3 lines (`version`, `resolved`, `integrity`).

## Reachability

`mermaid` is a **runtime** dependency of the visualization, not a build-only or transitive one: `viz/js/workflow.js` fetches `data/workflow.mmd` and renders it client-side. So the advisories describe code paths the published site actually executes, which is why this is worth doing promptly rather than waiting for a Dependabot PR.

Dependabot had not opened a PR for these — the three it did open (#487, #488, #489, all merged earlier today) covered `js-yaml` and `vite`.