### PR TITLE
fix(content): repair runaway code fences and re-mirror (#476, #500)

### DIFF
--- a/agents/security-analyst.md
+++ b/agents/security-analyst.md
@@ -240,7 +240,6 @@ Header always set X-Content-Type-Options nosniff
 Header always set X-Frame-Options DENY
 SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
 ```
-```text
 
 ## Security Incident Response
 

--- a/agents/senior-web-designer.md
+++ b/agents/senior-web-designer.md
@@ -122,7 +122,6 @@ theme: {
   }
 }
 ```
-```text
 
 ## Limitations
 

--- a/i18n/caveman-lite/skills/escalate-issues/SKILL.md
+++ b/i18n/caveman-lite/skills/escalate-issues/SKILL.md
@@ -94,7 +94,7 @@ Is it purely cosmetic? → LOW
 Capture all relevant context for the specialist to review.
 
 **Issue Report Template**:
-```markdown
+````markdown
 # Issue: [Brief Title]
 
 **Severity**: CRITICAL | HIGH | MEDIUM | LOW
@@ -138,7 +138,7 @@ Clear description of the problem in 2-3 sentences.
 
 - [Link to related documentation]
 - [Link to similar past issues]
-```text
+````
 
 **Got:** Issue documented with full context in `ESCALATION_REPORTS/issue_YYYYMMDD_HHMM.md`
 

--- a/i18n/caveman-lite/skills/plan-release-cycle/SKILL.md
+++ b/i18n/caveman-lite/skills/plan-release-cycle/SKILL.md
@@ -133,7 +133,7 @@ P0 features block the release. P1 features should be included if ready. P2 featu
 
 Define how release candidates are produced and tested:
 
-```markdown
+````markdown
 ### Release Candidate Process
 
 1. **RC1 Tag**: Tag from the stabilization branch after all P0 features merged and CI green
@@ -161,7 +161,7 @@ Define how release candidates are produced and tested:
    ```bash
    git tag -a v2.0.0-rc.2 -m "Release candidate 2 for v2.0.0"
    ```
-```text
+````
 
 **Got:** RC process documented with tagging convention, distribution method, testing checklist, and escalation criteria.
 

--- a/i18n/caveman-lite/skills/setup-putior-ci/SKILL.md
+++ b/i18n/caveman-lite/skills/setup-putior-ci/SKILL.md
@@ -179,7 +179,7 @@ Key configuration points:
 
 Insert sentinel markers in the target file where the diagram should appear.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -191,7 +191,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **Expected:** Sentinel markers in README.md (or other target file). The content between them will be replaced on each CI run.
 

--- a/i18n/caveman-lite/skills/tidy-project-structure/SKILL.md
+++ b/i18n/caveman-lite/skills/tidy-project-structure/SKILL.md
@@ -161,7 +161,7 @@ Fix broken links, update examples, add missing sections.
 5. Update copyright year
 
 **README template structure**:
-```markdown
+````markdown
 # Project Name
 
 Brief description (1-2 sentences).
@@ -189,7 +189,7 @@ Link to CONTRIBUTING.md or inline guidelines.
 ## License
 
 LICENSE badge and link.
-```text
+````
 
 **Got:** All READMEs updated; examples verified to run
 

--- a/i18n/caveman-lite/skills/write-claude-md/SKILL.md
+++ b/i18n/caveman-lite/skills/write-claude-md/SKILL.md
@@ -88,7 +88,7 @@ Key architectural decisions and patterns used in this project.
 
 **For R packages**:
 
-```markdown
+````markdown
 ## Development Workflow
 
 ```r
@@ -110,7 +110,7 @@ devtools::check()       # Full package check
 - `.Rprofile` - Session configuration
 - `.Renviron` - Environment variables (git-ignored)
 - `renv.lock` - Locked dependencies
-```text
+````
 
 **For Node.js/TypeScript**:
 

--- a/i18n/caveman-lite/skills/write-claude-md/SKILL.md
+++ b/i18n/caveman-lite/skills/write-claude-md/SKILL.md
@@ -49,7 +49,7 @@ Create a CLAUDE.md file that gives AI assistants effective project-specific cont
 
 Place `CLAUDE.md` in the project root:
 
-```markdown
+````markdown
 # Project Name
 
 Brief description of what this project is and its purpose.
@@ -78,7 +78,7 @@ Key architectural decisions and patterns used in this project.
 - Always use descriptive variable names
 - Follow [language-specific style guide]
 - Write tests for all new functionality
-```text
+````
 
 **Got:** A `CLAUDE.md` file exists in the project root with at minimum a project description, quick start commands, architecture overview, and conventions section.
 

--- a/i18n/caveman-lite/skills/write-vignette/SKILL.md
+++ b/i18n/caveman-lite/skills/write-vignette/SKILL.md
@@ -55,7 +55,7 @@ usethis::use_vignette("getting-started", title = "Getting Started with packagena
 
 ### Step 2: Write Vignette Content
 
-```markdown
+````markdown
 ---
 title: "Getting Started with packagename"
 output: rmarkdown::html_vignette
@@ -98,7 +98,7 @@ Cover optional or advanced functionality.
 ## Conclusion
 
 Summarize and point to other vignettes or resources.
-```text
+````
 
 **Got:** The vignette Rmd file contains Introduction, Installation, Basic Usage, Advanced Features, and Conclusion sections. Code examples use the package's exported functions and produce visible output.
 

--- a/i18n/caveman-ultra/skills/escalate-issues/SKILL.md
+++ b/i18n/caveman-ultra/skills/escalate-issues/SKILL.md
@@ -94,7 +94,7 @@ If err: uncertain → default HIGH, escalate human re-triage.
 Capture context for specialist.
 
 **Report Template**:
-```markdown
+````markdown
 # Issue: [Brief Title]
 
 **Severity**: CRITICAL | HIGH | MEDIUM | LOW
@@ -138,7 +138,7 @@ Clear description of the problem in 2-3 sentences.
 
 - [Link to related documentation]
 - [Link to similar past issues]
-```text
+````
 
 → Documented w/ full context → `ESCALATION_REPORTS/issue_YYYYMMDD_HHMM.md`.
 

--- a/i18n/caveman-ultra/skills/plan-release-cycle/SKILL.md
+++ b/i18n/caveman-ultra/skills/plan-release-cycle/SKILL.md
@@ -130,7 +130,7 @@ If err: P0 at risk of missing freeze → escalate immediately. Options: extend d
 
 How RCs are produced + tested:
 
-```markdown
+````markdown
 ### Release Candidate Process
 
 1. **RC1 Tag**: Tag from the stabilization branch after all P0 features merged and CI green
@@ -158,7 +158,7 @@ How RCs are produced + tested:
    ```bash
    git tag -a v2.0.0-rc.2 -m "Release candidate 2 for v2.0.0"
    ```
-```text
+````
 
 → RC process doc'd: tagging convention, distribution, testing checklist, escalation.
 

--- a/i18n/caveman-ultra/skills/setup-putior-ci/SKILL.md
+++ b/i18n/caveman-ultra/skills/setup-putior-ci/SKILL.md
@@ -179,7 +179,7 @@ Key configuration points:
 
 Insert sentinel markers in the target file where the diagram should appear.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -191,7 +191,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **Expected:** Sentinel markers in README.md (or other target file). The content between them will be replaced on each CI run.
 

--- a/i18n/caveman-ultra/skills/tidy-project-structure/SKILL.md
+++ b/i18n/caveman-ultra/skills/tidy-project-structure/SKILL.md
@@ -160,7 +160,7 @@ Fix broken links, update examples, add missing sections.
 5. Update copyright year
 
 **README template**:
-```markdown
+````markdown
 # Project Name
 
 Brief description (1-2 sentences).
@@ -188,7 +188,7 @@ Link to CONTRIBUTING.md or inline guidelines.
 ## License
 
 LICENSE badge and link.
-```text
+````
 
 **Got:** All READMEs updated; examples verified to run.
 

--- a/i18n/caveman-ultra/skills/write-claude-md/SKILL.md
+++ b/i18n/caveman-ultra/skills/write-claude-md/SKILL.md
@@ -49,7 +49,7 @@ CLAUDE.md → AI assistants effective project-specific ctx.
 
 Place `CLAUDE.md` in project root:
 
-```markdown
+````markdown
 # Project Name
 
 Brief description of what this project is and its purpose.
@@ -78,7 +78,7 @@ Key architectural decisions and patterns used in this project.
 - Always use descriptive variable names
 - Follow [language-specific style guide]
 - Write tests for all new functionality
-```text
+````
 
 **Got:** `CLAUDE.md` in project root w/ min: project desc, quick start cmds, architecture, conventions.
 

--- a/i18n/caveman-ultra/skills/write-claude-md/SKILL.md
+++ b/i18n/caveman-ultra/skills/write-claude-md/SKILL.md
@@ -88,7 +88,7 @@ Key architectural decisions and patterns used in this project.
 
 **R packages**:
 
-```markdown
+````markdown
 ## Development Workflow
 
 ```r
@@ -110,7 +110,7 @@ devtools::check()       # Full package check
 - `.Rprofile` - Session configuration
 - `.Renviron` - Environment variables (git-ignored)
 - `renv.lock` - Locked dependencies
-```text
+````
 
 **Node.js/TS**:
 

--- a/i18n/caveman-ultra/skills/write-vignette/SKILL.md
+++ b/i18n/caveman-ultra/skills/write-vignette/SKILL.md
@@ -55,7 +55,7 @@ usethis::use_vignette("getting-started", title = "Getting Started with packagena
 
 ### Step 2: Content
 
-```markdown
+````markdown
 ---
 title: "Getting Started with packagename"
 output: rmarkdown::html_vignette
@@ -98,7 +98,7 @@ Cover optional or advanced functionality.
 ## Conclusion
 
 Summarize and point to other vignettes or resources.
-```text
+````
 
 **Got:** Vignette Rmd has Intro, Install, Basic Usage, Advanced, Conclusion. Code uses pkg's exported fns + produces visible out.
 

--- a/i18n/caveman/skills/escalate-issues/SKILL.md
+++ b/i18n/caveman/skills/escalate-issues/SKILL.md
@@ -94,7 +94,7 @@ Is it purely cosmetic? → LOW
 Grab all context for specialist review.
 
 **Issue Report Template**:
-```markdown
+````markdown
 # Issue: [Brief Title]
 
 **Severity**: CRITICAL | HIGH | MEDIUM | LOW
@@ -138,7 +138,7 @@ Clear description of the problem in 2-3 sentences.
 
 - [Link to related documentation]
 - [Link to similar past issues]
-```text
+````
 
 **Got:** Issue logged with full context in `ESCALATION_REPORTS/issue_YYYYMMDD_HHMM.md`
 

--- a/i18n/caveman/skills/plan-release-cycle/SKILL.md
+++ b/i18n/caveman/skills/plan-release-cycle/SKILL.md
@@ -133,7 +133,7 @@ P0 features block release. P1 features included if ready. P2 features deferred w
 
 Define how release candidates produced and tested:
 
-```markdown
+````markdown
 ### Release Candidate Process
 
 1. **RC1 Tag**: Tag from the stabilization branch after all P0 features merged and CI green
@@ -161,7 +161,7 @@ Define how release candidates produced and tested:
    ```bash
    git tag -a v2.0.0-rc.2 -m "Release candidate 2 for v2.0.0"
    ```
-```text
+````
 
 **Got:** RC process documented with tagging convention, distribution method, testing checklist, escalation criteria.
 

--- a/i18n/caveman/skills/setup-putior-ci/SKILL.md
+++ b/i18n/caveman/skills/setup-putior-ci/SKILL.md
@@ -179,7 +179,7 @@ Key configuration points:
 
 Insert sentinel markers in the target file where the diagram should appear.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -191,7 +191,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **Expected:** Sentinel markers in README.md (or other target file). The content between them will be replaced on each CI run.
 

--- a/i18n/caveman/skills/tidy-project-structure/SKILL.md
+++ b/i18n/caveman/skills/tidy-project-structure/SKILL.md
@@ -161,7 +161,7 @@ Fix broken links, update examples, add missing sections.
 5. Update copyright year
 
 **README template structure**:
-```markdown
+````markdown
 # Project Name
 
 Brief description (1-2 sentences).
@@ -189,7 +189,7 @@ Link to CONTRIBUTING.md or inline guidelines.
 ## License
 
 LICENSE badge and link.
-```text
+````
 
 **Got:** All READMEs updated; examples verified to run
 

--- a/i18n/caveman/skills/write-claude-md/SKILL.md
+++ b/i18n/caveman/skills/write-claude-md/SKILL.md
@@ -88,7 +88,7 @@ Key architectural decisions and patterns used in this project.
 
 **For R packages**:
 
-```markdown
+````markdown
 ## Development Workflow
 
 ```r
@@ -110,7 +110,7 @@ devtools::check()       # Full package check
 - `.Rprofile` - Session configuration
 - `.Renviron` - Environment variables (git-ignored)
 - `renv.lock` - Locked dependencies
-```text
+````
 
 **For Node.js/TypeScript**:
 

--- a/i18n/caveman/skills/write-claude-md/SKILL.md
+++ b/i18n/caveman/skills/write-claude-md/SKILL.md
@@ -49,7 +49,7 @@ Create CLAUDE.md file giving AI assistants effective project-specific context.
 
 Place `CLAUDE.md` in project root:
 
-```markdown
+````markdown
 # Project Name
 
 Brief description of what this project is and its purpose.
@@ -78,7 +78,7 @@ Key architectural decisions and patterns used in this project.
 - Always use descriptive variable names
 - Follow [language-specific style guide]
 - Write tests for all new functionality
-```text
+````
 
 **Got:** `CLAUDE.md` file exists in project root with at minimum project description, quick start commands, architecture overview, conventions section.
 

--- a/i18n/caveman/skills/write-vignette/SKILL.md
+++ b/i18n/caveman/skills/write-vignette/SKILL.md
@@ -55,7 +55,7 @@ usethis::use_vignette("getting-started", title = "Getting Started with packagena
 
 ### Step 2: Write Vignette Content
 
-```markdown
+````markdown
 ---
 title: "Getting Started with packagename"
 output: rmarkdown::html_vignette
@@ -98,7 +98,7 @@ Cover optional or advanced functionality.
 ## Conclusion
 
 Summarize and point to other vignettes or resources.
-```text
+````
 
 **Got:** Vignette Rmd file contains Introduction, Installation, Basic Usage, Advanced Features, Conclusion sections. Code examples use package's exported functions and produce visible output.
 

--- a/i18n/de/skills/escalate-issues/SKILL.md
+++ b/i18n/de/skills/escalate-issues/SKILL.md
@@ -96,7 +96,7 @@ Ist es rein kosmetisch? -> NIEDRIG
 Allen relevanten Kontext fuer den Spezialisten zur Pruefung erfassen.
 
 **Fehlerbericht-Vorlage**:
-```markdown
+````markdown
 # Problem: [Kurzer Titel]
 
 **Schweregrad**: KRITISCH | HOCH | MITTEL | NIEDRIG
@@ -140,7 +140,7 @@ Klare Beschreibung des Problems in 2-3 Saetzen.
 
 - [Link zu verwandter Dokumentation]
 - [Link zu aehnlichen frueheren Problemen]
-```text
+````
 
 **Erwartet:** Problem mit vollstaendigem Kontext in `ESCALATION_REPORTS/issue_JJJJMMTT_HHMM.md` dokumentiert
 

--- a/i18n/de/skills/plan-release-cycle/SKILL.md
+++ b/i18n/de/skills/plan-release-cycle/SKILL.md
@@ -134,7 +134,7 @@ P0-Funktionen blockieren das Release. P1-Funktionen sollten eingeschlossen werde
 
 Definieren, wie Release Candidates erzeugt und getestet werden:
 
-```markdown
+````markdown
 ### Release Candidate Process
 
 1. **RC1 Tag**: Tag from the stabilization branch after all P0 features merged and CI green
@@ -162,7 +162,7 @@ Definieren, wie Release Candidates erzeugt und getestet werden:
    ```bash
    git tag -a v2.0.0-rc.2 -m "Release candidate 2 for v2.0.0"
    ```
-```text
+````
 
 **Erwartet:** RC-Prozess dokumentiert mit Tagging-Konvention, Verteilungsmethode, Test-Checkliste und Eskalationskriterien.
 

--- a/i18n/de/skills/setup-putior-ci/SKILL.md
+++ b/i18n/de/skills/setup-putior-ci/SKILL.md
@@ -174,7 +174,7 @@ Key configuration points:
 
 Insert sentinel markers in das Ziel file where the diagram should appear.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -186,7 +186,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **Erwartet:** Sentinel markers in README.md (or other target file). The content zwischen them wird replaced on each CI run.
 

--- a/i18n/de/skills/tidy-project-structure/SKILL.md
+++ b/i18n/de/skills/tidy-project-structure/SKILL.md
@@ -162,7 +162,7 @@ Defekte Links reparieren, Beispiele aktualisieren, fehlende Abschnitte ergaenzen
 5. Copyright-Jahr aktualisieren
 
 **README-Vorlagenstruktur**:
-```markdown
+````markdown
 # Projektname
 
 Kurzbeschreibung (1-2 Saetze).
@@ -190,7 +190,7 @@ Link zu CONTRIBUTING.md oder eingebettete Richtlinien.
 ## Lizenz
 
 LIZENZ-Badge und Link.
-```text
+````
 
 **Erwartet:** Alle READMEs aktualisiert; Beispiele auf Funktionsfaehigkeit verifiziert
 

--- a/i18n/de/skills/write-claude-md/SKILL.md
+++ b/i18n/de/skills/write-claude-md/SKILL.md
@@ -88,7 +88,7 @@ Wichtige Architekturentscheidungen und in diesem Projekt verwendete Muster.
 
 **Fuer R-Pakete**:
 
-```markdown
+````markdown
 ## Entwicklungsworkflow
 
 ```r
@@ -110,7 +110,7 @@ devtools::check()       # Vollstaendige Paketpruefung
 - `.Rprofile` - Sitzungskonfiguration
 - `.Renviron` - Umgebungsvariablen (per git ignoriert)
 - `renv.lock` - Gesperrte Abhaengigkeiten
-```text
+````
 
 **Fuer Node.js/TypeScript**:
 

--- a/i18n/de/skills/write-claude-md/SKILL.md
+++ b/i18n/de/skills/write-claude-md/SKILL.md
@@ -49,7 +49,7 @@ Eine CLAUDE.md-Datei erstellen, die KI-Assistenten effektiven projektspezifische
 
 `CLAUDE.md` im Projektstammverzeichnis ablegen:
 
-```markdown
+````markdown
 # Projektname
 
 Kurze Beschreibung des Projekts und seines Zwecks.
@@ -78,7 +78,7 @@ Wichtige Architekturentscheidungen und in diesem Projekt verwendete Muster.
 - Immer beschreibende Variablennamen verwenden
 - [Sprachspezifischen Stil-Guide] befolgen
 - Tests fuer alle neuen Funktionalitaeten schreiben
-```text
+````
 
 **Erwartet:** Eine `CLAUDE.md`-Datei existiert im Projektstammverzeichnis mit mindestens einer Projektbeschreibung, Schnellstart-Befehlen, einer Architekturuebersicht und einem Konventionsabschnitt.
 

--- a/i18n/de/skills/write-vignette/SKILL.md
+++ b/i18n/de/skills/write-vignette/SKILL.md
@@ -57,7 +57,7 @@ usethis::use_vignette("getting-started", title = "Getting Started with packagena
 
 ### Schritt 2: Vignetten-Inhalt schreiben
 
-```markdown
+````markdown
 ---
 title: "Getting Started with packagename"
 output: rmarkdown::html_vignette
@@ -100,7 +100,7 @@ Cover optional or advanced functionality.
 ## Conclusion
 
 Summarize and point to other vignettes or resources.
-```text
+````
 
 **Erwartet:** Die Vignetten-Rmd-Datei enthaelt die Abschnitte Introduction, Installation, Basic Usage, Advanced Features und Conclusion. Code-Beispiele verwenden die exportierten Funktionen des Pakets und liefern sichtbare Ausgaben.
 

--- a/i18n/es/skills/escalate-issues/SKILL.md
+++ b/i18n/es/skills/escalate-issues/SKILL.md
@@ -94,7 +94,7 @@ Is it purely cosmetic? → LOW
 Capture all relevant context for the specialist to review.
 
 **Issue Report Template**:
-```markdown
+````markdown
 # Issue: [Brief Title]
 
 **Severity**: CRITICAL | HIGH | MEDIUM | LOW
@@ -138,7 +138,7 @@ Clear description of the problem in 2-3 sentences.
 
 - [Link to related documentation]
 - [Link to similar past issues]
-```text
+````
 
 **Esperado:** Issue documented with full context in `ESCALATION_REPORTS/issue_YYYYMMDD_HHMM.md`
 

--- a/i18n/es/skills/plan-release-cycle/SKILL.md
+++ b/i18n/es/skills/plan-release-cycle/SKILL.md
@@ -133,7 +133,7 @@ P0 features block the release. P1 features should be included if ready. P2 featu
 
 Define how release candidates are produced and tested:
 
-```markdown
+````markdown
 ### Release Candidate Process
 
 1. **RC1 Tag**: Tag from the stabilization branch after all P0 features merged and CI green
@@ -161,7 +161,7 @@ Define how release candidates are produced and tested:
    ```bash
    git tag -a v2.0.0-rc.2 -m "Release candidate 2 for v2.0.0"
    ```
-```text
+````
 
 **Esperado:** RC process documented with tagging convention, distribution method, testing checklist, and escalation criteria.
 

--- a/i18n/es/skills/setup-putior-ci/SKILL.md
+++ b/i18n/es/skills/setup-putior-ci/SKILL.md
@@ -175,7 +175,7 @@ Puntos clave de configuración:
 
 Insertar marcadores centinela en el archivo destino donde el diagrama debe aparecer.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -187,7 +187,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **Esperado:** Marcadores centinela en README.md (u otro archivo destino). El contenido entre ellos será reemplazado en cada ejecución de CI.
 

--- a/i18n/es/skills/tidy-project-structure/SKILL.md
+++ b/i18n/es/skills/tidy-project-structure/SKILL.md
@@ -161,7 +161,7 @@ Fix broken links, update examples, add missing sections.
 5. Update copyright year
 
 **README template structure**:
-```markdown
+````markdown
 # Project Name
 
 Brief description (1-2 sentences).
@@ -189,7 +189,7 @@ Link to CONTRIBUTING.md or inline guidelines.
 ## License
 
 LICENSE badge and link.
-```text
+````
 
 **Esperado:** All READMEs updated; examples verified to run
 

--- a/i18n/es/skills/write-claude-md/SKILL.md
+++ b/i18n/es/skills/write-claude-md/SKILL.md
@@ -49,7 +49,7 @@ Crea un archivo CLAUDE.md que proporcione a los asistentes de IA contexto efecti
 
 Colocar `CLAUDE.md` en la raíz del proyecto:
 
-```markdown
+````markdown
 # Nombre del Proyecto
 
 Breve descripción de qué es este proyecto y su propósito.
@@ -78,7 +78,7 @@ Decisiones arquitectónicas clave y patrones utilizados en este proyecto.
 - Usar siempre nombres de variables descriptivos
 - Seguir la [guía de estilo específica del lenguaje]
 - Escribir pruebas para toda nueva funcionalidad
-```text
+````
 
 **Esperado:** Existe un archivo `CLAUDE.md` en la raíz del proyecto con al menos una descripción del proyecto, comandos de inicio rápido, resumen de arquitectura y sección de convenciones.
 

--- a/i18n/es/skills/write-claude-md/SKILL.md
+++ b/i18n/es/skills/write-claude-md/SKILL.md
@@ -88,7 +88,7 @@ Decisiones arquitectónicas clave y patrones utilizados en este proyecto.
 
 **Para paquetes R**:
 
-```markdown
+````markdown
 ## Flujo de Trabajo de Desarrollo
 
 ```r
@@ -110,7 +110,7 @@ devtools::check()       # Verificación completa del paquete
 - `.Rprofile` - Configuración de sesión
 - `.Renviron` - Variables de entorno (ignorado por git)
 - `renv.lock` - Dependencias bloqueadas
-```text
+````
 
 **Para Node.js/TypeScript**:
 

--- a/i18n/es/skills/write-vignette/SKILL.md
+++ b/i18n/es/skills/write-vignette/SKILL.md
@@ -56,7 +56,7 @@ usethis::use_vignette("getting-started", title = "Getting Started with packagena
 
 ### Paso 2: Escribir el Contenido de la Viñeta
 
-```markdown
+````markdown
 ---
 title: "Getting Started with packagename"
 output: rmarkdown::html_vignette
@@ -99,7 +99,7 @@ Cover optional or advanced functionality.
 ## Conclusion
 
 Summarize and point to other vignettes or resources.
-```text
+````
 
 **Esperado:** El archivo Rmd de la viñeta contiene secciones de Introducción, Instalación, Uso Básico, Funciones Avanzadas y Conclusión. Los ejemplos de código usan las funciones exportadas del paquete y producen salida visible.
 

--- a/i18n/ja/skills/escalate-issues/SKILL.md
+++ b/i18n/ja/skills/escalate-issues/SKILL.md
@@ -94,7 +94,7 @@ Is it purely cosmetic? → LOW
 専門家がレビューするためのすべての関連コンテキストを記録する。
 
 **課題レポートテンプレート**：
-```markdown
+````markdown
 # Issue: [Brief Title]
 
 **Severity**: CRITICAL | HIGH | MEDIUM | LOW
@@ -138,7 +138,7 @@ Clear description of the problem in 2-3 sentences.
 
 - [Link to related documentation]
 - [Link to similar past issues]
-```text
+````
 
 **期待結果:** 完全なコンテキスト付きで`ESCALATION_REPORTS/issue_YYYYMMDD_HHMM.md`に文書化された課題
 

--- a/i18n/ja/skills/plan-release-cycle/SKILL.md
+++ b/i18n/ja/skills/plan-release-cycle/SKILL.md
@@ -133,7 +133,7 @@ P0 features block the release. P1 features should be included if ready. P2 featu
 
 Define how release candidates are produced and tested:
 
-```markdown
+````markdown
 ### Release Candidate Process
 
 1. **RC1 Tag**: Tag from the stabilization branch after all P0 features merged and CI green
@@ -161,7 +161,7 @@ Define how release candidates are produced and tested:
    ```bash
    git tag -a v2.0.0-rc.2 -m "Release candidate 2 for v2.0.0"
    ```
-```text
+````
 
 **期待結果:** RC process documented with tagging convention, distribution method, testing checklist, and escalation criteria.
 

--- a/i18n/ja/skills/setup-putior-ci/SKILL.md
+++ b/i18n/ja/skills/setup-putior-ci/SKILL.md
@@ -174,7 +174,7 @@ Key configuration points:
 
 Insert sentinel markers in the target file where the diagram should appear.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -186,7 +186,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **期待結果:** Sentinel markers in README.md (or other target file). The content between them will be replaced on each CI run.
 

--- a/i18n/ja/skills/tidy-project-structure/SKILL.md
+++ b/i18n/ja/skills/tidy-project-structure/SKILL.md
@@ -161,7 +161,7 @@ Fix broken links, update examples, add missing sections.
 5. Update copyright year
 
 **README template structure**:
-```markdown
+````markdown
 # Project Name
 
 Brief description (1-2 sentences).
@@ -189,7 +189,7 @@ Link to CONTRIBUTING.md or inline guidelines.
 ## License
 
 LICENSE badge and link.
-```text
+````
 
 **期待結果:** All READMEs updated; examples verified to run
 

--- a/i18n/ja/skills/write-claude-md/SKILL.md
+++ b/i18n/ja/skills/write-claude-md/SKILL.md
@@ -49,7 +49,7 @@ AIアシスタントに効果的なプロジェクト固有のコンテキスト
 
 プロジェクトルートに `CLAUDE.md` を配置する:
 
-```markdown
+````markdown
 # Project Name
 
 Brief description of what this project is and its purpose.
@@ -78,7 +78,7 @@ Key architectural decisions and patterns used in this project.
 - Always use descriptive variable names
 - Follow [language-specific style guide]
 - Write tests for all new functionality
-```text
+````
 
 **期待結果：** プロジェクトルートに `CLAUDE.md` ファイルが存在し、最低限プロジェクトの説明、クイックスタートコマンド、アーキテクチャの概要、規約セクションが含まれている。
 

--- a/i18n/ja/skills/write-claude-md/SKILL.md
+++ b/i18n/ja/skills/write-claude-md/SKILL.md
@@ -88,7 +88,7 @@ Key architectural decisions and patterns used in this project.
 
 **Rパッケージの場合**:
 
-```markdown
+````markdown
 ## Development Workflow
 
 ```r
@@ -110,7 +110,7 @@ devtools::check()       # Full package check
 - `.Rprofile` - Session configuration
 - `.Renviron` - Environment variables (git-ignored)
 - `renv.lock` - Locked dependencies
-```text
+````
 
 **Node.js/TypeScriptの場合**:
 

--- a/i18n/ja/skills/write-vignette/SKILL.md
+++ b/i18n/ja/skills/write-vignette/SKILL.md
@@ -54,7 +54,7 @@ usethis::use_vignette("getting-started", title = "Getting Started with packagena
 
 ### ステップ2: ビネットコンテンツの記述
 
-```markdown
+````markdown
 ---
 title: "Getting Started with packagename"
 output: rmarkdown::html_vignette
@@ -97,7 +97,7 @@ Cover optional or advanced functionality.
 ## Conclusion
 
 Summarize and point to other vignettes or resources.
-```text
+````
 
 **期待結果：** ビネットのRmdファイルに「はじめに」、インストール、基本的な使い方、高度な機能、まとめのセクションが含まれる。コード例がパッケージのエクスポートされた関数を使用して表示可能な出力を生成する。
 

--- a/i18n/wenyan-lite/skills/setup-putior-ci/SKILL.md
+++ b/i18n/wenyan-lite/skills/setup-putior-ci/SKILL.md
@@ -179,7 +179,7 @@ Key configuration points:
 
 Insert sentinel markers in the target file where the diagram should appear.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -191,7 +191,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **Expected:** Sentinel markers in README.md (or other target file). The content between them will be replaced on each CI run.
 

--- a/i18n/wenyan-lite/skills/write-claude-md/SKILL.md
+++ b/i18n/wenyan-lite/skills/write-claude-md/SKILL.md
@@ -49,7 +49,7 @@ metadata:
 
 將 `CLAUDE.md` 置於專案根：
 
-```markdown
+````markdown
 # Project Name
 
 Brief description of what this project is and its purpose.
@@ -78,7 +78,7 @@ Key architectural decisions and patterns used in this project.
 - Always use descriptive variable names
 - Follow [language-specific style guide]
 - Write tests for all new functionality
-```text
+````
 
 **預期：** 專案根中存在 `CLAUDE.md` 文件,至少含專案描述、快速開始命令、架構概述與慣例段。
 
@@ -88,7 +88,7 @@ Key architectural decisions and patterns used in this project.
 
 **對 R 套件**：
 
-```markdown
+````markdown
 ## Development Workflow
 
 ```r
@@ -110,7 +110,7 @@ devtools::check()       # Full package check
 - `.Rprofile` - Session configuration
 - `.Renviron` - Environment variables (git-ignored)
 - `renv.lock` - Locked dependencies
-```text
+````
 
 **對 Node.js/TypeScript**：
 

--- a/i18n/wenyan-ultra/skills/escalate-issues/SKILL.md
+++ b/i18n/wenyan-ultra/skills/escalate-issues/SKILL.md
@@ -94,7 +94,7 @@ Is it purely cosmetic? → LOW
 捕關境供專閱。
 
 **議報模**：
-```markdown
+````markdown
 # Issue: [Brief Title]
 
 **Severity**: CRITICAL | HIGH | MEDIUM | LOW
@@ -138,7 +138,7 @@ Clear description of the problem in 2-3 sentences.
 
 - [Link to related documentation]
 - [Link to similar past issues]
-```text
+````
 
 得：議以全境錄於 `ESCALATION_REPORTS/issue_YYYYMMDD_HHMM.md`。
 

--- a/i18n/wenyan-ultra/skills/plan-release-cycle/SKILL.md
+++ b/i18n/wenyan-ultra/skills/plan-release-cycle/SKILL.md
@@ -133,7 +133,7 @@ P0 阻發。P1 備則含。P2 延而不延期。
 
 定候如何產與試：
 
-```markdown
+````markdown
 ### Release Candidate Process
 
 1. **RC1 Tag**: Tag from the stabilization branch after all P0 features merged and CI green
@@ -161,7 +161,7 @@ P0 阻發。P1 備則含。P2 延而不延期。
    ```bash
    git tag -a v2.0.0-rc.2 -m "Release candidate 2 for v2.0.0"
    ```
-```text
+````
 
 得：候程記含標規、布法、試清單、升則。
 

--- a/i18n/wenyan-ultra/skills/setup-putior-ci/SKILL.md
+++ b/i18n/wenyan-ultra/skills/setup-putior-ci/SKILL.md
@@ -179,7 +179,7 @@ Key configuration points:
 
 Insert sentinel markers in the target file where the diagram should appear.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -191,7 +191,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **Expected:** Sentinel markers in README.md (or other target file). The content between them will be replaced on each CI run.
 

--- a/i18n/wenyan-ultra/skills/tidy-project-structure/SKILL.md
+++ b/i18n/wenyan-ultra/skills/tidy-project-structure/SKILL.md
@@ -161,7 +161,7 @@ markdown-link-check README.md
 5. 更權年
 
 **README 模構**：
-```markdown
+````markdown
 # Project Name
 
 Brief description (1-2 sentences).
@@ -189,7 +189,7 @@ Link to CONTRIBUTING.md or inline guidelines.
 ## License
 
 LICENSE badge and link.
-```text
+````
 
 得：諸 README 更；例驗行
 

--- a/i18n/wenyan-ultra/skills/write-claude-md/SKILL.md
+++ b/i18n/wenyan-ultra/skills/write-claude-md/SKILL.md
@@ -49,7 +49,7 @@ metadata:
 
 置 `CLAUDE.md` 於案根：
 
-```markdown
+````markdown
 # Project Name
 
 Brief description of what this project is and its purpose.
@@ -78,7 +78,7 @@ Key architectural decisions and patterns used in this project.
 - Always use descriptive variable names
 - Follow [language-specific style guide]
 - Write tests for all new functionality
-```text
+````
 
 得：`CLAUDE.md` 存於案根，至少含案述、速啟命、構覽、規節。
 

--- a/i18n/wenyan-ultra/skills/write-claude-md/SKILL.md
+++ b/i18n/wenyan-ultra/skills/write-claude-md/SKILL.md
@@ -88,7 +88,7 @@ Key architectural decisions and patterns used in this project.
 
 **R 包**：
 
-```markdown
+````markdown
 ## Development Workflow
 
 ```r
@@ -110,7 +110,7 @@ devtools::check()       # Full package check
 - `.Rprofile` - Session configuration
 - `.Renviron` - Environment variables (git-ignored)
 - `renv.lock` - Locked dependencies
-```text
+````
 
 **Node.js/TypeScript**：
 

--- a/i18n/wenyan-ultra/skills/write-vignette/SKILL.md
+++ b/i18n/wenyan-ultra/skills/write-vignette/SKILL.md
@@ -55,7 +55,7 @@ usethis::use_vignette("getting-started", title = "Getting Started with packagena
 
 ### 二：書示例容
 
-```markdown
+````markdown
 ---
 title: "Getting Started with packagename"
 output: rmarkdown::html_vignette
@@ -98,7 +98,7 @@ Cover optional or advanced functionality.
 ## Conclusion
 
 Summarize and point to other vignettes or resources.
-```text
+````
 
 得：示例 Rmd 含 Introduction、Installation、Basic Usage、Advanced Features、Conclusion 節。碼例用包出函生可見出。
 

--- a/i18n/wenyan/skills/setup-putior-ci/SKILL.md
+++ b/i18n/wenyan/skills/setup-putior-ci/SKILL.md
@@ -179,7 +179,7 @@ Key configuration points:
 
 Insert sentinel markers in the target file where the diagram should appear.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -191,7 +191,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **Expected:** Sentinel markers in README.md (or other target file). The content between them will be replaced on each CI run.
 

--- a/i18n/wenyan/skills/write-claude-md/SKILL.md
+++ b/i18n/wenyan/skills/write-claude-md/SKILL.md
@@ -49,7 +49,7 @@ metadata:
 
 置 `CLAUDE.md` 於項目根：
 
-```markdown
+````markdown
 # Project Name
 
 Brief description of what this project is and its purpose.
@@ -78,7 +78,7 @@ Key architectural decisions and patterns used in this project.
 - Always use descriptive variable names
 - Follow [language-specific style guide]
 - Write tests for all new functionality
-```text
+````
 
 得：`CLAUDE.md` 文存於項目根，至少含項目述、速始命、架構覽、約段。
 
@@ -88,7 +88,7 @@ Key architectural decisions and patterns used in this project.
 
 **為 R 包**：
 
-```markdown
+````markdown
 ## Development Workflow
 
 ```r
@@ -110,7 +110,7 @@ devtools::check()       # Full package check
 - `.Rprofile` - Session configuration
 - `.Renviron` - Environment variables (git-ignored)
 - `renv.lock` - Locked dependencies
-```text
+````
 
 **為 Node.js/TypeScript**：
 

--- a/i18n/zh-CN/skills/write-claude-md/SKILL.md
+++ b/i18n/zh-CN/skills/write-claude-md/SKILL.md
@@ -46,7 +46,7 @@ metadata:
 
 将 `CLAUDE.md` 放在项目根目录：
 
-```markdown
+````markdown
 # Project Name
 
 Brief description of what this project is and its purpose.
@@ -75,7 +75,7 @@ Key architectural decisions and patterns used in this project.
 - Always use descriptive variable names
 - Follow [language-specific style guide]
 - Write tests for all new functionality
-```text
+````
 
 **预期结果：** 项目根目录存在 `CLAUDE.md` 文件，至少包含项目描述、快速启动命令、架构概述和约定规范章节。
 
@@ -85,7 +85,7 @@ Key architectural decisions and patterns used in this project.
 
 **R 包项目**：
 
-```markdown
+````markdown
 ## Development Workflow
 
 ```r
@@ -107,7 +107,7 @@ devtools::check()       # Full package check
 - `.Rprofile` - Session configuration
 - `.Renviron` - Environment variables (git-ignored)
 - `renv.lock` - Locked dependencies
-```text
+````
 
 **Node.js/TypeScript 项目**：
 

--- a/skills/escalate-issues/SKILL.md
+++ b/skills/escalate-issues/SKILL.md
@@ -89,7 +89,7 @@ Is it purely cosmetic? → LOW
 Capture all relevant context for the specialist to review.
 
 **Issue Report Template**:
-```markdown
+````markdown
 # Issue: [Brief Title]
 
 **Severity**: CRITICAL | HIGH | MEDIUM | LOW
@@ -133,7 +133,7 @@ Clear description of the problem in 2-3 sentences.
 
 - [Link to related documentation]
 - [Link to similar past issues]
-```text
+````
 
 **Expected:** Issue documented with full context in `ESCALATION_REPORTS/issue_YYYYMMDD_HHMM.md`
 

--- a/skills/plan-release-cycle/SKILL.md
+++ b/skills/plan-release-cycle/SKILL.md
@@ -128,7 +128,7 @@ P0 features block the release. P1 features should be included if ready. P2 featu
 
 Define how release candidates are produced and tested:
 
-```markdown
+````markdown
 ### Release Candidate Process
 
 1. **RC1 Tag**: Tag from the stabilization branch after all P0 features merged and CI green
@@ -156,7 +156,7 @@ Define how release candidates are produced and tested:
    ```bash
    git tag -a v2.0.0-rc.2 -m "Release candidate 2 for v2.0.0"
    ```
-```text
+````
 
 **Expected:** RC process documented with tagging convention, distribution method, testing checklist, and escalation criteria.
 

--- a/skills/setup-putior-ci/SKILL.md
+++ b/skills/setup-putior-ci/SKILL.md
@@ -169,7 +169,7 @@ Key configuration points:
 
 Insert sentinel markers in the target file where the diagram should appear.
 
-```markdown
+````markdown
 ## Workflow
 
 <!-- PUTIOR-WORKFLOW-START -->
@@ -181,7 +181,7 @@ flowchart TD
 ```
 
 <!-- PUTIOR-WORKFLOW-END -->
-```text
+````
 
 **Expected:** Sentinel markers in README.md (or other target file). The content between them will be replaced on each CI run.
 

--- a/skills/tidy-project-structure/SKILL.md
+++ b/skills/tidy-project-structure/SKILL.md
@@ -156,7 +156,7 @@ Fix broken links, update examples, add missing sections.
 5. Update copyright year
 
 **README template structure**:
-```markdown
+````markdown
 # Project Name
 
 Brief description (1-2 sentences).
@@ -184,7 +184,7 @@ Link to CONTRIBUTING.md or inline guidelines.
 ## License
 
 LICENSE badge and link.
-```text
+````
 
 **Expected:** All READMEs updated; examples verified to run
 

--- a/skills/write-claude-md/SKILL.md
+++ b/skills/write-claude-md/SKILL.md
@@ -44,7 +44,7 @@ Create a CLAUDE.md file that gives AI assistants effective project-specific cont
 
 Place `CLAUDE.md` in the project root:
 
-```markdown
+````markdown
 # Project Name
 
 Brief description of what this project is and its purpose.
@@ -73,7 +73,7 @@ Key architectural decisions and patterns used in this project.
 - Always use descriptive variable names
 - Follow [language-specific style guide]
 - Write tests for all new functionality
-```text
+````
 
 **Expected:** A `CLAUDE.md` file exists in the project root with at minimum a project description, quick start commands, architecture overview, and conventions section.
 

--- a/skills/write-claude-md/SKILL.md
+++ b/skills/write-claude-md/SKILL.md
@@ -83,7 +83,7 @@ Key architectural decisions and patterns used in this project.
 
 **For R packages**:
 
-```markdown
+````markdown
 ## Development Workflow
 
 ```r
@@ -105,7 +105,7 @@ devtools::check()       # Full package check
 - `.Rprofile` - Session configuration
 - `.Renviron` - Environment variables (git-ignored)
 - `renv.lock` - Locked dependencies
-```text
+````
 
 **For Node.js/TypeScript**:
 

--- a/skills/write-vignette/SKILL.md
+++ b/skills/write-vignette/SKILL.md
@@ -50,7 +50,7 @@ usethis::use_vignette("getting-started", title = "Getting Started with packagena
 
 ### Step 2: Write Vignette Content
 
-```markdown
+````markdown
 ---
 title: "Getting Started with packagename"
 output: rmarkdown::html_vignette
@@ -93,7 +93,7 @@ Cover optional or advanced functionality.
 ## Conclusion
 
 Summarize and point to other vignettes or resources.
-```text
+````
 
 **Expected:** The vignette Rmd file contains Introduction, Installation, Basic Usage, Advanced Features, and Conclusion sections. Code examples use the package's exported functions and produce visible output.
 
@@ -133,26 +133,37 @@ knitr::opts_chunk$set(
 
 ### Step 4: Handle External Dependencies
 
-For vignettes that need network access or optional packages:
+For vignettes that need network access or optional packages, write these chunks into
+the `.Rmd` itself:
 
-```r
-{r check-available, include=FALSE}
+````markdown
+```{r check-available, include=FALSE}
 has_suggested <- requireNamespace("optionalpkg", quietly = TRUE)
+```
 
-{r use-suggested, eval=has_suggested}
+```{r use-suggested, eval=has_suggested}
 optionalpkg::special_function()
 ```
+````
 
-For long-running computations, pre-compute and save results:
+For long-running computations, pre-compute once and load the cached result at build
+time. The two snippets run in **different working directories**, which is why the paths
+differ.
+
+Run this once from the package root, outside the vignette:
 
 ```r
-# Save pre-computed results to vignettes/
 saveRDS(expensive_result, "vignettes/precomputed.rds")
+```
 
-# Load in vignette
-{r load-precomputed}
+Then read it from the vignette, which knitr builds with `vignettes/` as the working
+directory:
+
+````markdown
+```{r load-precomputed}
 result <- readRDS("precomputed.rds")
 ```
+````
 
 **Expected:** External dependencies are handled gracefully: optional packages are conditionally loaded with `requireNamespace()`, network-dependent code uses `eval=FALSE` or `tryCatch()`, and expensive computations use pre-computed `.rds` files.
 

--- a/skills/write-vignette/SKILL.md
+++ b/skills/write-vignette/SKILL.md
@@ -103,22 +103,29 @@ Summarize and point to other vignettes or resources.
 
 Use chunk options for different purposes:
 
-```r
-# Standard evaluated chunk
-{r example-basic}
+````markdown
+Standard evaluated chunk:
+
+```{r example-basic}
 result <- compute_something(1:10)
 result
+```
 
-# Show code but don't run (for illustrative purposes)
-{r api-example, eval=FALSE}
+Show code but don't run, for illustrative purposes:
+
+```{r api-example, eval=FALSE}
 connect_to_api(key = "your_key_here")
+```
 
-# Run but hide code (show only output)
-{r hidden-setup, echo=FALSE}
+Run but hide the code, showing only output:
+
+```{r hidden-setup, echo=FALSE}
 library(packagename)
+```
 
-# Set global options
-{r setup, include=FALSE}
+Set global options, once, at the top of the document:
+
+```{r setup, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
@@ -126,6 +133,7 @@ knitr::opts_chunk$set(
   fig.height = 5
 )
 ```
+````
 
 **Expected:** A setup chunk with `include=FALSE` sets global options (`collapse`, `comment`, `fig.width`, `fig.height`). Chunks are configured appropriately: `eval=FALSE` for illustrative code, `echo=FALSE` for hidden setup, and standard chunks for interactive examples.
 


### PR DESCRIPTION
Closes **#476**. Closes **#500**.

Eight English files contained a fence that had swallowed the document's own structure, faithfully mirrored into 44 translated files. **1,110 lines of translated content and 174 of English rendered as preformatted text** — including `## Security Incident Response` and `## Limitations` in agent definitions.

## Two shapes

**Nested template** (6 skills). A ```markdown template contains a nested fence; the nested closer closes the *template* early, and the line meant to close the template instead opens a runaway.

**Stray opener** (2 agents). A ```text sits on the line immediately after a closing delimiter:

```
SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
```          <- closes the config fence
```text      <- opens one nothing closes
## Security Incident Response
```

Fixed by four-backticking the outer template so it contains its nested fences, and deleting the two stray openers. The 44 mirrors were repaired by script replicating the hand edits exactly — preview by default, refuses any file it cannot classify rather than guessing. Nothing was refused.

`runaway-fences` now reports **0** across 552 English and 3,645 translated files.

## Scope correction — 8 files, not 11

Recorded on #476. Verified with `extractFences`:

- **Three of the five "more files" are not affected.** `agents/senior-data-scientist.md`, `guides/agentskills-alignment.md`, `guides/running-a-code-review.md` all close their last fence normally.
- **`setup-putior-ci`'s cited runaways are not runaways.** Its `yaml` at L47 and `r` at L100 are well-formed. Its actual runaway is the `text` fence at L184. The `r` fence contains ```` ```mermaid ```` as an R string literal, indented four spaces, closing nothing.
- **Four files look affected and are not**: `create-skill`, `creating-skills`, `design-training-program`, `evolve-skill-from-traces` use ```markdown fences that contain `**Expected:**` *deliberately*, because they show a step template. Two also escape their nested delimiters (`\```language`).

The detector took four refinements to converge — keying on a bare heading flagged 94 files; keying on `## ` flagged bash/R `##` comments and runbook templates. What settled it was validating against the 8 instances verified by eye, all of which it catches.

## Re-measured, as #476 requires

| | before | after |
|---|---:|---:|
| findings | 331 | **335** |
| `fencesCompared` | 22,998 | 22,977 |
| `language` tag | 1 | **0** |

`fencesCompared` drops because nested fences are now template body rather than separate fences. The `language` finding — the corpus's only one — is gone, because that fence existed *only* as an artifact of the mis-parse.

**The +5 is the point of the fix, not a regression.** A runaway is `text`-tagged and therefore exempt, so everything it swallowed was invisible to the checker. Exposing that content makes real frozen fences comparable again, and five diverge:

```
de/escalate-issues:170        python   (was inside the L143 runaway)
de/tidy-project-structure:209 bash     (was inside the L193 runaway)
de/write-vignette:113         r
es/write-vignette:112         r
ja/write-vignette:110         r
```

Those divergences always existed. #476 predicted precisely this: left unfixed, the phantom bodies stay pinned permanently.

All five are **ordinal-unsound**, not restorable by the next normalizer run — their fence counts now differ from the *basis*, the historical English revision each file's `source_commit` names, which still carries the pre-repair structure. Bumping `source_commit` would make them restorable and is the wrong fix: it asserts currency with every English change since, the staleness-hiding defect in #405. They belong in #478/#483 triage.

## #500, fixed in the same file

`write-vignette` embedded bare `{r label, opts}` R Markdown chunk headers inside ```r fences — a syntax error in R, so the block was not copy-pasteable — and saved `vignettes/precomputed.rds` while reading `precomputed.rds`.

The chunk examples now sit in four-backtick ```markdown fences with proper ```{r} inner fences, and the two snippets state the working directory each assumes: package root for the save, `vignettes/` for the read, which is what knitr uses.

## After this

Normalizer-reachable work is exactly the parked set — **31 fences across 7 files**: `de/design-shiny-ui` (8, #498) and the six regulated files (23). Register: #501.

## Gates

- `npm run test:scripts` — 58/58
- `npm run validate:line-endings` — clean
- `node scripts/check-content-style.js --added` — 0 blocking errors