### PR TITLE
fix(i18n): restore yaml and typescript code fences to English (#477 batch 6)

### DIFF
--- a/i18n/de/skills/escalate-issues/SKILL.md
+++ b/i18n/de/skills/escalate-issues/SKILL.md
@@ -207,16 +207,15 @@ to_agent: security-analyst
 blocking: false
 ---
 
-# Sicherheitsbedenken: Hartcodierter API-Schluessel in Konfiguration
+# Security Concern: Hardcoded API Key in Config
 
-**Datei**: config/production.yml:45
-**Muster**: API_KEY="sk_live_abc123..."
+**File**: config/production.yml:45
+**Pattern**: API_KEY="sk_live_abc123..."
 
-**Anfrage**: Bitte pruefen ob dies ein gueltiges Geheimnis oder ein
-Platzhalter ist. Wenn gueltig, sichere Credential-Management-Strategie
-empfehlen.
+**Request**: Please review if this is a valid secret or a placeholder.
+If valid, recommend secure credential management strategy.
 
-**Kontext**: Waehrend Konfigurations-Bereinigungsdurchlauf entdeckt.
+**Context**: Discovered during config cleanup sweep.
 ```
 
 **Fuer menschliche Pruefer** (ausfuehrliches Markdown):

--- a/i18n/es/skills/scaffold-nextjs-app/SKILL.md
+++ b/i18n/es/skills/scaffold-nextjs-app/SKILL.md
@@ -94,10 +94,10 @@ Edita `next.config.ts` según las necesidades del proyecto:
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // Habilitar modo estricto de React
+  // Enable React strict mode
   reactStrictMode: true,
 
-  // Dominios de optimización de imágenes
+  // Image optimization domains
   images: {
     remotePatterns: [
       {

--- a/i18n/es/skills/setup-tailwind-typescript/SKILL.md
+++ b/i18n/es/skills/setup-tailwind-typescript/SKILL.md
@@ -194,8 +194,8 @@ Actualiza `tailwind.config.ts`:
 
 ```typescript
 const config: Config = {
-  darkMode: "class", // o "media" para la preferencia del sistema
-  // ... resto de la configuración
+  darkMode: "class", // or "media" for system preference
+  // ... rest of config
 };
 ```
 

--- a/i18n/ja/skills/scaffold-nextjs-app/SKILL.md
+++ b/i18n/ja/skills/scaffold-nextjs-app/SKILL.md
@@ -93,10 +93,10 @@ my-app/
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // Reactストリクトモードを有効にする
+  // Enable React strict mode
   reactStrictMode: true,
 
-  // 画像最適化ドメイン
+  // Image optimization domains
   images: {
     remotePatterns: [
       {

--- a/i18n/ja/skills/setup-tailwind-typescript/SKILL.md
+++ b/i18n/ja/skills/setup-tailwind-typescript/SKILL.md
@@ -193,8 +193,8 @@ export function Button({ className, variant = "primary", ...props }: ButtonProps
 
 ```typescript
 const config: Config = {
-  darkMode: "class", // システム設定の場合は"media"
-  // ... 残りの設定
+  darkMode: "class", // or "media" for system preference
+  // ... rest of config
 };
 ```
 

--- a/i18n/wenyan-ultra/skills/scaffold-mcp-server/SKILL.md
+++ b/i18n/wenyan-ultra/skills/scaffold-mcp-server/SKILL.md
@@ -154,6 +154,7 @@ export function registerTools(server: McpServer): void {
     },
     async ({ param1, param2 }) => {
       try {
+        // TODO: Implement tool logic
         const result = await performAction(param1, param2);
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -273,9 +274,11 @@ async function runTests(): Promise<void> {
   const client = new Client({ name: "test-client", version: "1.0.0" });
   await client.connect(clientTransport);
 
+  // Test: tools/list returns all expected tools
   const tools = await client.listTools();
   console.assert(tools.tools.length === EXPECTED_TOOL_COUNT);
 
+  // Test: each tool with valid input
   for (const tool of tools.tools) {
     const result = await client.callTool({
       name: tool.name,
@@ -284,6 +287,7 @@ async function runTests(): Promise<void> {
     console.assert(!result.isError, `${tool.name} failed`);
   }
 
+  // Test: each tool with invalid input returns isError
   for (const tool of tools.tools) {
     const result = await client.callTool({
       name: tool.name,

--- a/i18n/wenyan-ultra/skills/scaffold-nextjs-app/SKILL.md
+++ b/i18n/wenyan-ultra/skills/scaffold-nextjs-app/SKILL.md
@@ -93,8 +93,10 @@ my-app/
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Enable React strict mode
   reactStrictMode: true,
 
+  // Image optimization domains
   images: {
     remotePatterns: [
       {

--- a/i18n/wenyan-ultra/skills/setup-tailwind-typescript/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-tailwind-typescript/SKILL.md
@@ -193,7 +193,7 @@ export function Button({ className, variant = "primary", ...props }: ButtonProps
 
 ```typescript
 const config: Config = {
-  darkMode: "class",
+  darkMode: "class", // or "media" for system preference
   // ... rest of config
 };
 ```


### PR DESCRIPTION
Sixth tag-scoped batch of the #477 fence-parity backlog. Restores **9 frozen fences (1 `yaml`, 8 `typescript`) across 8 translated SKILL.md files**.

## Measured

| tag | before | after |
|---|---:|---:|
| yaml | 34 | 33 |
| typescript | 27 | 19 |
| **total findings** | **366** | **357** |

Every other tag at zero delta; `fencesCompared` holds at 22,998.

**Two tags in one PR.** The remaining backlog is long-tailed — strict one-tag-per-PR would mean nine more. The diff stays reviewable and revertable as a unit, which is what #477's tag-scoping is for. The tail (nginx 9, javascript 7, json 7, protobuf 7, go 6, css 5, latex 2 and six singletons) is planned as one final batch.

## #476 exclusion — the first batch that actually needed one

The plan contained 7 fences in #476-affected files. They split two ways, and the difference is the whole point of checking rather than excluding by filename:

**`setup-putior-ci` × 6 locales — EXCLUDED.** Here the divergent `yaml` fence *is* the runaway. #476 records it as `yaml` at English L47 spanning 42 lines, and `extractFences` confirms fence 0 is that block — 47 lines in `caveman`, the 5 extra being the #475 scaffolder injection. Restoring a runaway against a basis that mis-parses it is exactly what #476 forbids. Reverted after the write, as batch 1 did.

**`de/escalate-issues` — KEPT.** Its runaways are fences 2 and 4, both `text` and `markdown` and therefore exempt. The divergent frozen fence is fence 3 (`yaml`, L201), lying between them and inside neither.

Batches 2–5 needed no exclusion at all, each verified the same way rather than assumed.

## A policy question, escalated rather than decided — #507

The `de/escalate-issues` fence is a **hybrid**. It is legitimately tagged `yaml` because it opens with machine-consumed frontmatter (`type: escalation`, `to_agent: security-analyst`, introduced in prose as "structured format for MCP tools") — but everything after the `---` is a human-fillable report:

```
# Security Concern: Hardcoded API Key in Config
**File**: config/production.yml:45
**Request**: Please review if this is a valid secret or a placeholder.
```

That body is precisely what the `text`/`markdown` exemption exists to protect — *"a German reviewer should be able to emit a German report"*. A whole-fence freeze cannot govern the two halves differently.

This PR **restores it**, because default-deny is settled and an ad-hoc exemption here is the retagging attack CLAUDE.md explicitly warns the rule against. #507 records the question and proposes splitting the fence in the English source: frozen ```yaml for the frontmatter, localisable ```markdown for the body.

## Checks

| check | result |
|---|---|
| fork / step-misalignment containment (#498) | 0 suspects |
| empty-token audit | **0 detector-blind (9/9 measured)** |
| placeholder drift (#497) | 0 |
| compliance leak scan | clean, no `domain: compliance` file in plan |
| line endings · content-style `--added` · 500-line limit | clean |

Parked-set register: #501. Advances #477 toward dropping `--warn`.