### PR TITLE
feat(i18n): refuse to restore a translation whose steps do not correspond (#498)

### DIFF
--- a/scripts/lib/code-tokens.js
+++ b/scripts/lib/code-tokens.js
@@ -1,0 +1,333 @@
+/**
+ * code-tokens.js
+ *
+ * Per-tag code-skeleton extraction and a containment measure, for detecting the
+ * content forks that `normalize-i18n-fences.js` would otherwise rewrite blind
+ * (#498).
+ *
+ * ## The question this answers
+ *
+ * The normalizer maps translated fence *i* onto English fence *i*, guarded by
+ * fence count and tag sequence. Both can agree coincidentally while the
+ * translation's steps no longer correspond to English — `de/design-shiny-ui`
+ * carries 8 `r` fences in the same tag sequence as its English source, but its
+ * Schritt 5 is English's Step 6. Restoring by ordinal there gives every fence
+ * the body of a different step, and neither existing gate can see it:
+ * `check-i18n-fence-parity.js` asks whether a body matches SOME English fence in
+ * SOME revision, and a scrambled file is a permutation of legitimate English
+ * bodies, so every fence individually passes.
+ *
+ * ## The measure
+ *
+ * A faithful translation localises comments and string literals and leaves the
+ * CODE alone — that is the keep-code-in-English rule the repair exists to
+ * restore. So strip exactly what a translator legitimately rewrites (comments,
+ * string bodies) and compare what is left: the code skeleton. An old and new
+ * body of the same fence share nearly all of it; a fork shares almost none.
+ *
+ * `containment(pre, post) = |tokens(post) ∩ tokens(pre)| / |tokens(post)|`
+ *
+ * — the fraction of the restored body's skeleton already present in the body
+ * being replaced.
+ *
+ * ## Why this file is per-tag, and why it is default-deny
+ *
+ * The prototype was one regex tuned for R identifiers stripping `#` comments,
+ * and it produced five false positives across seven #477 batches, in two
+ * distinct modes, both traced to that single assumption:
+ *
+ * 1. **`de/prepare-print-model` scored 0.30** (#495). A YAML-ish config fence has
+ *    nothing R-shaped in it, so the measure fell through to natural-language
+ *    words — which a faithful translation legitimately changes.
+ *
+ *    The fix is the identifier shape, and it is worth being exact about which
+ *    part does the work: `GENERIC_TOKEN` below is broad enough to score those
+ *    two real fences 0.68 and 0.72, already clear of the threshold. `tokens:
+ *    'keys'` takes them to 1.00 by dropping the value prose entirely — in a
+ *    config block the keys are the skeleton and the values are documentation
+ *    (`temperature: material-specific (see select-print-material skill)`). So
+ *    keys-mode is not what rescues this file; it removes the erosion that a
+ *    block with a higher prose-to-key ratio would ride across the threshold.
+ *
+ * 2. **Four files scored 0.00** (batch 7) — the maximum fork signal on the most
+ *    innocuous possible change. `de/repair-broken-references` (`javascript`) and
+ *    `de|es|zh-CN/review-web-design` (`css`) were comment-only restores at zero
+ *    non-comment changed lines. Stripping `#` and not `//` or `/* *\/` meant the
+ *    "code tokens" being measured in those fences WERE the comment words.
+ *
+ * That second mode is why an unrecognised tag is `unmeasured` rather than
+ * measured with a plausible default. Guessing wrong fails in the dangerous
+ * direction: a JS fence that genuinely WAS misaligned would have been
+ * indistinguishable from those four, so a wrong default does not merely add
+ * noise — it destroys the signal for every tag it covers. An honest "cannot
+ * measure this" is recoverable; a confident wrong score is not.
+ *
+ * The same reasoning governs the empty-token case. Containment over an empty
+ * denominator is vacuously 1, so an unparseable fence scores a silent perfect —
+ * on #503 that hid 8 of 86 fences behind an apparent "0 suspects". `measure()`
+ * returns `measurable: false` there instead, and callers must report it.
+ *
+ * Adding a tag here requires knowing its comment syntax and deciding whether its
+ * skeleton is identifiers or keys. Do not add one by analogy.
+ */
+
+/**
+ * `line`    — line-comment markers.
+ * `block`   — [open, close] pairs; not nested, per C-family semantics.
+ * `strings` — quote delimiters whose contents are dropped, longest first.
+ * `tokens`  — which skeleton a fence of this tag has: `generic` (identifiers and
+ *             numerics) or `keys` (a config block, where values carry prose).
+ *
+ * `wordStart` markers only open a comment at the start of a line or after
+ * whitespace. `#` and `%` and `--` occur mid-token often enough that ignoring
+ * this eats real code (`foo#bar`, `50%`, `a--b`); `//` does not, and requiring
+ * it there would miss the overwhelmingly common `x = 1;// note`.
+ */
+const WORD_START_MARKERS = new Set(['#', '%', '--']);
+
+const DQ = { open: '"', close: '"', escape: '\\' };
+const SQ = { open: "'", close: "'", escape: '\\' };
+const BQ = { open: '`', close: '`', escape: '\\' };
+
+const HASH = { line: ['#'], block: [], strings: [DQ, SQ], tokens: 'generic' };
+const SLASH = { line: ['//'], block: [['/*', '*/']], strings: [DQ, SQ, BQ], tokens: 'generic' };
+
+/**
+ * Every tag the tool can measure. The live #477 backlog at the time of writing
+ * is bash=126 r=105 yaml=33 dockerfile=21 typescript=19 python=9 json=7 nginx=5
+ * protobuf=4 css=2 latex=2 gitignore=1 sql=1 — all covered here. Tags outside
+ * this table (`logql`, `bibtex`, `traceql`, `powershell`, `language` …) report
+ * `unmeasured` rather than being scored by a default that has not been checked
+ * against them.
+ */
+export const TAG_SYNTAX = {
+  // Shell family and friends: `#` line comments, identifier skeleton.
+  bash: HASH,
+  sh: HASH,
+  shell: HASH,
+  zsh: HASH,
+  console: HASH,
+  r: HASH,
+  ruby: HASH,
+  perl: HASH,
+  dockerfile: HASH,
+  nginx: HASH,
+  gitignore: HASH,
+  makefile: HASH,
+  ini: HASH,
+  properties: HASH,
+
+  // Python additionally drops triple-quoted docstrings, which translators do
+  // rewrite; leaving them in measures prose.
+  python: {
+    line: ['#'],
+    block: [],
+    strings: [
+      { open: '"""', close: '"""' },
+      { open: "'''", close: "'''" },
+      DQ, SQ,
+    ],
+    tokens: 'generic',
+  },
+
+  // C family.
+  javascript: SLASH,
+  js: SLASH,
+  jsx: SLASH,
+  typescript: SLASH,
+  ts: SLASH,
+  tsx: SLASH,
+  java: SLASH,
+  c: SLASH,
+  cpp: SLASH,
+  go: SLASH,
+  rust: SLASH,
+  kotlin: SLASH,
+  swift: SLASH,
+  scala: SLASH,
+  groovy: SLASH,
+  protobuf: SLASH,
+  proto: SLASH,
+  scss: SLASH,
+  less: SLASH,
+
+  // CSS proper has no `//`. Admitting it would truncate at an unquoted
+  // `url(http://…)`, which is legal CSS — and the two measured `css` false
+  // positives were both block comments, so there is no evidence for the risk.
+  css: { line: [], block: [['/*', '*/']], strings: [DQ, SQ], tokens: 'generic' },
+
+  sql: { line: ['--'], block: [['/*', '*/']], strings: [DQ, SQ], tokens: 'generic' },
+  html: { line: [], block: [['<!--', '-->']], strings: [DQ, SQ], tokens: 'generic' },
+  xml: { line: [], block: [['<!--', '-->']], strings: [DQ, SQ], tokens: 'generic' },
+  svg: { line: [], block: [['<!--', '-->']], strings: [DQ, SQ], tokens: 'generic' },
+  latex: { line: ['%'], block: [], strings: [], tokens: 'generic' },
+  tex: { line: ['%'], block: [], strings: [], tokens: 'generic' },
+
+  // Config blocks: the keys are the skeleton, the values carry prose.
+  yaml: { line: ['#'], block: [], strings: [], tokens: 'keys' },
+  yml: { line: ['#'], block: [], strings: [], tokens: 'keys' },
+  toml: { line: ['#'], block: [], strings: [], tokens: 'keys' },
+  // JSON has no comment syntax at all; jsonc/json5 are not in the corpus.
+  json: { line: [], block: [], strings: [], tokens: 'json-keys' },
+  jsonl: { line: [], block: [], strings: [], tokens: 'json-keys' },
+};
+
+/**
+ * Blank out comments and string bodies, preserving line structure so the
+ * line-anchored key extractors still see the shape they expect.
+ *
+ * A single left-to-right scan rather than a per-language lexer: it has to be
+ * right about the interaction between the three (a `#` inside a string is not a
+ * comment; a `"` inside a comment does not open a string), and that interaction
+ * is what a sequence of independent regex passes gets wrong.
+ */
+export function stripCommentsAndStrings(body, syntax) {
+  const { line = [], block = [], strings = [] } = syntax;
+  const blank = (s) => s.replace(/[^\n]/g, ' ');
+  const n = body.length;
+  let out = '';
+  let i = 0;
+
+  const atWordStart = (idx) => idx === 0 || /\s/.test(body[idx - 1]);
+
+  outer: while (i < n) {
+    for (const [open, close] of block) {
+      if (body.startsWith(open, i)) {
+        const end = body.indexOf(close, i + open.length);
+        const stop = end < 0 ? n : end + close.length;
+        out += blank(body.slice(i, stop));
+        i = stop;
+        continue outer;
+      }
+    }
+
+    for (const marker of line) {
+      if (!body.startsWith(marker, i)) continue;
+      if (WORD_START_MARKERS.has(marker) && !atWordStart(i)) continue;
+      let end = body.indexOf('\n', i);
+      if (end < 0) end = n;
+      out += blank(body.slice(i, end));
+      i = end;
+      continue outer;
+    }
+
+    for (const s of strings) {
+      if (!body.startsWith(s.open, i)) continue;
+      let j = i + s.open.length;
+      while (j < n) {
+        if (s.escape && body[j] === s.escape) { j += 2; continue; }
+        if (body.startsWith(s.close, j)) { j += s.close.length; break; }
+        // An unterminated quote must not swallow the rest of the fence — a
+        // lone apostrophe in an English comment is common, and eating from
+        // there to EOF would delete most of the skeleton on one side only.
+        if (body[j] === '\n' && s.open.length === 1) break;
+        j += 1;
+      }
+      out += blank(body.slice(i, Math.min(j, n)));
+      i = Math.min(j, n);
+      continue outer;
+    }
+
+    out += body[i];
+    i += 1;
+  }
+
+  return out;
+}
+
+const GENERIC_TOKEN = /[A-Za-z_][A-Za-z0-9_]*|[0-9]+(?:\.[0-9]+)?/g;
+const YAML_KEY = /^[ \t]*(?:-[ \t]+)?["']?([A-Za-z_][A-Za-z0-9_.-]*)["']?[ \t]*:/gm;
+const JSON_KEY = /"([^"\\\n]+)"[ \t]*:/g;
+
+/**
+ * The code skeleton of one fence body, as a set of tokens.
+ * @returns {{ok: true, tokens: Set<string>} | {ok: false, reason: string}}
+ */
+export function codeTokens(body, tag) {
+  const syntax = TAG_SYNTAX[String(tag || '').toLowerCase()];
+  if (!syntax) return { ok: false, reason: `unknown-tag:${tag || 'untagged'}` };
+
+  const stripped = stripCommentsAndStrings(body, syntax);
+  const pattern = syntax.tokens === 'keys' ? YAML_KEY
+    : syntax.tokens === 'json-keys' ? JSON_KEY
+      : GENERIC_TOKEN;
+
+  const tokens = new Set();
+  pattern.lastIndex = 0;
+  let m;
+  while ((m = pattern.exec(stripped)) !== null) {
+    tokens.add(m[1] !== undefined ? m[1] : m[0]);
+    if (m[0] === '') pattern.lastIndex += 1;
+  }
+  return { ok: true, tokens };
+}
+
+/**
+ * How much of `post`'s code skeleton is already present in `pre`.
+ *
+ * Never returns a score for an empty denominator. Containment over an empty set
+ * is vacuously 1, which is indistinguishable from a perfect match and is how a
+ * fence the extractor could not read becomes a silent pass.
+ *
+ * @returns {{measurable: true, containment: number, tokens: number, shared: number}
+ *          | {measurable: false, reason: string}}
+ */
+export function measure(pre, post, tag) {
+  const a = codeTokens(pre, tag);
+  const b = codeTokens(post, tag);
+  if (!a.ok) return { measurable: false, reason: a.reason };
+  if (!b.ok) return { measurable: false, reason: b.reason };
+  if (b.tokens.size === 0) {
+    return { measurable: false, reason: a.tokens.size === 0 ? 'no-code-tokens' : 'no-code-tokens-in-basis' };
+  }
+  let shared = 0;
+  for (const t of b.tokens) if (a.tokens.has(t)) shared += 1;
+  return {
+    measurable: true,
+    containment: shared / b.tokens.size,
+    tokens: b.tokens.size,
+    shared,
+  };
+}
+
+/**
+ * Below this, ordinal mapping is treated as untrustworthy and the file is
+ * refused rather than rewritten.
+ *
+ * Measured over two populations, not guessed.
+ *
+ * **Clean population** — the 956 measurable fences the seven merged #477 batches
+ * actually restored, each already human-reviewed at merge:
+ *
+ *   1.00  930    0.8-0.9  5    0.6-0.7  6    0.4-0.5  3
+ *   0.9-1.0 3    0.7-0.8  4    0.5-0.6  5    below 0.4: none
+ *
+ * **Fork population** — the 8 fences of `de/design-shiny-ui`, the one known
+ * content fork: 0.00, 0.00, 0.04, 0.12, 0.20, 0.25, 0.83, 0.86.
+ *
+ * Six of the eight sit below the clean population's minimum of 0.40, so any
+ * threshold in (0.25, 0.40) separates the two perfectly. 0.5 is deliberately
+ * above that band: a threshold fitted to the observed clean minimum has zero
+ * margin, and one future clean fence at 0.38 would fail it silently in the
+ * dangerous direction. The margin costs 3 fences in 2 files out of the 345
+ * swept — a false refusal sends a file to manual triage, which is the
+ * recoverable error, while a false pass rewrites it.
+ *
+ * Both false suspects are small-token artifacts and are reported with their
+ * token count so a reviewer can see it: `de/generate-puzzle` (c=0.40, n=5) is a
+ * translated path placeholder `/pfad/zum/skript.R`, where two words out of five
+ * tokens cost 0.40; `ja/instrument-distributed-tracing` (c=0.43, n=7, twice) is
+ * an elision comment written `# ...` inside a `go` fence, where `#` is not a
+ * comment marker, so its prose counts as code. A minimum-token floor would
+ * remove both — floor=8 clears all three suspects — but it reclassifies 332 of
+ * 956 fences (35%) as unmeasurable, and buying a 0.3% false-positive rate with
+ * a third of the tool's coverage is the wrong trade. Report `n`; let the human
+ * dismiss it.
+ *
+ * Note the fork's own spread: two of its eight fences score 0.83 and 0.86, above
+ * ANY threshold in the separating band. That is why the refusal is FILE-scoped
+ * on the minimum rather than per-fence — a per-fence rule would have restored
+ * two fences of a file known to be scrambled, the partly-rewritten-file-with-
+ * nothing-going-red outcome the batch carve-outs exist to avoid.
+ */
+export const DEFAULT_FORK_THRESHOLD = 0.5;

--- a/scripts/lib/code-tokens.js
+++ b/scripts/lib/code-tokens.js
@@ -114,8 +114,10 @@ export const TAG_SYNTAX = {
   nginx: HASH,
   gitignore: HASH,
   makefile: HASH,
-  ini: HASH,
   properties: HASH,
+  // `;` is INI's canonical comment marker and `#` only its common extension, so
+  // HASH alone counts semicolon comment prose as code tokens.
+  ini: { line: ['#', ';'], block: [], strings: [DQ, SQ], tokens: 'generic' },
 
   // Python additionally drops triple-quoted docstrings, which translators do
   // rewrite; leaving them in measures prose.
@@ -141,7 +143,10 @@ export const TAG_SYNTAX = {
   c: SLASH,
   cpp: SLASH,
   go: SLASH,
-  rust: SLASH,
+  // Rust deliberately does NOT get SLASH: `'` is a lifetime sigil, not only a
+  // char quote, so `&'a str` opens a string that runs to the end of the line and
+  // deletes the rest of the signature from the skeleton.
+  rust: { line: ['//'], block: [['/*', '*/']], strings: [DQ, BQ], tokens: 'generic' },
   kotlin: SLASH,
   swift: SLASH,
   scala: SLASH,
@@ -166,7 +171,12 @@ export const TAG_SYNTAX = {
   // Config blocks: the keys are the skeleton, the values carry prose.
   yaml: { line: ['#'], block: [], strings: [], tokens: 'keys' },
   yml: { line: ['#'], block: [], strings: [], tokens: 'keys' },
-  toml: { line: ['#'], block: [], strings: [], tokens: 'keys' },
+  // TOML spells assignment `key = value`, so the YAML `key:` extractor matches
+  // nothing in it — every TOML fence came out `no-code-tokens`, which reads as
+  // "this fence is all comments" when the truth is "this tool cannot parse it".
+  // A wrong reason is worse than an unknown tag, because it names a benign
+  // cause for a tooling gap.
+  toml: { line: ['#'], block: [], strings: [], tokens: 'toml-keys' },
   // JSON has no comment syntax at all; jsonc/json5 are not in the corpus.
   json: { line: [], block: [], strings: [], tokens: 'json-keys' },
   jsonl: { line: [], block: [], strings: [], tokens: 'json-keys' },
@@ -238,6 +248,8 @@ export function stripCommentsAndStrings(body, syntax) {
 const GENERIC_TOKEN = /[A-Za-z_][A-Za-z0-9_]*|[0-9]+(?:\.[0-9]+)?/g;
 const YAML_KEY = /^[ \t]*(?:-[ \t]+)?["']?([A-Za-z_][A-Za-z0-9_.-]*)["']?[ \t]*:/gm;
 const JSON_KEY = /"([^"\\\n]+)"[ \t]*:/g;
+// `[table]` headers as well as `key =`: a TOML fence can be mostly headers.
+const TOML_KEY = /^[ \t]*(?:\[+[ \t]*)?["']?([A-Za-z_][A-Za-z0-9_.-]*)["']?[ \t]*(?:=|\])/gm;
 
 /**
  * The code skeleton of one fence body, as a set of tokens.
@@ -250,7 +262,8 @@ export function codeTokens(body, tag) {
   const stripped = stripCommentsAndStrings(body, syntax);
   const pattern = syntax.tokens === 'keys' ? YAML_KEY
     : syntax.tokens === 'json-keys' ? JSON_KEY
-      : GENERIC_TOKEN;
+      : syntax.tokens === 'toml-keys' ? TOML_KEY
+        : GENERIC_TOKEN;
 
   const tokens = new Set();
   pattern.lastIndex = 0;
@@ -306,12 +319,17 @@ export function measure(pre, post, tag) {
  * content fork: 0.00, 0.00, 0.04, 0.12, 0.20, 0.25, 0.83, 0.86.
  *
  * Six of the eight sit below the clean population's minimum of 0.40, so any
- * threshold in (0.25, 0.40) separates the two perfectly. 0.5 is deliberately
- * above that band: a threshold fitted to the observed clean minimum has zero
- * margin, and one future clean fence at 0.38 would fail it silently in the
- * dangerous direction. The margin costs 3 fences in 2 files out of the 345
- * swept — a false refusal sends a file to manual triage, which is the
- * recoverable error, while a false pass rewrites it.
+ * threshold in (0.25, 0.40) separates the two on this data. 0.5 is deliberately
+ * above that band, and it is worth being exact about which risk the margin buys
+ * down, because the obvious phrasing has it backwards.
+ *
+ * Raising the threshold refuses MORE. So the margin does nothing about a future
+ * clean fence scoring below 0.40 — that fence gets refused either way, and a
+ * false refusal is the recoverable error: the file goes to manual triage. What
+ * the margin covers is the unobserved upper tail of the FORK population, a fork
+ * scoring in [0.40, 0.50) that a threshold fitted to the clean minimum would
+ * wave through and rewrite. With one fork on record, that tail is unmeasured,
+ * and 0.5 prices it at 3 fences in 2 files out of the 345 swept.
  *
  * Both false suspects are small-token artifacts and are reported with their
  * token count so a reviewer can see it: `de/generate-puzzle` (c=0.40, n=5) is a

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -180,12 +180,32 @@ if (!['source-commit', 'head'].includes(BASIS)) {
  * `--fork-threshold 0` disables the check, and is the escape hatch for a
  * reviewer who has read a flagged file and confirmed it is faithful. There is
  * deliberately no `--no-fork-check`: naming the number forces the caller to say
- * what standard they are dropping to, and it shows up verbatim in the report
- * header, so a run made with the guard off cannot be mistaken for a guarded one.
+ * what standard they are dropping to, and the value is printed in the report
+ * summary on EVERY run, so a run made with the guard off cannot be mistaken for
+ * a guarded one.
+ *
+ * That last clause was false when written. The threshold was printed only
+ * inside the refusal block, which `--fork-threshold 0` makes unreachable by
+ * construction — containment is in [0, 1], so `containment < 0` never holds and
+ * `forks` is always empty. A disabled run therefore emitted a report
+ * byte-identical to a guarded one, on the exact file the feature exists to
+ * protect, while `check-i18n-fence-parity.js` reported the result OK afterwards
+ * by design. The same silence covered every guarded run that happened to refuse
+ * nothing. Printing it unconditionally is what makes the sentence true.
+ *
+ * Parsed with an explicit numeric pattern rather than `Number()` alone: JS
+ * coerces whitespace to 0, so `--fork-threshold ' '` passed the `[0, 1]` range
+ * check and silently turned the guard off — the disabling value arriving
+ * through what looks like a typo.
  */
-const FORK_THRESHOLD = Number(opts['fork-threshold']);
+const FORK_THRESHOLD_RAW = opts['fork-threshold'];
+if (!/^(?:[01](?:\.[0-9]+)?|\.[0-9]+)$/.test(FORK_THRESHOLD_RAW)) {
+  console.error(`ERROR: --fork-threshold must be a decimal in [0, 1] (got '${FORK_THRESHOLD_RAW}')`);
+  process.exit(2);
+}
+const FORK_THRESHOLD = Number(FORK_THRESHOLD_RAW);
 if (!Number.isFinite(FORK_THRESHOLD) || FORK_THRESHOLD < 0 || FORK_THRESHOLD > 1) {
-  console.error(`ERROR: --fork-threshold must be a number in [0, 1] (got '${opts['fork-threshold']}')`);
+  console.error(`ERROR: --fork-threshold must be a decimal in [0, 1] (got '${FORK_THRESHOLD_RAW}')`);
   process.exit(2);
 }
 
@@ -565,6 +585,10 @@ if (!PREVIEW) {
 
 console.log(`\n${PREVIEW ? 'PREVIEW — nothing written (pass --write to apply)' : 'Wrote changes'}`);
 console.log(`basis: ${BASIS}`);
+// Unconditional, and next to `basis`, because it describes the standard the run
+// was made at rather than an event that happened during it. Inside the refusal
+// block it was invisible exactly when it mattered most.
+console.log(`fork threshold: ${FORK_THRESHOLD}${FORK_THRESHOLD === 0 ? '   *** DISABLED — step correspondence was NOT checked ***' : ''}`);
 console.log(`files ${PREVIEW ? 'to change' : 'changed'}: ${filesChanged}`);
 console.log(`fences ${PREVIEW ? 'to restore' : 'restored'}: ${fencesRestored}`);
 if (changedByLocale.size) {
@@ -579,6 +603,7 @@ if (forks.length) {
   for (const f of forks) console.log(`  ${f.file}  (${f.n} divergent gated fence(s); ${f.reason})`);
   console.log(`  threshold: containment < ${FORK_THRESHOLD} (--fork-threshold 0 disables)`);
 }
+
 // Never folded into a pass. Containment over an empty token set is vacuously 1,
 // and reporting these as OK is how #503 hid 8 of its 86 fences behind an
 // apparent "0 suspects". Most are fences that are entirely `#` comments — the
@@ -589,5 +614,15 @@ if (unmeasured.length) {
   for (const u of unmeasured) byReason.set(u.reason, (byReason.get(u.reason) || 0) + 1);
   console.log(`\n${unmeasured.length} gated fence(s) could not be measured for step correspondence:`);
   console.log(`  ${[...byReason.entries()].sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join('  ')}`);
-  console.log('  These were NOT checked for the #498 fork shape. They are still restored.');
+  // Splitting on the file's actual disposition rather than asserting one. The
+  // flat claim "they are still restored" was false twice over: a fence in a
+  // refused file is not restored at all, and a fence outside `--tag` scope was
+  // never a candidate. A report that overstates what was written is the same
+  // class of defect as the empty-token pass it sits next to.
+  const forkedFiles = new Set(forks.map((f) => f.file));
+  const inRefused = unmeasured.filter((u) => forkedFiles.has(u.file)).length;
+  const inRepaired = unmeasured.length - inRefused;
+  console.log(`  ${inRepaired} in file(s) this run repairs — unchecked for the #498 shape, and restored`);
+  console.log(`  ${inRefused} in file(s) refused above — unchecked, and NOT restored`);
+  console.log('  (a fence outside --tag scope is counted here but was never a restore candidate)');
 }

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -45,6 +45,15 @@
  * positional rule can safely reconstruct. Those 46 carry 206 fences and are
  * tracked as content forks in #478.
  *
+ * Those two structural checks are necessary and not sufficient: both can agree
+ * coincidentally while the steps no longer correspond. A third check reads the
+ * CODE SKELETON of each gated fence pair and refuses the file when it says the
+ * nth fence is a different step (#498, `lib/code-tokens.js`). Without it, an
+ * unscoped run today rewrites all 8 fences of `i18n/de/skills/design-shiny-ui`,
+ * whose Schritt 5 is English Step 6 — and the parity checker reports the result
+ * `OK`, because a scrambled file is a permutation of legitimate English bodies
+ * and every fence individually matches some English revision.
+ *
  * Scope: skills only. The checker also covers the agents/teams/guides mirrors,
  * whose 87 gated violations this tool does not yet repair (#477).
  *
@@ -75,6 +84,7 @@
  *   node scripts/normalize-i18n-fences.js --basis head
  *   node scripts/normalize-i18n-fences.js --locale de    # restrict to one locale
  *   node scripts/normalize-i18n-fences.js --tag yaml,json  # restrict to tags (#477 batches)
+ *   node scripts/normalize-i18n-fences.js --fork-threshold 0  # disable the #498 check
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
@@ -82,6 +92,7 @@ import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
 import { extractFences, toLines, isGated, buildEnglishFenceHistory } from './lib/fences.js';
+import { measure, DEFAULT_FORK_THRESHOLD } from './lib/code-tokens.js';
 import { assertNotShallow } from './lib/git-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -112,7 +123,7 @@ const argv = process.argv.slice(2);
  * `"--dry"` as the locale value.
  */
 const BOOL_FLAGS = new Set(['--write', '--dry']);
-const VALUE_FLAGS = new Set(['--basis', '--locale', '--tag']);
+const VALUE_FLAGS = new Set(['--basis', '--locale', '--tag', '--fork-threshold']);
 
 function usageError(message) {
   console.error(`ERROR: ${message}`);
@@ -120,7 +131,10 @@ function usageError(message) {
   process.exit(2);
 }
 
-const opts = { write: false, dry: false, basis: 'source-commit', locale: null, tag: null };
+const opts = {
+  write: false, dry: false, basis: 'source-commit', locale: null, tag: null,
+  'fork-threshold': String(DEFAULT_FORK_THRESHOLD),
+};
 for (let i = 0; i < argv.length; i++) {
   const arg = argv[i];
   const eq = arg.indexOf('=');
@@ -156,6 +170,22 @@ const ONLY_LOCALE = opts.locale;
 
 if (!['source-commit', 'head'].includes(BASIS)) {
   console.error(`ERROR: --basis must be 'source-commit' or 'head' (got '${BASIS}')`);
+  process.exit(2);
+}
+
+/**
+ * Containment below which ordinal mapping is treated as untrustworthy (#498).
+ * See `lib/code-tokens.js` for the measured basis of the default.
+ *
+ * `--fork-threshold 0` disables the check, and is the escape hatch for a
+ * reviewer who has read a flagged file and confirmed it is faithful. There is
+ * deliberately no `--no-fork-check`: naming the number forces the caller to say
+ * what standard they are dropping to, and it shows up verbatim in the report
+ * header, so a run made with the guard off cannot be mistaken for a guarded one.
+ */
+const FORK_THRESHOLD = Number(opts['fork-threshold']);
+if (!Number.isFinite(FORK_THRESHOLD) || FORK_THRESHOLD < 0 || FORK_THRESHOLD > 1) {
+  console.error(`ERROR: --fork-threshold must be a number in [0, 1] (got '${opts['fork-threshold']}')`);
   process.exit(2);
 }
 
@@ -346,6 +376,10 @@ const blobs = readBlobs(specs);
 let filesChanged = 0;
 let fencesRestored = 0;
 const skipped = [];
+/** Files refused because their code skeleton says the steps do not correspond. */
+const forks = [];
+/** Fences the containment measure could not read — reported, never scored (#498). */
+const unmeasured = [];
 const changedByLocale = new Map();
 // Every edit is planned first and applied afterwards, so preview and write walk
 // identical code and the preview cannot describe a run the write does not make.
@@ -418,6 +452,66 @@ for (const t of targets) {
     continue;
   }
 
+  /**
+   * Fence count and tag sequence can both agree while the translation is a fork
+   * whose steps no longer correspond (#498). `de/design-shiny-ui` carries 8 `r`
+   * fences in the same sequence as English, but its Schritt 5 is English's Step
+   * 6 — so ordinal restore gives every fence the body of a different step, and
+   * the parity checker cannot see it: a scrambled file is a permutation of
+   * legitimate English bodies, so every fence individually matches SOME English
+   * revision and passes.
+   *
+   * The tell is the code skeleton. A faithful translation localises comments and
+   * string literals and leaves the code alone, so an old and new body of the
+   * same fence share nearly all of it; a different step shares almost none.
+   *
+   * Scoped like the two checks above and for the same reason: whether ordinal
+   * mapping is trustworthy is a property of the WHOLE file, so every GATED fence
+   * pair is measured, not just the divergent ones `--tag` selected. That is
+   * strictly more sensitive here than restricting to divergences — in a forked
+   * file a non-divergent gated fence still carries some OTHER step's English
+   * body, which is exactly the permutation this measure reads. Localisable
+   * fences are excluded because differing wholesale is what they are for.
+   */
+  const below = [];
+  let measured = 0;
+  for (let i = 0; i < translatedFences.length; i++) {
+    const f = translatedFences[i];
+    if (!isGated(f) || basisFences[i].body === f.body) continue;
+    const m = measure(f.body, basisFences[i].body, tagOf(f));
+    if (!m.measurable) {
+      unmeasured.push({ file: t.relPath, fence: i + 1, tag: tagOf(f), reason: m.reason });
+      continue;
+    }
+    measured += 1;
+    if (m.containment < FORK_THRESHOLD) {
+      below.push({ containment: m.containment, tokens: m.tokens, fence: i + 1, tag: tagOf(f) });
+    }
+  }
+  if (below.length) {
+    // File-scoped, not fence-scoped. Two of design-shiny-ui's eight fences score
+    // 0.83 and 0.86 — above any threshold that separates the populations — so
+    // refusing only the fences that scored low would restore two fences of a
+    // file known to be scrambled and hand a reviewer a partly-rewritten file
+    // with nothing going red.
+    //
+    // The fence quoted is the one carrying the most disagreeing tokens, NOT the
+    // lowest score. Those differ, and the lowest score is the weaker evidence:
+    // design-shiny-ui's minimum is a 3-token fence at 0.00, which reads as noise
+    // a reviewer would dismiss, while `(1 - containment) * tokens` surfaces a
+    // 28-token fence at 0.04 — the same verdict with the argument attached.
+    const evidence = below.reduce((a, b) =>
+      (1 - b.containment) * b.tokens > (1 - a.containment) * a.tokens ? b : a);
+    forks.push({
+      file: t.relPath,
+      n: divergent.length,
+      reason: `${below.length} of ${measured} measured gated fence(s) below threshold; `
+        + `worst evidence fence ${evidence.fence} [${evidence.tag}] at containment `
+        + `${evidence.containment.toFixed(2)} over ${evidence.tokens} code token(s)`,
+    });
+    continue;
+  }
+
   // Splice from the bottom so earlier indices stay valid.
   const lines = toLines(t.text);
   let restoredHere = 0;
@@ -479,4 +573,21 @@ if (changedByLocale.size) {
 if (skipped.length) {
   console.log(`\n${skipped.length} file(s) skipped — ordinal mapping is not sound, repair by hand:`);
   for (const s of skipped) console.log(`  ${s.file}  (${s.n} divergent gated fence(s); ${s.reason})`);
+}
+if (forks.length) {
+  console.log(`\n${forks.length} file(s) refused — the steps may not correspond (#498), repair by hand:`);
+  for (const f of forks) console.log(`  ${f.file}  (${f.n} divergent gated fence(s); ${f.reason})`);
+  console.log(`  threshold: containment < ${FORK_THRESHOLD} (--fork-threshold 0 disables)`);
+}
+// Never folded into a pass. Containment over an empty token set is vacuously 1,
+// and reporting these as OK is how #503 hid 8 of its 86 fences behind an
+// apparent "0 suspects". Most are fences that are entirely `#` comments — the
+// separately-tracked #502 population — and unknown tags name a gap in
+// `lib/code-tokens.js`, not a clean fence.
+if (unmeasured.length) {
+  const byReason = new Map();
+  for (const u of unmeasured) byReason.set(u.reason, (byReason.get(u.reason) || 0) + 1);
+  console.log(`\n${unmeasured.length} gated fence(s) could not be measured for step correspondence:`);
+  console.log(`  ${[...byReason.entries()].sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join('  ')}`);
+  console.log('  These were NOT checked for the #498 fork shape. They are still restored.');
 }

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -619,10 +619,16 @@ if (unmeasured.length) {
   // refused file is not restored at all, and a fence outside `--tag` scope was
   // never a candidate. A report that overstates what was written is the same
   // class of defect as the empty-token pass it sits next to.
+  //
+  // Both counts are FENCES, and the first version labelled them "in file(s)",
+  // which reads as a file count. It also said "restored" unconditionally, four
+  // lines under `PREVIEW — nothing written` — the same overstatement in a
+  // narrower spelling, and the test asserted the wrong wording so it held.
   const forkedFiles = new Set(forks.map((f) => f.file));
   const inRefused = unmeasured.filter((u) => forkedFiles.has(u.file)).length;
   const inRepaired = unmeasured.length - inRefused;
-  console.log(`  ${inRepaired} in file(s) this run repairs — unchecked for the #498 shape, and restored`);
-  console.log(`  ${inRefused} in file(s) refused above — unchecked, and NOT restored`);
+  const restored = PREVIEW ? 'would be restored' : 'restored';
+  console.log(`  ${inRepaired} fence(s) in file(s) this run repairs — unchecked for the #498 shape, and ${restored}`);
+  console.log(`  ${inRefused} fence(s) in file(s) refused above — unchecked, and not restored`);
   console.log('  (a fence outside --tag scope is counted here but was never a restore candidate)');
 }

--- a/scripts/test/code-tokens.test.js
+++ b/scripts/test/code-tokens.test.js
@@ -364,3 +364,69 @@ test('the default threshold sits between the measured populations', () => {
   assert.ok(DEFAULT_FORK_THRESHOLD > 0.25);
   assert.ok(DEFAULT_FORK_THRESHOLD <= 0.5);
 });
+
+// ── the per-tag `strings` entries ───────────────────────────────────────────
+//
+// Every entry in a syntax's `strings` list is a mutation site of its own, and
+// dropping one does not merely lose coverage — it turns the translated string
+// body back into "code", which is the false-refusal direction. Assert each
+// quote style the corpus actually uses.
+
+test('single-quoted string bodies are not code (HASH family)', () => {
+  const m = measure("echo 'Verarbeitung abgeschlossen'", "echo 'Processing complete'", 'bash');
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1, 'dropping SQ from HASH makes faithful translations look forked');
+});
+
+test('double-quoted string bodies are not code (HASH family)', () => {
+  const m = measure('message <- "Fertig"', 'message <- "Done"', 'r');
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1);
+});
+
+test('backtick template bodies are not code (C family)', () => {
+  const m = measure(
+    'const label = `Bericht erzeugt`;',
+    'const label = `Report generated`;',
+    'typescript',
+  );
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1, 'dropping BQ from SLASH makes faithful translations look forked');
+});
+
+test('an escaped quote does not close the string early', () => {
+  const { tokens } = codeTokens('echo "a \\" b" && kubectl get pods', 'bash');
+  assert.ok(tokens.has('kubectl'), 'an escaped quote ended the string and swallowed the command');
+});
+
+// ── tags whose skeleton is not what the family default assumes ──────────────
+
+test('toml keys and table headers are extracted, not silently unmeasurable', () => {
+  // TOML spells assignment `key = value`, so the YAML `key:` extractor matched
+  // nothing and every TOML fence reported `no-code-tokens` — a benign-sounding
+  // reason ("all comments") for a tooling gap.
+  const de = ['[paket]', 'name = "werkzeug"', 'version = "1.0"  # Fassung'].join('\n');
+  const en = ['[paket]', 'name = "tool"', 'version = "1.0"  # release'].join('\n');
+  const m = measure(de, en, 'toml');
+  assert.equal(m.measurable, true, `toml scored unmeasurable: ${m.reason}`);
+  assert.equal(m.containment, 1);
+  assert.ok(m.tokens >= 3, `expected the table header and both keys, got ${m.tokens}`);
+});
+
+test('a rust lifetime does not open a string and eat the signature', () => {
+  // `'` is a lifetime sigil as well as a char quote, so admitting single-quoted
+  // strings for rust deletes the rest of the line from the skeleton.
+  const { tokens } = codeTokens("fn parse<'a>(input: &'a str) -> Result<Token, Error> {", 'rust');
+  assert.ok(tokens.has('Result'), 'a lifetime swallowed the return type');
+  assert.ok(tokens.has('Error'), 'a lifetime swallowed the error type');
+});
+
+test('ini treats ; as a comment, its canonical marker', () => {
+  const m = measure(
+    ['; Datenbankeinstellungen', 'host = localhost'].join('\n'),
+    ['; Database settings', 'host = localhost'].join('\n'),
+    'ini',
+  );
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1);
+});

--- a/scripts/test/code-tokens.test.js
+++ b/scripts/test/code-tokens.test.js
@@ -1,0 +1,366 @@
+/**
+ * Tests for `scripts/lib/code-tokens.js` (#498).
+ *
+ * The fixtures are not invented. Every "should score high" body below is a real
+ * pair the seven merged #477 batches actually restored and a human reviewed at
+ * merge, and every one of them is a case the ORIGINAL prototype got wrong — it
+ * scored five of them between 0.00 and 0.30, the maximum fork signal, on
+ * comment-only and config-only changes. The "should score low" body is the one
+ * true positive across 984 fences, `de/design-shiny-ui`.
+ *
+ * A detector that merely *can* fire is not evidence it admits the class you are
+ * hunting, so the two constraint suites below do not stop at asserting the right
+ * answer: each also measures the same bytes under the WRONG per-tag rule and
+ * asserts that answer is wrong. If the per-tag table were quietly reduced to one
+ * default again, those tests go red rather than continuing to pass on a
+ * coincidence.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  measure, codeTokens, stripCommentsAndStrings, TAG_SYNTAX, DEFAULT_FORK_THRESHOLD,
+} from '../lib/code-tokens.js';
+
+const lines = (...xs) => xs.join('\n');
+
+// ── constraint 3: per-tag comment syntax ────────────────────────────────────
+//
+// Four batch-7 files scored 0.00 — a perfect fork signal — on restores verified
+// at zero non-comment changed lines. The prototype stripped `#` and nothing
+// else, so in a CSS or JavaScript fence the "code tokens" it compared WERE the
+// comment words, which a faithful translation changes wholesale.
+
+const CSS_DE = lines(
+  '/* Beispiel gut strukturierte Typoskala (Verhaeltnis 1,25) */',
+  ':root {',
+  '  --text-xs: 0.64rem;    /* 10.24px */',
+  '  --text-base: 1rem;     /* 16px */',
+  '}',
+);
+const CSS_EN = lines(
+  '/* Example well-structured type scale (1.25 ratio) */',
+  ':root {',
+  '  --text-xs: 0.64rem;    /* 10.24px */',
+  '  --text-base: 1rem;     /* 16px */',
+  '}',
+);
+
+const JS_DE = lines(
+  '// Vorher (defekt)',
+  "import { helper } from './utils/helper';",
+  '',
+  '// Nachher (repariert — Datei nach lib/ verschoben)',
+  "import { helper } from './lib/helper';",
+);
+const JS_EN = lines(
+  '// Before (broken)',
+  "import { helper } from './utils/helper';",
+  '',
+  '// After (fixed — file moved to lib/)',
+  "import { helper } from './lib/helper';",
+);
+
+test('css: a block-comment-only translation scores a perfect match', () => {
+  const m = measure(CSS_DE, CSS_EN, 'css');
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1, 'de/review-web-design regressed to a fork signal');
+});
+
+test('javascript: a line-comment-only translation scores a perfect match', () => {
+  const m = measure(JS_DE, JS_EN, 'javascript');
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1, 'de/repair-broken-references regressed to a fork signal');
+});
+
+test('per-tag comment syntax is load-bearing, not decoration', () => {
+  // The same bytes under the prototype's rule. `bash` strips `#` and knows
+  // nothing of `//` or `/* */`, which is exactly how these two files produced
+  // the maximum fork signal on the most innocuous possible change.
+  const asHash = measure(JS_DE, JS_EN, 'bash');
+  assert.equal(asHash.measurable, true);
+  assert.ok(
+    asHash.containment < DEFAULT_FORK_THRESHOLD,
+    `expected the wrong comment syntax to misfire, got ${asHash.containment}`,
+  );
+});
+
+// ── constraint 1: per-tag identifier shape ──────────────────────────────────
+//
+// `de/prepare-print-model` scored 0.30 on a faithful config block: an R-tuned
+// identifier regex finds nothing R-shaped in YAML, so the measure fell through
+// to natural-language words — which a config block legitimately translates,
+// because its VALUES are prose and only its KEYS are skeleton.
+
+const YAML_DE = lines(
+  'layer_height: 0.2mm',
+  'line_width: 0.4mm (= Duesendurchmesser)',
+  'perimeters: 3-4 (strukturell), 2 (kosmetisch)',
+  'infill_pattern: gyroid (FDM), grid (einfach)',
+  'temperature: materialspezifisch (siehe select-print-material Skill)',
+);
+const YAML_EN = lines(
+  'layer_height: 0.2mm',
+  'line_width: 0.4mm (= nozzle diameter)',
+  'perimeters: 3-4 (structural), 2 (cosmetic)',
+  'infill_pattern: gyroid (FDM), grid (basic)',
+  'temperature: material-specific (see select-print-material skill)',
+);
+
+test('yaml: translated prose in VALUES does not move the score', () => {
+  const m = measure(YAML_DE, YAML_EN, 'yaml');
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1, 'de/prepare-print-model regressed to a fork signal');
+});
+
+test('yaml: a changed KEY does move the score', () => {
+  // Without this the test above is vacuous — keys-mode would also score 1 if it
+  // extracted nothing at all, which is precisely the empty-set trap below.
+  const forked = YAML_EN.replace('layer_height:', 'exposure_time:').replace('perimeters:', 'lift_speed:');
+  const m = measure(forked, YAML_EN, 'yaml');
+  assert.equal(m.measurable, true);
+  assert.ok(m.containment < 1, 'key changes are invisible, so keys-mode measures nothing');
+});
+
+test('keys-mode buys margin on a config block that generic tokens only survive', () => {
+  // Measured, and narrower than the claim this test was first written to make.
+  // The prototype scored the real `de/prepare-print-model` fences 0.30 because
+  // its identifier regex was tuned for R and found almost nothing in YAML. The
+  // generic tokenizer here is broader and already clears the threshold on the
+  // same bytes — 0.68 and 0.72 on the two full fences. So generic-vs-keys is
+  // NOT what rescues that file; a usable identifier shape is.
+  //
+  // Keys-mode still earns its place by removing the erosion rather than
+  // outrunning it: value prose is the thing a config fence legitimately
+  // translates, and every word of it drags a generic score toward the
+  // threshold. A block with a higher prose-to-key ratio than this one crosses.
+  const asKeys = measure(YAML_DE, YAML_EN, 'yaml');
+  const asGeneric = measure(YAML_DE, YAML_EN, 'bash');
+  assert.equal(asKeys.containment, 1);
+  assert.ok(
+    asGeneric.containment < asKeys.containment,
+    `keys-mode should score strictly higher; got ${asGeneric.containment} vs ${asKeys.containment}`,
+  );
+});
+
+test('keys-mode is coarser than generic but still catches a permutation', () => {
+  // The cost of measuring 8 keys instead of 41 tokens is sensitivity, so the
+  // reduction has to be shown non-blind: swapping this skill's two real config
+  // fences is the fork shape a yaml block can actually take.
+  const FDM = YAML_EN;
+  const SLA = lines(
+    'layer_height: 0.05mm',
+    'bottom_layers: 6-8 (strong bed adhesion)',
+    'exposure_time: material-specific (2-8s per layer)',
+    'lift_speed: 60-80mm/min',
+    'retract_speed: 150-180mm/min',
+  );
+  const m = measure(FDM, SLA, 'yaml');
+  assert.equal(m.measurable, true);
+  assert.ok(
+    m.containment < DEFAULT_FORK_THRESHOLD,
+    `a swapped config fence scored ${m.containment}, at or above the threshold`,
+  );
+});
+
+// ── constraint 2: never score an empty token set as a pass ───────────────────
+
+test('a fence with no code tokens is unmeasured, NOT a perfect match', () => {
+  // Containment over an empty denominator is vacuously 1. Reporting that as a
+  // pass hid 8 of #503's 86 fences behind an apparent "0 suspects".
+  const de = lines('# Modell in den Slicer importieren', '# Wandstaerke pruefen');
+  const en = lines('# Import the model into the slicer', '# Check wall thickness');
+  const m = measure(de, en, 'bash');
+  assert.equal(m.measurable, false);
+  assert.equal(m.reason, 'no-code-tokens');
+  assert.equal(m.containment, undefined, 'an unreadable fence was handed a score');
+});
+
+test('an empty basis is unmeasured even when the translated side has tokens', () => {
+  const m = measure('install.packages("bslib")', '# nothing but a comment', 'r');
+  assert.equal(m.measurable, false);
+  assert.equal(m.reason, 'no-code-tokens-in-basis');
+});
+
+test('an unrecognised tag is unmeasured, never scored by a default', () => {
+  // Guessing fails in the dangerous direction: a wrong comment syntax does not
+  // add noise, it inverts the signal, so a genuinely misaligned fence of that
+  // tag becomes indistinguishable from a faithful one.
+  const m = measure('rate(x[5m])', 'rate(y[5m])', 'promql');
+  assert.equal(m.measurable, false);
+  assert.equal(m.reason, 'unknown-tag:promql');
+});
+
+test('an untagged fence is unmeasured rather than assumed', () => {
+  const m = measure('a', 'b', '');
+  assert.equal(m.measurable, false);
+  assert.equal(m.reason, 'unknown-tag:untagged');
+});
+
+// ── the true positive ───────────────────────────────────────────────────────
+
+test('the one known content fork scores below the threshold', () => {
+  // de/design-shiny-ui Schritt 5 is English Step 6, so ordinal mapping pairs the
+  // accessibility step's body against the custom-CSS step's. Both files carry 8
+  // `r` fences in an identical tag sequence, so neither structural guard sees it.
+  const de = lines(
+    '# Semantisches HTML mit ARIA-Labels',
+    'ui <- page_fillable(',
+    '  tags$a(href = "#main", class = "skip-link", "Zum Inhalt springen"),',
+    '  tags$main(id = "main", role = "main",',
+    '    plotOutput("chart", alt = "Umsatz nach Quartal")',
+    '  )',
+    ')',
+  );
+  const en = lines(
+    '# Inline CSS',
+    'ui <- page_sidebar(',
+    '  theme = my_theme,',
+    '  tags$style(HTML("',
+    '    .value-box { border-radius: 8px; }',
+    '  ")),',
+    '  sidebar = sidebar("Controls")',
+    ')',
+  );
+  const m = measure(de, en, 'r');
+  assert.equal(m.measurable, true);
+  assert.ok(
+    m.containment < DEFAULT_FORK_THRESHOLD,
+    `a known fork scored ${m.containment}, at or above the threshold`,
+  );
+});
+
+test('a faithful r translation of the SAME shape stays above the threshold', () => {
+  // The paired positive: without it the test above passes on a detector that
+  // scores everything low.
+  const de = lines(
+    '# Marken-Theme definieren',
+    'my_theme <- bslib::bs_theme(',
+    '  version = 5,',
+    '  primary = "#0054AD"',
+    ')',
+  );
+  const en = lines(
+    '# Define the brand theme',
+    'my_theme <- bslib::bs_theme(',
+    '  version = 5,',
+    '  primary = "#0054AD"',
+    ')',
+  );
+  const m = measure(de, en, 'r');
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1);
+});
+
+// ── the scanner ─────────────────────────────────────────────────────────────
+
+test('a comment marker inside a string does not open a comment', () => {
+  const { tokens } = codeTokens('grep pattern "value # not a comment" file', 'bash');
+  assert.ok(tokens.has('file'), 'a quoted # truncated the rest of the line');
+});
+
+test('a quote inside a comment does not open a string', () => {
+  // Otherwise the apostrophe swallows every following line as string body, and
+  // the skeleton on that side collapses while the other side keeps its own.
+  const { tokens } = codeTokens(lines("# it's fine", 'library(shiny)', 'runApp()'), 'r');
+  assert.ok(tokens.has('library') && tokens.has('runApp'), 'an apostrophe in a comment ate the code');
+});
+
+test('an unterminated quote stops at the newline instead of eating the fence', () => {
+  const { tokens } = codeTokens(lines('echo "unterminated', 'kubectl apply -f pod.yaml'), 'bash');
+  assert.ok(tokens.has('kubectl'), 'an unbalanced quote swallowed the rest of the fence');
+});
+
+test('hash only opens a comment at a word boundary', () => {
+  const { tokens } = codeTokens('docker build -t image:tag#digest .', 'bash');
+  assert.ok(tokens.has('digest'), 'a mid-word # was read as a comment');
+});
+
+test('css does not treat // as a comment, so a bare url survives', () => {
+  const { tokens } = codeTokens('background: url(http://example.com/a.png);', 'css');
+  assert.ok(tokens.has('png'), 'a // inside a url truncated the declaration');
+});
+
+test('block comments span lines', () => {
+  const stripped = stripCommentsAndStrings(
+    lines('/* line one', '   line two */', 'body { color: red; }'), TAG_SYNTAX.css,
+  );
+  assert.ok(!stripped.includes('line two'));
+  assert.ok(stripped.includes('color'));
+});
+
+test('an unterminated block comment does not leave its text as code', () => {
+  const stripped = stripCommentsAndStrings(lines('/* runs to EOF', 'still comment'), TAG_SYNTAX.css);
+  assert.equal(stripped.trim(), '');
+});
+
+test('stripping preserves line count, which the key extractors depend on', () => {
+  const body = lines('a: 1', '# note', 'b: 2');
+  const stripped = stripCommentsAndStrings(body, TAG_SYNTAX.yaml);
+  assert.equal(stripped.split('\n').length, body.split('\n').length);
+});
+
+test('python triple-quoted docstrings are string bodies, not code', () => {
+  const de = lines('def f():', '    """Gibt den Wert zurueck."""', '    return value');
+  const en = lines('def f():', '    """Return the value."""', '    return value');
+  const m = measure(de, en, 'python');
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1);
+});
+
+test('sql uses -- for line comments', () => {
+  const m = measure(
+    lines('-- Alle Chargen', 'SELECT batch_id FROM batches;'),
+    lines('-- All batches', 'SELECT batch_id FROM batches;'),
+    'sql',
+  );
+  assert.equal(m.containment, 1);
+});
+
+test('html uses <!-- --> for comments', () => {
+  const m = measure(
+    lines('<!-- Kopfzeile -->', '<main id="content"></main>'),
+    lines('<!-- Header -->', '<main id="content"></main>'),
+    'html',
+  );
+  assert.equal(m.containment, 1);
+});
+
+test('json keys are the skeleton', () => {
+  const m = measure(
+    '{ "name": "Werkzeug", "beschreibung": "Ein Werkzeug" }',
+    '{ "name": "tool", "beschreibung": "A tool" }',
+    'json',
+  );
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1);
+});
+
+// ── the measure itself ──────────────────────────────────────────────────────
+
+test('containment is over the BASIS token set, not the union', () => {
+  // The question is how much of what would be written is already there, so a
+  // translated body carrying extra code must not dilute the denominator.
+  const m = measure('alpha beta gamma delta', 'alpha beta', 'bash');
+  assert.equal(m.measurable, true);
+  assert.equal(m.containment, 1);
+  assert.equal(m.tokens, 2);
+});
+
+test('the report carries the token count the verdict rests on', () => {
+  // Both live false positives are small-token artifacts; a reviewer can only
+  // dismiss them if n travels with the score.
+  const m = measure('cd /pfad/zum/skript', 'cd /path/to/script', 'bash');
+  assert.equal(m.measurable, true);
+  assert.equal(typeof m.tokens, 'number');
+  assert.equal(typeof m.shared, 'number');
+  assert.ok(m.tokens > 0);
+});
+
+test('the default threshold sits between the measured populations', () => {
+  // Clean population minimum across the 956 merged-batch fences: 0.40.
+  // Fork population: six of eight below 0.26. Any value in (0.25, 0.40)
+  // separates them; the default is deliberately above that band for margin.
+  assert.ok(DEFAULT_FORK_THRESHOLD > 0.25);
+  assert.ok(DEFAULT_FORK_THRESHOLD <= 0.5);
+});

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -436,3 +436,112 @@ test('--locale scopes the dirty check to that locale', async (t) => {
   assert.equal(r.status, 0, r.stderr);
   assert.doesNotMatch(readFileSync(translated, 'utf8'), /hallo/);
 });
+
+// ── the fork refusal (#498) ─────────────────────────────────────────────────
+
+/**
+ * A translation whose steps do not correspond to English, carrying the SAME
+ * fence count in the SAME tag sequence — so both structural guards pass and the
+ * tool would rewrite every fence with the body of a different step.
+ *
+ * This is `de/design-shiny-ui` in miniature: there, German Schritt 5 is English
+ * Step 6, and `check-i18n-fence-parity.js` reports the corrupted result `OK`,
+ * because a scrambled file is a permutation of legitimate English bodies and
+ * every fence individually matches some English revision.
+ */
+function addForkedSkill(dir) {
+  const english = [
+    '---', 'name: forked-skill', 'description: Two steps.', '---', '',
+    '# Forked', '', '## Procedure', '',
+    '### Step 1: Launch the app', '',
+    '```r', 'library(shiny)', 'runApp("app")', '```', '',
+    '### Step 2: Install the theme package', '',
+    '```r', 'install.packages("bslib")', 'library(bslib)', '```', '',
+  ].join('\n');
+  mkdirSync(join(dir, 'skills', 'forked-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'forked-skill', 'SKILL.md'), english, 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english forked-skill source']);
+  const sc = git(dir, ['rev-parse', 'HEAD']);
+
+  const translatedPath = join(dir, 'i18n', 'de', 'skills', 'forked-skill', 'SKILL.md');
+  mkdirSync(dirname(translatedPath), { recursive: true });
+  writeFileSync(translatedPath, [
+    '---', 'name: forked-skill', 'description: Zwei Schritte.',
+    'locale: de', 'source_locale: en', `source_commit: ${sc}`, '---', '',
+    '# Verzweigt', '', '## Ablauf', '',
+    // The steps are in the opposite order, so fence 1 faces fence 2's basis.
+    '### Schritt 1: Theme-Paket installieren', '',
+    '```r', '# Paket installieren', 'install.packages("bslib")', 'library(bslib)', '```', '',
+    '### Schritt 2: App starten', '',
+    '```r', '# App starten', 'library(shiny)', 'runApp("app")', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de translation whose steps are permuted']);
+  return translatedPath;
+}
+
+test('a forked translation is refused, and its bytes are left alone', async (t) => {
+  const { dir } = makeFixture(t);
+  const forked = addForkedSkill(dir);
+  const before = readFileSync(forked, 'utf8');
+
+  const r = run(dir, ['--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /file\(s\) refused — the steps may not correspond/);
+  assert.match(r.stdout, /i18n\/de\/skills\/forked-skill\/SKILL\.md/);
+  assert.equal(readFileSync(forked, 'utf8'), before, 'a refused file was rewritten anyway');
+});
+
+test('--fork-threshold 0 restores the very file the guard refused', async (t) => {
+  // Without this the test above is vacuous: it would pass on a fixture the tool
+  // had no reason to touch, and on a build where the fork check did nothing but
+  // print. The difference between the two runs IS the guard.
+  const { dir } = makeFixture(t);
+  const forked = addForkedSkill(dir);
+
+  const r = run(dir, ['--write', '--fork-threshold', '0']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.doesNotMatch(r.stdout, /refused — the steps may not correspond/);
+  const after = readFileSync(forked, 'utf8');
+  assert.ok(after.includes('runApp("app")'), 'nothing was restored, so the refusal proves nothing');
+  assert.ok(!after.includes('# Paket installieren'), 'the translated body survived');
+});
+
+test('the refusal quotes the fence carrying the most disagreeing tokens', async (t) => {
+  // The lowest-scoring fence is often a 3-token one a reviewer would dismiss as
+  // noise. Reporting `(1 - containment) * tokens` puts the argument next to the
+  // verdict.
+  const { dir } = makeFixture(t);
+  addForkedSkill(dir);
+
+  const r = run(dir);
+
+  assert.match(r.stdout, /measured gated fence\(s\) below threshold/);
+  assert.match(r.stdout, /worst evidence fence \d+ \[r\] at containment 0\.\d+ over \d+ code token\(s\)/);
+});
+
+test('the fork guard does not refuse an ordinary faithful translation', async (t) => {
+  // The class the prototype got wrong: a comment-only restore, which it scored
+  // 0.00 — the maximum fork signal — on four real files. A guard that refuses
+  // these is worse than no guard, because it stops the repair it exists to make
+  // safe.
+  const { dir, translated } = makeFixture(t);
+
+  const r = run(dir, ['--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.doesNotMatch(r.stdout, /refused — the steps may not correspond/);
+  assert.ok(readFileSync(translated, 'utf8').includes(ENGLISH_FENCE));
+});
+
+test('--fork-threshold rejects a value outside [0, 1]', async (t) => {
+  const { dir } = makeFixture(t);
+
+  for (const value of ['2', '-1', 'half', '']) {
+    const r = run(dir, ['--fork-threshold', value]);
+    assert.equal(r.status, 2, `'${value}' was accepted`);
+  }
+});

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -717,8 +717,35 @@ test('the unmeasured report distinguishes repaired files from refused ones', asy
 
   const r = run(dir);
 
-  assert.match(r.stdout, /1 in file\(s\) this run repairs — unchecked for the #498 shape, and restored/);
-  assert.match(r.stdout, /0 in file\(s\) refused above — unchecked, and NOT restored/);
+  assert.match(r.stdout, /1 fence\(s\) in file\(s\) this run repairs/);
+  assert.match(r.stdout, /0 fence\(s\) in file\(s\) refused above — unchecked, and not restored/);
+});
+
+test('the unmeasured report does not claim a restore a preview did not make', async (t) => {
+  // The first wording said "restored" four lines under `PREVIEW — nothing
+  // written`, and the test asserted that wording, so the contradiction held.
+  // Asserting BOTH modes is what makes the tense load-bearing.
+  const { dir } = makeFixture(t);
+  addUnmeasurableSkill(dir);
+
+  const preview = run(dir);
+  assert.match(preview.stdout, /unchecked for the #498 shape, and would be restored/);
+
+  const written = run(dir, ['--write']);
+  assert.match(written.stdout, /unchecked for the #498 shape, and restored/);
+  assert.doesNotMatch(written.stdout, /would be restored/);
+});
+
+test('the unmeasured counts are labelled as fences, which is what they count', async (t) => {
+  // They were labelled "in file(s)", which reads as a file count.
+  const { dir } = makeFixture(t);
+  addUnmeasurableSkill(dir);
+
+  const r = run(dir);
+
+  const line = r.stdout.split('\n').find((l) => l.includes('this run repairs'));
+  assert.ok(line, `no unmeasured disposition line:\n${r.stdout}`);
+  assert.match(line, /^\s*\d+ fence\(s\)/, `count is not labelled as fences: ${line}`);
 });
 
 // ── the threshold is disclosed on every run ─────────────────────────────────

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -545,3 +545,207 @@ test('--fork-threshold rejects a value outside [0, 1]', async (t) => {
     assert.equal(r.status, 2, `'${value}' was accepted`);
   }
 });
+
+/**
+ * A file where only SOME fences are forked — the shape the real defect takes.
+ * `de/design-shiny-ui` scores 6 of its 8 fences below the threshold and the
+ * other two at 0.83 and 0.86, so a rule that refused only when EVERY measured
+ * fence fell below it would have released the one true positive.
+ *
+ * The all-forked fixture above cannot see that: there `below.length` equals
+ * `measured`, so `if (below.length === measured)` passes every test while
+ * rewriting the file this feature exists to protect.
+ */
+function addPartlyForkedSkill(dir) {
+  const english = [
+    '---', 'name: partly-forked', 'description: Three steps.', '---', '',
+    '# Partly', '', '## Procedure', '',
+    '```r', 'library(shiny)', 'runApp("app")', '```', '',
+    '```r', 'install.packages("bslib")', 'library(bslib)', '```', '',
+    '```r', 'sass_input <- sass::sass_file("styles.scss")', 'sass::sass(sass_input)', '```', '',
+  ].join('\n');
+  mkdirSync(join(dir, 'skills', 'partly-forked'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'partly-forked', 'SKILL.md'), english, 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english partly-forked source']);
+  const sc = git(dir, ['rev-parse', 'HEAD']);
+
+  const p = join(dir, 'i18n', 'de', 'skills', 'partly-forked', 'SKILL.md');
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, [
+    '---', 'name: partly-forked', 'description: Drei Schritte.',
+    'locale: de', 'source_locale: en', `source_commit: ${sc}`, '---', '',
+    '# Teilweise', '', '## Ablauf', '',
+    // Fences 1 and 2 are faithful — only their comments are German, so they
+    // score 1.00 and must NOT be what triggers the refusal.
+    '```r', '# App starten', 'library(shiny)', 'runApp("app")', '```', '',
+    '```r', '# Paket installieren', 'install.packages("bslib")', 'library(bslib)', '```', '',
+    // Fence 3 is a different step entirely.
+    '```r', '# Barrierefreiheit', 'tags$main(role = "main")', 'plotOutput("chart", alt = "Umsatz")', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de translation with one forked step among three']);
+  return p;
+}
+
+test('a file with only SOME fences forked is still refused', async (t) => {
+  const { dir } = makeFixture(t);
+  const partly = addPartlyForkedSkill(dir);
+  const before = readFileSync(partly, 'utf8');
+
+  const r = run(dir, ['--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /i18n\/de\/skills\/partly-forked\/SKILL\.md/);
+  assert.match(r.stdout, /1 of 3 measured gated fence\(s\) below threshold/);
+  assert.equal(readFileSync(partly, 'utf8'), before, 'a partly-forked file was rewritten');
+});
+
+test('--fork-threshold 0 restores the partly-forked file too', async (t) => {
+  const { dir } = makeFixture(t);
+  const partly = addPartlyForkedSkill(dir);
+
+  const r = run(dir, ['--write', '--fork-threshold', '0']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.ok(readFileSync(partly, 'utf8').includes('sass::sass_file'), 'nothing was restored');
+});
+
+/**
+ * A file where the LOWEST-scoring fence and the MOST-EVIDENCED fence are
+ * different fences, so the report's choice between them is observable. Without
+ * this, `below.reduce((a, b) => a)` — always take the first — keeps the
+ * evidence-weighting test green.
+ */
+function addEvidenceSkill(dir) {
+  const english = [
+    '---', 'name: evidence-skill', 'description: Two steps.', '---', '',
+    '# Evidence', '', '## Procedure', '',
+    '```r', 'n <- 1', '```', '',
+    '```r',
+    'summarise_metrics <- function(frame, group_col, value_col) {',
+    '  dplyr::group_by(frame, .data[[group_col]]) |>',
+    '    dplyr::summarise(total = sum(.data[[value_col]], na.rm = TRUE))',
+    '}', '```', '',
+  ].join('\n');
+  mkdirSync(join(dir, 'skills', 'evidence-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'evidence-skill', 'SKILL.md'), english, 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english evidence-skill source']);
+  const sc = git(dir, ['rev-parse', 'HEAD']);
+
+  const p = join(dir, 'i18n', 'de', 'skills', 'evidence-skill', 'SKILL.md');
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, [
+    '---', 'name: evidence-skill', 'description: Zwei Schritte.',
+    'locale: de', 'source_locale: en', `source_commit: ${sc}`, '---', '',
+    '# Beweis', '', '## Ablauf', '',
+    // Fence 1: 2 tokens, shares none -> containment 0.00, evidence weight ~2.
+    '```r', 'z <- 9', '```', '',
+    // Fence 2: many tokens, shares none -> containment 0.00, evidence weight ~14.
+    '```r',
+    'plot_theme <- ggplot2::theme_minimal(base_size = 12)',
+    'ggplot2::ggsave("chart.png", width = 8, height = 6)',
+    '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de translation where the lowest score is not the best evidence']);
+  return p;
+}
+
+test('the refusal names the most-evidenced fence, not the lowest-scoring one', async (t) => {
+  const { dir } = makeFixture(t);
+  addEvidenceSkill(dir);
+
+  const r = run(dir);
+
+  const line = r.stdout.split('\n').find((l) => l.includes('evidence-skill'));
+  assert.ok(line, `no refusal line for evidence-skill:\n${r.stdout}`);
+  const m = /worst evidence fence (\d+) \[r\] at containment ([\d.]+) over (\d+) code token\(s\)/.exec(line);
+  assert.ok(m, `refusal line did not carry the evidence fields: ${line}`);
+  assert.equal(m[1], '2', `named fence ${m[1]}; fence 1 scores as low over far fewer tokens`);
+  assert.ok(Number(m[3]) > 2, `expected the many-token fence, got n=${m[3]}`);
+});
+
+/**
+ * A gated fence whose tag is outside `lib/code-tokens.js` — the honest
+ * "cannot measure this" path. Untested, deleting the unmeasured.push() is
+ * invisible, and the report silently loses the one signal that says a whole tag
+ * is going unchecked.
+ */
+function addUnmeasurableSkill(dir) {
+  const english = [
+    '---', 'name: unmeasurable-skill', 'description: Two fences.', '---', '',
+    '# Unmeasurable', '', '## Procedure', '',
+    '```bash', 'echo "english"', '```', '',
+    '```promql', 'rate(http_requests_total[5m])', '```', '',
+  ].join('\n');
+  mkdirSync(join(dir, 'skills', 'unmeasurable-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'unmeasurable-skill', 'SKILL.md'), english, 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english unmeasurable-skill source']);
+  const sc = git(dir, ['rev-parse', 'HEAD']);
+
+  const p = join(dir, 'i18n', 'de', 'skills', 'unmeasurable-skill', 'SKILL.md');
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, [
+    '---', 'name: unmeasurable-skill', 'description: Zwei Bloecke.',
+    'locale: de', 'source_locale: en', `source_commit: ${sc}`, '---', '',
+    '# Nicht messbar', '', '## Ablauf', '',
+    '```bash', 'echo "uebersetzt"', '```', '',
+    '```promql', 'rate(http_anfragen_gesamt[5m])', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de translation carrying an unmeasurable tag']);
+  return p;
+}
+
+test('an unmeasurable tag is reported by name, never silently passed', async (t) => {
+  const { dir } = makeFixture(t);
+  addUnmeasurableSkill(dir);
+
+  const r = run(dir);
+
+  assert.match(r.stdout, /gated fence\(s\) could not be measured for step correspondence/);
+  assert.match(r.stdout, /unknown-tag:promql=1/);
+});
+
+test('the unmeasured report distinguishes repaired files from refused ones', async (t) => {
+  // "They are still restored" was false for a fence in a refused file.
+  const { dir } = makeFixture(t);
+  addUnmeasurableSkill(dir);
+
+  const r = run(dir);
+
+  assert.match(r.stdout, /1 in file\(s\) this run repairs — unchecked for the #498 shape, and restored/);
+  assert.match(r.stdout, /0 in file\(s\) refused above — unchecked, and NOT restored/);
+});
+
+// ── the threshold is disclosed on every run ─────────────────────────────────
+
+test('the report states the threshold the run was made at, even with no refusals', async (t) => {
+  // It used to print only inside the refusal block, which --fork-threshold 0
+  // makes unreachable by construction: containment is in [0, 1], so
+  // `containment < 0` never holds and `forks` is always empty. A disabled run
+  // and a guarded one emitted byte-identical reports.
+  const { dir } = makeFixture(t);
+
+  const guarded = run(dir);
+  const off = run(dir, ['--fork-threshold', '0']);
+
+  assert.match(guarded.stdout, /fork threshold: 0\.5/);
+  assert.match(off.stdout, /fork threshold: 0\s+\*\*\* DISABLED/);
+  assert.notEqual(guarded.stdout, off.stdout, 'a disabled run is indistinguishable from a guarded one');
+});
+
+test('--fork-threshold refuses a whitespace value instead of coercing it to 0', async (t) => {
+  // Number(' ') is 0, so the range check passed and the guard silently turned
+  // off — the disabling value arriving through what looks like a typo.
+  const { dir } = makeFixture(t);
+
+  for (const value of [' ', '\t', ' 0.5 ', '0x0', '1e-1', '+0']) {
+    const r = run(dir, ['--fork-threshold', value]);
+    assert.equal(r.status, 2, `'${value}' was accepted: ${r.stdout}`);
+    assert.match(r.stderr, /must be a decimal in \[0, 1\]/);
+  }
+});

--- a/skills/run-copilot-review-loop/SKILL.md
+++ b/skills/run-copilot-review-loop/SKILL.md
@@ -9,7 +9,9 @@ description: >
   resolveReviewThread GraphQL mutation, the
   copilot-pull-request-reviewer[bot] slug, and how to read the bot's
   verdict (COMMENTED plus a "human review recommended" banner is not a
-  blocking finding). Use when Copilot has left review comments on your
+  blocking finding, while "generated no new comments" hides a collapsed
+  Suppressed comments block that posts no threads and has repeatedly
+  held real defects). Use when Copilot has left review comments on your
   PR, when bot review threads must be closed out with an auditable
   fix-reply-resolve trail before merge, or when you need to verify that
   a re-review actually landed on the new HEAD rather than the old one.
@@ -183,12 +185,23 @@ Interpret the result against how the bot actually reports:
 
 - **`COMMENTED` is the bot's terminal state.** Copilot does not return `APPROVED` or `CHANGES_REQUESTED`; a `COMMENTED` review is not a rejection.
 - **Boilerplate is not a finding.** A review body announcing "0 new comments" and/or the standing "human review recommended" style banner is fixed bot messaging — it does not block the PR.
-- **Clean pass** = the fresh review introduced zero new comments **and** the Step 2 thread query returns no unresolved threads.
+- **"Generated no new comments" is a headline, not a verdict.** It is routinely followed by a collapsed `<details><summary>Suppressed comments (N)</summary>` block that the summary line does not count, and that block carries real defects. Across five consecutive passes on one PR the headline read "no new comments" every time and the suppressed block held genuine findings on four of them — including a fail-closed contract violation (an unwritable snapshot exiting `1`, where `1` already means "the repository changed") and a flag that deleted its baseline before the verdict was known, reopening the exact hole the PR existed to close. Read the block every pass:
+
+  ```bash
+  gh api repos/OWNER/REPO/pulls/PR/reviews \
+    --jq '.[] | select(.user.login=="copilot-pull-request-reviewer[bot]"
+          and .commit_id=="<head-sha>") | .body' \
+    | rg -A5 '^\*\*'
+  ```
+
+  Filter on the bot login **and** the head sha: replying to a thread creates a review record under your own login, and an unfiltered query happily returns your own reply as the latest review. Treat suppressed entries as leads, not verdicts — one of the five in that run was wrong (it asserted the reverse field order for `git status --porcelain -z` renames), so triage each on its merits as you would any reviewer's.
+
+- **Clean pass** = the fresh review introduced zero new comments **and** its suppressed block is empty or every entry has been triaged **and** the Step 2 thread query returns no unresolved threads.
 - **New threads** = re-enter the loop at Step 2 with the new findings.
 
 **Expected:** An unambiguous verdict: clean pass (stop) or a concrete list of new threads (iterate).
 
-**On failure:** When the prose is ambiguous, do not parse it — count unresolved threads with the Step 2 query. The thread count is ground truth; the review body is commentary.
+**On failure:** When the prose is ambiguous, do not parse it — count unresolved threads with the Step 2 query. The thread count is ground truth; the review body is commentary. The one thing the thread count does *not* cover is the suppressed block, which produces no threads at all — that is why it needs its own read.
 
 ## Validation
 
@@ -198,11 +211,13 @@ Interpret the result against how the bot actually reports:
 - [ ] PR description (and any other cited location) corrected where a finding referenced it
 - [ ] Latest bot review `submitted_at` is newer than the Step 1 baseline, or the bot is no longer in `requested_reviewers`
 - [ ] Final verdict read via Step 8 and interpreted as a clean pass, not merely assumed from `COMMENTED`
+- [ ] The latest review body's `Suppressed comments` block was opened and every entry triaged — not inferred from a "no new comments" headline
 
 ## Common Pitfalls
 
 - **ID-type confusion**: The single most common failure. The REST replies endpoint 404s when fed a `PRRT_...` thread node-id; the `resolveReviewThread` mutation errors when fed a numeric comment databaseId. Reply with the databaseId, resolve with the node-id.
 - **Reading `COMMENTED` as a failing verdict**: Copilot never approves; `COMMENTED` plus a "human review recommended" banner is its normal clean output. Treating it as a blocking finding stalls the merge on boilerplate.
+- **Trusting "generated no new comments"**: the opposite error, and the more expensive one. That headline does not count the collapsed `Suppressed comments` block beneath it, which posts no review threads — so a review that found real defects reads as a clean pass through both the headline *and* the Step 2 thread count, and the PR merges with them. It is the same shape as any other green that means nothing: the summary is a claim about the summary, not about the diff. Open the block every pass.
 - **Polling without a baseline**: The reviews list still contains the pre-fix review, so a poll that merely checks "does a Copilot review exist" succeeds instantly against stale data and reports a false clean pass. Baseline `submitted_at` before re-requesting.
 - **Re-requesting before pushing**: The bot reviews the HEAD it sees at request time. Re-request first and it re-reviews the unfixed code — the same findings come straight back.
 - **Squashing all fixes into one commit**: Replies can no longer cite a per-finding sha, and the audit trail from finding to fix dissolves. One commit per finding.


### PR DESCRIPTION
Closes #498.

The normalizer maps translated fence *i* onto English fence *i*, guarded by fence count and tag
sequence. Both can agree coincidentally while the translation is a fork whose steps no longer
correspond — and neither existing gate can see it. `check-i18n-fence-parity.js` asks whether a
body matches *some* English fence in *some* revision, and a scrambled file is a permutation of
legitimate English bodies, so every fence individually passes. It reports `OK` on the corrupted
file, correctly, per the rule as written.

This adds the third check: read the **code skeleton** and refuse the file when it says the nth
fence is a different step.

## The measure

A faithful translation localises comments and string literals and leaves the code alone — that is
the keep-code-in-English rule the repair exists to restore. So strip exactly what a translator
legitimately rewrites and compare what is left:

```
containment(pre, post) = |tokens(post) ∩ tokens(pre)| / |tokens(post)|
```

## What changes today

An unscoped preview on this branch, before and after:

| | files | fences | `de/design-shiny-ui` |
|---|---:|---:|---|
| before | 7 | 31 | rewritten, all 8 fences |
| after | 6 | 23 | refused |

```
1 file(s) refused — the steps may not correspond (#498), repair by hand:
  i18n/de/skills/design-shiny-ui/SKILL.md  (8 divergent gated fence(s); 6 of 8 measured
  gated fence(s) below threshold; worst evidence fence 5 [r] at containment 0.04 over
  28 code token(s))
  threshold: containment < 0.5 (--fork-threshold 0 disables)
```

The remaining 6 files / 23 fences are **exactly** #501 §1's regulated set, re-derived from a
different code path than the one that produced that table. They are still restorable by this
tool; the `domain: compliance` carve-out is an operator decision, not something this change
enforces.

## The three constraints from #498, and what measurement said about each

**Per-tag comment syntax** — four batch-7 files scored 0.00, the maximum fork signal, on
comment-only restores verified at zero non-comment changed lines. Stripping `#` and not `//` or
`/* */` meant the "code tokens" compared in a JS or CSS fence *were* the comment words. All four
score 1.00 now.

**Per-tag identifier shape** — this one I have to state more narrowly than the issue does.
`de/prepare-print-model` scored 0.30 because the prototype's regex was tuned for **R identifiers**
and found nothing in YAML. The broader tokenizer here already scores those two real fences 0.68
and 0.72, clear of the threshold. Keys-mode takes them to 1.00 by dropping value prose, so it
removes the erosion that a block with a higher prose-to-key ratio would ride across the threshold
— but it is not what rescues that file. The test asserting otherwise failed, and was corrected
rather than adjusted.

**Never score an empty token set** — containment over an empty denominator is vacuously 1, which
is how #503 hid 8 of its 86 fences behind an apparent "0 suspects". `measure()` returns
`measurable: false` and callers report it in a section of its own. On the merged batches that
bucket turns out to be mostly fences that are entirely `#` comments — the separately tracked #502
population — which is a useful cross-check that it is finding a real class rather than noise.

Unrecognised tags are unmeasured, never scored by a default. Guessing wrong does not add noise, it
*inverts* the signal: a genuinely misaligned fence of that tag becomes indistinguishable from a
faithful one, so the whole tag goes dark. The 13 tags in the live backlog are all covered.

## Where the threshold comes from

Measured over two populations, not picked.

**Clean** — the 956 measurable fences the seven merged #477 batches actually restored, each already
human-reviewed at merge:

```
1.00  930    0.8-0.9  5    0.6-0.7  6    0.4-0.5  3
0.9-1.0 3    0.7-0.8  4    0.5-0.6  5    below 0.4: none
```

**Fork** — the 8 fences of `de/design-shiny-ui`: 0.00, 0.00, 0.04, 0.12, 0.20, 0.25, 0.83, 0.86.

Six of eight sit below the clean minimum of 0.40, so any value in (0.25, 0.40) separates them on
this data. The default 0.5 is deliberately *above* that band, and it is worth being exact about
which risk the margin buys down, because the obvious phrasing has it backwards.

Raising the threshold refuses **more**. So the margin does nothing about a future clean fence
scoring below 0.40 — that fence is refused either way, and a false refusal is the recoverable
error: the file goes to manual triage. What the margin covers is the unobserved upper tail of the
**fork** population, a fork scoring in [0.40, 0.50) that a threshold fitted to the clean minimum
would wave through and rewrite. It prices that tail at 3 fences in 2 files out of the 345 swept.

Both false suspects are small-token artifacts, reported with `n` so a reviewer can dismiss them:
`de/generate-puzzle` (0.40, n=5) is the translated path placeholder `/pfad/zum/skript.R`;
`ja/instrument-distributed-tracing` (0.43, n=7, twice) is an elision comment written `# ...`
inside a `go` fence, where `#` is not a comment marker. A minimum-token floor removes both —
floor=8 clears all three — but reclassifies 332 of 956 fences (35%) as unmeasurable. Buying a
0.3% false-positive rate with a third of the tool's coverage is the wrong trade.

**One positive instance.** The fork population is n=1. The separation is large and the mechanism is
understood, but no threshold claim from a single positive is strong, which is why `--fork-threshold`
is a flag and the number is echoed in every report.

## Scoping decisions

- **The check spans every gated fence pair**, not just the divergent ones `--tag` selected, for the
  same reason the two structural checks do: whether ordinal mapping is trustworthy is a property of
  the whole file. It is also strictly more sensitive — in a forked file a non-divergent gated fence
  still carries some *other* step's English body, which is the permutation this measure reads.
- **Refusal is file-scoped.** Two of design-shiny-ui's eight fences score 0.83 and 0.86, above any
  threshold in the separating band, so a per-fence rule would restore two fences of a file known to
  be scrambled and hand a reviewer a partly-rewritten file with nothing going red.
- **The fence quoted is the one carrying the most disagreeing tokens**, not the lowest score. The
  minimum here is a 3-token fence at 0.00, which reads as noise; `(1 - containment) * tokens`
  surfaces a 28-token fence at 0.04 — the same verdict with the argument attached.
- **No `--no-fork-check`.** `--fork-threshold 0` disables it, and naming the number forces the
  caller to say what standard they dropped to. The value is printed in the report summary on every
  run, so a run made with the guard off cannot be mistaken for a guarded one. (That sentence was
  false as first written — see the review round below.)

## Proving the gates can fail

Every "is refused" test is paired with a `--fork-threshold 0` run proving the same fixture *is*
rewritten, and with a faithful comment-only fixture proving the guard does not block the repair it
exists to make safe.

Nine mutants, all killed — the full list is in the review-round section below.

`npm run test:scripts`: 58 → 105 tests, all green.

## Deferred

#498 also asks whether `check-i18n-fence-parity.js` should gain a positional warn-mode. Not done
here: it would flag every legitimately reordered translation, so it cannot be the frozen-fence rule
and would need its own suppression story. The containment measure answers the same question without
that cost, at the point where it matters — before a rewrite.

## Adversarial review round

Five review lenses (scanner correctness, tag-table accuracy, the statistical
argument, the integration, test quality), each finding then handed to an independent
verifier prompted to refute it. 24 findings raised, **9 confirmed / 13 refuted**
(1 verifier errored on a finding another lens had already confirmed).

Three of the confirmed ones were claims this branch made that were false:

- The docblock argued against a `--no-fork-check` flag because `--fork-threshold 0`
  "shows up verbatim in the report header". It did not — the threshold printed only
  inside the refusal block, which the disabling value makes unreachable by
  construction. `--locale zh-CN` and the same command with `--fork-threshold 0`
  produced byte-identical stdout, and `--locale de --fork-threshold 0` planned all 8
  fences of `design-shiny-ui` with no line naming a threshold, a refusal or a fork.
  Now printed unconditionally, with a DISABLED marker at 0.
- `--fork-threshold ' '` silently disabled the guard: `Number(' ')` is 0 and 0 passes
  a `[0, 1]` check. Now parsed with an explicit decimal pattern.
- The unmeasured section claimed those fences were "still restored"; for a refused
  file, nothing was. Now split by the file's actual disposition.

Three were coverage gaps where a one-line source change stayed green — every fork
fixture had *all* its fences forked, so `below.length === measured` released the true
positive; the evidence-weighting test asserted the report's format, so
`reduce((a, b) => a)` passed; the `unmeasured` path and the per-tag `strings` entries
had no tests at all. And one factual error: `toml` was mapped to the YAML `key:`
extractor, so every TOML fence reported `no-code-tokens` — a benign-sounding reason
for a tooling gap.

One refuted finding was still directionally right about the prose. The docstring said
the 0.5 margin guards against "one future clean fence at 0.38 failing silently in the
dangerous direction". Raising a threshold refuses *more*, so a clean fence below the
band is refused either way — the recoverable error. The margin actually buys down the
unobserved upper tail of the *fork* population. Reworded.

### Mutants killed

Each fix carries a test proven able to fail:

```
if (below.length) -> if (below.length === measured)          KILLED by 1
? b : a)          -> ? a : a)                                KILLED by 1
delete unmeasured.push(...)                                  KILLED by 2
delete the `fork threshold:` header print                    KILLED by 1
threshold regex    -> /^[\s\S]*$/                            KILLED by 1
HASH strings [DQ, SQ] -> [DQ]                                KILLED by 1
toml tokens 'toml-keys' -> 'keys'                            KILLED by 1
delete below.push(...)                                       KILLED by 2
delete the 'no-code-tokens' return                           KILLED by 2
```

`npm run test:scripts`: 58 → 105 tests, all green.
