### PR TITLE
fix(i18n): restore the remaining reachable fences (#477 batch 7, final mechanical)

### DIFF
--- a/i18n/caveman-ultra/skills/instrument-distributed-tracing/SKILL.md
+++ b/i18n/caveman-ultra/skills/instrument-distributed-tracing/SKILL.md
@@ -171,7 +171,7 @@ import (
     "context"
     "github.com/gin-gonic/gin"
     "go.opentelemetry.io/otel"
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Node.js w/ Express**:
@@ -190,7 +190,7 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc')
 const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
 const { Resource } = require('@opentelemetry/resources');
 const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 → Traces from svcs appear in Jaeger UI / Grafana. HTTP req → spans auto.
@@ -227,7 +227,7 @@ import (
     "go.opentelemetry.io/otel/attribute"
     "go.opentelemetry.io/otel/codes"
     "go.opentelemetry.io/otel/trace"
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Span attrs best practice**:
@@ -269,7 +269,7 @@ import (
     "go.opentelemetry.io/otel/propagation"
 )
 
-# ... (see EXAMPLES.md)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Msg queue propagation** (Kafka):

--- a/i18n/de/skills/configure-nginx/SKILL.md
+++ b/i18n/de/skills/configure-nginx/SKILL.md
@@ -196,7 +196,7 @@ docker compose run --rm certbot certonly \
 
 ```nginx
 server {
-    # ... SSL-Konfiguration oben ...
+    # ... SSL config above ...
 
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -205,7 +205,7 @@ server {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';" always;
 
-    # Nginx-Version verbergen
+    # Hide Nginx version
     server_tokens off;
 }
 ```
@@ -214,7 +214,7 @@ server {
 
 ```nginx
 http {
-    # Rate-Limit-Zonen definieren
+    # Define rate limit zones
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=login:10m rate=1r/s;
 

--- a/i18n/de/skills/repair-broken-references/SKILL.md
+++ b/i18n/de/skills/repair-broken-references/SKILL.md
@@ -236,10 +236,10 @@ Import-Anweisungen aktualisieren um nach Verschiebungen auf korrekte Pfade zu ve
 
 **JavaScript-Beispiel**:
 ```javascript
-// Vorher (defekt)
+// Before (broken)
 import { helper } from './utils/helper';
 
-// Nachher (repariert — Datei nach lib/ verschoben)
+// After (fixed — file moved to lib/)
 import { helper } from './lib/helper';
 ```
 

--- a/i18n/de/skills/review-web-design/SKILL.md
+++ b/i18n/de/skills/review-web-design/SKILL.md
@@ -80,7 +80,7 @@ Visuelle Hierarchie fuehrt das Auge des Nutzers durch Inhalte nach Wichtigkeit.
 - [ ] **Schriftgroesse**: Basis-Schriftgroesse betraegt mindestens 16px fuer Fliesstext
 
 ```css
-/* Beispiel gut strukturierte Typoskala (Verhaeltnis 1,25) */
+/* Example well-structured type scale (1.25 ratio) */
 :root {
   --text-xs: 0.64rem;    /* 10.24px */
   --text-sm: 0.8rem;     /* 12.8px */

--- a/i18n/de/skills/serialize-data-formats/SKILL.md
+++ b/i18n/de/skills/serialize-data-formats/SKILL.md
@@ -126,7 +126,7 @@ message Measurement {
   string sensor_id = 1;
   double value = 2;
   string unit = 3;
-  int64 timestamp_ms = 4;  // Unix-Millisekunden
+  int64 timestamp_ms = 4;  // Unix milliseconds
 }
 
 message MeasurementBatch {

--- a/i18n/es/skills/review-web-design/SKILL.md
+++ b/i18n/es/skills/review-web-design/SKILL.md
@@ -80,7 +80,7 @@ La jerarquía visual guía el ojo del usuario a través del contenido en orden d
 - [ ] **Tamaño de fuente**: El tamaño base de fuente es al menos 16px para el texto del cuerpo
 
 ```css
-/* Ejemplo de escala tipográfica bien estructurada (ratio 1.25) */
+/* Example well-structured type scale (1.25 ratio) */
 :root {
   --text-xs: 0.64rem;    /* 10.24px */
   --text-sm: 0.8rem;     /* 12.8px */

--- a/i18n/ja/skills/configure-alerting-rules/SKILL.md
+++ b/i18n/ja/skills/configure-alerting-rules/SKILL.md
@@ -193,7 +193,7 @@ curl -X POST http://localhost:9090/-/reload
 {{ end }}
 {{ end }}
 
-# ... (完全なメールとPagerDutyのテンプレートはEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete email and PagerDuty templates)
 ```
 
 **レシーバーでテンプレートを使用**：

--- a/i18n/ja/skills/configure-nginx/SKILL.md
+++ b/i18n/ja/skills/configure-nginx/SKILL.md
@@ -193,7 +193,7 @@ docker compose run --rm certbot certonly \
 
 ```nginx
 server {
-    # ... 上記のSSL設定 ...
+    # ... SSL config above ...
 
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -202,7 +202,7 @@ server {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';" always;
 
-    # Nginxバージョンを隠す
+    # Hide Nginx version
     server_tokens off;
 }
 ```
@@ -211,7 +211,7 @@ server {
 
 ```nginx
 http {
-    # レート制限ゾーンの定義
+    # Define rate limit zones
     limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=login:10m rate=1r/s;
 

--- a/i18n/ja/skills/instrument-distributed-tracing/SKILL.md
+++ b/i18n/ja/skills/instrument-distributed-tracing/SKILL.md
@@ -174,7 +174,7 @@ import (
     "context"
     "github.com/gin-gonic/gin"
     "go.opentelemetry.io/otel"
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **Node.jsとExpress**：
@@ -193,7 +193,7 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc')
 const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
 const { Resource } = require('@opentelemetry/resources');
 const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **期待結果：** インストルメントされたサービスからのトレースがJaegerのUIまたはGrafanaに表示され、HTTPリクエストが自動的にスパンを作成する。
@@ -230,7 +230,7 @@ import (
     "go.opentelemetry.io/otel/attribute"
     "go.opentelemetry.io/otel/codes"
     "go.opentelemetry.io/otel/trace"
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **スパン属性のベストプラクティス**：
@@ -272,7 +272,7 @@ import (
     "go.opentelemetry.io/otel/propagation"
 )
 
-# ... (完全な設定はEXAMPLES.mdを参照)
+# ... (see EXAMPLES.md for complete configuration)
 ```
 
 **メッセージキューの伝播**（Kafka）：

--- a/i18n/ja/skills/serialize-data-formats/SKILL.md
+++ b/i18n/ja/skills/serialize-data-formats/SKILL.md
@@ -129,7 +129,7 @@ message Measurement {
   string sensor_id = 1;
   double value = 2;
   string unit = 3;
-  int64 timestamp_ms = 4;  // Unixミリ秒
+  int64 timestamp_ms = 4;  // Unix milliseconds
 }
 
 message MeasurementBatch {

--- a/i18n/wenyan-ultra/skills/run-chaos-experiment/SKILL.md
+++ b/i18n/wenyan-ultra/skills/run-chaos-experiment/SKILL.md
@@ -186,8 +186,13 @@ kubectl get events -n production --sort-by=.metadata.creationTimestamp | grep ap
 察影於 Grafana：
 
 ```promql
+# Error rate during experiment
 rate(http_requests_total{status=~"5..", job="api"}[1m])
+
+# Latency spike
 histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job="api"}[1m]))
+
+# Pod restarts
 rate(kube_pod_container_status_restarts_total{pod=~"api-.*"}[5m])
 ```
 

--- a/i18n/wenyan-ultra/skills/scaffold-cli-command/SKILL.md
+++ b/i18n/wenyan-ultra/skills/scaffold-cli-command/SKILL.md
@@ -115,18 +115,23 @@ program
 
 ```javascript
 .action(async (name, options) => {
+  // 1. Get shared context (registries, adapters, paths)
   const ctx = getContext(options);
 
+  // 2. Resolve what to operate on
   const items = resolveItems(ctx, name, options);
   if (!items || items.length === 0) {
     reporter.error('Nothing found.');
     process.exit(1);
   }
 
+  // 3. Preview if dry-run
   if (options.dryRun) reporter.printDryRun();
 
+  // 4. Execute the operation
   const results = await executeOperation(items, ctx, options);
 
+  // 5. Output results (3 modes)
   if (options.json) {
     console.log(JSON.stringify(results, null, 2));
   } else if (options.quiet) {
@@ -187,6 +192,7 @@ if (options.quiet) {
   reporter.printResults(results);
   return;
 }
+// Default: human-readable output
 printHumanReadable(results, options);
 ```
 
@@ -231,11 +237,13 @@ if (options.json) {
 ### 六：理誤與邊例
 
 ```javascript
+// Unknown item
 if (!item) {
   reporter.error(`Unknown: ${name}. Use 'tool list' to browse.`);
   process.exit(1);
 }
 
+// Confirmation for destructive actions
 if (!options.yes && !options.quiet && !options.dryRun) {
   const answer = await askYesNo('Proceed?');
   if (!answer) {
@@ -244,6 +252,7 @@ if (!options.yes && !options.quiet && !options.dryRun) {
   }
 }
 
+// State validation
 if (!state.fires[name]) {
   reporter.error(`Not active. Nothing to remove.`);
   process.exit(1);
@@ -273,7 +282,7 @@ function run(args) {
 }
 
 describe('new-command', () => {
-  after(() => { });
+  after(() => { /* cleanup created files/state */ });
 
   it('dry-run shows preview', () => {
     const out = run('new-command arg --dry-run');

--- a/i18n/wenyan-ultra/skills/serialize-data-formats/SKILL.md
+++ b/i18n/wenyan-ultra/skills/serialize-data-formats/SKILL.md
@@ -131,7 +131,7 @@ message Measurement {
   string sensor_id = 1;
   double value = 2;
   string unit = 3;
-  int64 timestamp_ms = 4;
+  int64 timestamp_ms = 4;  // Unix milliseconds
 }
 
 message MeasurementBatch {

--- a/i18n/wenyan-ultra/skills/setup-uptime-checks/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-uptime-checks/SKILL.md
@@ -398,6 +398,7 @@ services:
 選丙：自態頁自 Prometheus 指：
 
 ```html
+<!-- Simple status page (served via Nginx or GitHub Pages) -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/i18n/zh-CN/skills/review-web-design/SKILL.md
+++ b/i18n/zh-CN/skills/review-web-design/SKILL.md
@@ -78,7 +78,7 @@ metadata:
 - [ ] **字号**：正文文本基础字号至少为 16px
 
 ```css
-/* 示例良好结构的字号比例（1.25 比率） */
+/* Example well-structured type scale (1.25 ratio) */
 :root {
   --text-xs: 0.64rem;    /* 10.24px */
   --text-sm: 0.8rem;     /* 12.8px */


### PR DESCRIPTION
Seventh and **last mechanical batch**. Restores **26 frozen fences across 15 translated SKILL.md files**, spanning every tag still reachable rather than one — the tail is long and thin (nginx, protobuf, css, json, go, javascript, sql all in single digits).

Findings **357 → 331**. `fencesCompared` holds at 22,998 and `filesCompared` at 3,644.

## After this, the mechanical backlog is exhausted

The arithmetic closes exactly:

| | findings | files |
|---|---:|---:|
| still normalizer-reachable — **all of it carved out** | 38 | 14 |
| ordinal mapping unsound | 206 | 46 |
| `agents`/`teams`/`guides` mirrors | 87 | 11 |
| **total** | **331** | |

Every fence a tool can safely fix has been fixed across #495, #496, #499, #503, #505, #508 and this PR. What remains needs a human, and is registered in **#501**:

| parked | findings | why |
|---|---:|---|
| regulated content, 6 files | 23 | named reviewer required; includes the 21 CFR Part 11 line |
| `de/design-shiny-ui` | 8 | content fork — needs re-scaffolding, not a fence restore (#498) |
| #476 runaway fences | 7 | the basis itself mis-parses |

## `de/tidy-project-structure` cuts both ways

Batch 2 **kept** its four `bash` fences, having verified they sit outside the runaway `text` region at L193–219. This batch **excludes** its `language` fence at L178, having verified it sits inside. Same file, opposite calls, both from `extractFences` rather than from the filename — which is the argument against excluding by name.

That `language` fence is the corpus's only one, and #476 names it explicitly: *"the single `language`-tagged one sits inside runaway regions."* It is a phantom that exists only because the template mis-parses, so restoring it would be meaningless.

## Checks

| check | result |
|---|---|
| placeholder drift (#497) | 0 |
| fork containment (#498) | 4 flagged — **all verified false**, see below |
| empty-token audit | 1 unmeasurable fence, verified comment-only |
| review: 3 locale-sharded agents + adversarial refuters | **0 raw findings** |
| heading correspondence | 1 flagged — verified false, see below |
| compliance leak scan | clean |
| line endings · content-style `--added` · 500-line limit | clean |

**The 4 fork suspects are a detector defect, not content.** All scored 0.00 — the maximum signal — on comment-only restores in `//` and `/* */` syntax:

```diff
-// Vorher (defekt)
+// Before (broken)
-/* Beispiel gut strukturierte Typoskala (Verhaeltnis 1,25) */
+/* Example well-structured type scale (1.25 ratio) */
```

The prototype strips `#` comments only, so in JavaScript and CSS fences the "code tokens" it measures **are comment words**. Verified at 0 non-comment changed lines in each of the four. Recorded on #498 as its third constraint, and the dangerous one: a JS/CSS fence that genuinely *was* misaligned would look identical, so the signal is unusable for those tags until fixed.

**The heading mismatch is a compressed-locale artifact.** `wenyan-ultra/run-chaos-experiment` has 9 `###` headings against English's 15. Resolved by three independent signals: containment 1.00, a purely additive diff (three PromQL comments — `# Error rate during experiment`, `# Latency spike`, `# Pod restarts`), and those comments verified present in the English source at L212/215/218. `wenyan-ultra` compresses headings by design; `caveman-ultra` kept all 15 in the same file, so this is per-file translator judgment rather than a systematic rule. The heading check therefore does not apply to the six compressed locales.

The fan-out ran under `guard:snapshot` / `guard:verify`; repo `unchanged at 6bedcd60`.

Advances #477 to the point where dropping `--warn` depends only on the parked set.