### PR TITLE
feat(i18n): add the placeholder-drift detector (#497)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "validate:translations": "node scripts/check-translation-freshness.js",
     "validate:i18n-parity": "node scripts/check-i18n-frontmatter-parity.js",
     "validate:i18n-fences": "node scripts/check-i18n-fence-parity.js",
+    "check:placeholder-drift": "node scripts/check-placeholder-drift.js",
     "normalize:i18n-fences": "node scripts/normalize-i18n-fences.js",
     "validate:content-style": "node scripts/check-content-style.js --all",
     "validate:line-endings": "node scripts/check-line-endings.js",

--- a/scripts/check-placeholder-drift.js
+++ b/scripts/check-placeholder-drift.js
@@ -36,16 +36,23 @@
  * deleted the target class and the resulting zero read as success.
  *
  * The predicate here is structural instead. A **substitution pair**: within a
- * frozen fence, an old and a new line are identical except for exactly one
- * token, and the removed form is still cited in a localisable register — prose
- * inline-code, or the body of an exempt `text`/`markdown`/`md` fence.
+ * frozen fence, an old and a new line differ by exactly ONE DISTINCT
+ * substitution, and the removed form is still cited in a localisable register —
+ * prose inline-code, or the body of an exempt `text`/`markdown`/`md` fence.
  *
- * "Exactly one token" is what carries it. The same commit rewrote
+ * That narrowness is what carries it. The same commit rewrote
  * `git commit -m "Entwicklung fuer naechste Version beginnen"` to
- * `git commit -m "Begin development for next version"` — five tokens changed,
- * an ordinary translation restore, and not a placeholder rename. Requiring a
- * single differing token separates a rename from a retranslation without
+ * `git commit -m "Begin development for next version"` — five distinct
+ * substitutions, an ordinary translation restore, not a placeholder rename.
+ * One-distinct-substitution separates a rename from a retranslation without
  * knowing anything about what the token looks like.
+ *
+ * Distinct substitutions, NOT differing positions. Counting positions inverted
+ * the detector on the commonest shape a placeholder takes: a rename applied
+ * completely to a line was invisible and only a rename occurring exactly once
+ * per line could be seen. `docker tag X:latest ghcr.io/USERNAME/X:latest` is two
+ * positions carrying one rename, and 5,783 gated-fence lines across 1,571 files
+ * in this corpus repeat a token.
  *
  * ## It stays advisory
  *
@@ -55,11 +62,36 @@
  * it and dismiss it. A gate that must be overridden routinely trains the reflex
  * #472 exists to prevent, so this reports and exits 0 on findings.
  *
- * ## Scope limit
+ * ## What it cannot see
  *
  * It compares two revisions, so it sees only drift a change INTRODUCES.
  * Pre-existing drift in the corpus is invisible to it and needs a separate
  * one-shot scan.
+ *
+ * Within a compared line, three shapes are out of reach, all measured rather
+ * than assumed:
+ *
+ * - **Two different placeholders renamed on one line** — two distinct
+ *   substitutions, rejected with the retranslations. `cp datei.txt ziel/` ->
+ *   `cp file.txt target/` is invisible.
+ * - **A rename that changes the token COUNT.** `-`, `_` and `.` are inside the
+ *   token class, so `paket-name` -> `package-name` is 1 -> 1 and is caught; but
+ *   `paket-name` -> `package name` is 1 -> 2 and is dropped by the length guard.
+ *   This needs the English form to contain a space, which a code identifier in a
+ *   frozen fence generally cannot, so it is largely theoretical for de/es.
+ * - **CJK.** `\p{L}` covers Han and kana, and those scripts do not delimit words
+ *   with spaces, so a whole phrase collapses to one token and a Latin run
+ *   adjacent to kana MERGES with it. `# 標準的な評価チャンク` is one token against
+ *   three for `# Standard evaluation chunk`. Latent rather than live: no
+ *   instance of a placeholder riding such a line inside a gated fence was found.
+ *
+ * Coverage is reported, not assumed. Every unexamined path increments a counter
+ * — `skippedFiles` for a fence-count change, a tag-sequence divergence, or a
+ * file added/deleted/renamed in the range, and `unalignedFences` for an
+ * oversized LCS table — and a run that compared nothing says so instead of
+ * printing a clean line. Across the seven merged batches plus the #476
+ * re-mirror the tool made 976 fence comparisons and skipped 44 files, all of
+ * them in the re-mirror, whose fence structure changed wholesale.
  *
  * Usage:
  *   node scripts/check-placeholder-drift.js                      # HEAD~1..HEAD
@@ -145,26 +177,37 @@ const CODE_SHAPED = /^(?:[a-z0-9]+_[a-z0-9_]+|[A-Z0-9]+_[A-Z0-9_]+|[a-z0-9]+-[a-
  * Every token cited in a register a translation is ALLOWED to localise, in one
  * revision of one file: prose inline-code spans, and exempt fence bodies.
  *
- * Bare prose is deliberately excluded — admitting it is one of the predicates
- * #497 rejected, and `--compare` still measures it: 223 hits over #496's 3,242
- * removed tokens, almost all ordinary German words that happen to sit in an
- * exempt block somewhere. (#497 quotes 143 for that predicate and 0 for the
- * code-shape one; the prototype behind those figures no longer exists, so the
- * exact definitions are unrecoverable and the numbers here are this file's own.
- * What reproduces is the shape of the comparison, not the digits.)
+ * Bare prose — a token appearing in un-backticked prose — is deliberately
+ * excluded, and NOTHING here measures it; `--compare` reports two other
+ * predicates, `codeShaped` and `anyExemptFence`. Over #496's 3,242 removed
+ * tokens those read 15 and 223 against this predicate's 4. (#497 quotes 0 and
+ * 143 for its own versions; the prototype behind those figures no longer
+ * exists, so the definitions are unrecoverable and the numbers here are this
+ * file's own. What reproduces is the shape of the comparison, not the digits.)
  *
- * The register is recorded rather than filtered on, and it turns out to separate
- * the classes by itself. Across all seven merged batches plus the #476 re-mirror
- * — 992 frozen fences — the two registers split 4 / 5:
+ * The register is recorded rather than filtered on. Across the seven merged
+ * batches plus the #476 re-mirror the two registers split 4 / 5 — inline-code
+ * 4, all in #496, two of them the real `paketname` defect; exempt-fence 5,
+ * every one an ordinary German word (`von` ×4, `Datei`).
  *
- *   inline-code   4, all in #496, two of them the real `paketname` defect
- *   exempt-fence  5, every one an ordinary German word (`von` ×4, `Datei`)
+ * **That split is not evidence the register discriminates, and the sort is a
+ * hunch rather than a finding.** The one confirmed true positive is cited in
+ * BOTH registers — `paketname` appears in prose inline-code at lines 69 and 167
+ * of the #496 revision AND in the exempt ```markdown example at line 75 — so it
+ * lands in the strong bucket by the tie-break in `note()`, not by
+ * discrimination. Had that batch repaired the backticks and left only the
+ * markdown example stale, the identical defect would have sorted last. Register
+ * is also perfectly confounded with batch here: all four inline-code hits are in
+ * #496 and all five exempt-fence hits are elsewhere, so "register predicts
+ * truth" is not separable from "#496 was the batch with the bug", and n = one
+ * independent rename.
  *
- * Someone who writes a placeholder in backticks is NAMING it. A token that
- * merely occurs as a word inside an exempt block usually is not. Sorting on that
- * puts the target class first and makes the rest a one-glance dismissal, without
- * deleting anything — with a single confirmed true positive on record, filtering
- * on it is exactly the move that tuned the previous detector to zero.
+ * It is kept because it costs nothing and the mechanism is plausible — someone
+ * who writes a placeholder in backticks is naming it — and because filtering on
+ * it, on this evidence, is exactly the move that tuned the previous detector to
+ * zero. It would be falsified by a real defect whose only citation is in an
+ * exempt fence, or by a backticked ordinary locale word producing an
+ * inline-code false positive.
  */
 function localisableCitations(text) {
   const lines = toLines(text);
@@ -260,13 +303,33 @@ function substitution(beforeLine, afterLine) {
   const from = tokensOf(beforeLine);
   const to = tokensOf(afterLine);
   if (from.length !== to.length) return null;
-  let at = -1;
+
+  // One distinct SUBSTITUTION, not one differing position. The first version
+  // counted positions, which inverted the detector on the commonest shape a
+  // placeholder takes: a rename applied COMPLETELY to a line was invisible,
+  // and only a rename occurring exactly once per line could be seen.
+  //
+  //   docker tag meineapp:latest ghcr.io/USERNAME/meineapp:latest
+  //   docker tag myapp:latest    ghcr.io/USERNAME/myapp:latest
+  //
+  // is two differing positions carrying one rename, and it was dropped. 5,783
+  // gated-fence lines across 1,571 files in this corpus repeat a token, so the
+  // shape is pervasive rather than incidental.
+  //
+  // Collapsing to distinct pairs keeps the property that does the work. The
+  // retranslation this predicate exists to reject —
+  // `"Entwicklung fuer naechste Version beginnen"` ->
+  // `"Begin development for next version"` — is five DISTINCT pairs and is
+  // still rejected. Two different placeholders renamed on one line is two
+  // distinct pairs and is still rejected too: that is one line carrying two
+  // renames, which this predicate does not claim to read.
+  const seen = new Map();
   for (let k = 0; k < to.length; k++) {
     if (from[k] === to[k]) continue;
-    if (at >= 0) return null;
-    at = k;
+    seen.set(`${from[k]} ${to[k]}`, { removed: from[k], added: to[k] });
+    if (seen.size > 1) return null;
   }
-  return at < 0 ? null : { removed: from[at], added: to[at] };
+  return seen.size === 1 ? [...seen.values()][0] : null;
 }
 
 /** Every token appearing in ANY exempt fence — the other rejected predicate. */
@@ -300,12 +363,34 @@ const skippedFiles = [];
 for (const path of changed) {
   const baseText = git(['show', `${BASE}:${path}`]);
   const headText = git(['show', `${HEAD}:${path}`]);
-  if (baseText === null || headText === null) continue; // added or deleted
+  if (baseText === null || headText === null) {
+    // Counted, not dropped. `git diff --name-only` reports a RENAME as its
+    // destination path alone, so a batch that moved a skill while restoring a
+    // fence inside it resolved no base blob and vanished here with no counter —
+    // the one unexamined path of three that left no trace.
+    skippedFiles.push({ path, reason: 'added, deleted or renamed in this range' });
+    continue;
+  }
 
   const baseFences = extractFences(baseText);
   const headFences = extractFences(headText);
   if (baseFences.length !== headFences.length) {
     skippedFiles.push({ path, reason: `fence count ${baseFences.length} -> ${headFences.length}` });
+    continue;
+  }
+
+  // Equal fence counts do not make ordinal mapping trustworthy on their own —
+  // a `text` -> `yaml` retag keeps the count and makes a translated table the
+  // "before body" of a frozen fence. The sibling normalizer validates the tag
+  // sequence before trusting the ordinal; so does this.
+  const alignmentTag = (f) => (f.lang === '' ? 'text' : f.lang);
+  const misaligned = headFences.findIndex((f, i) => alignmentTag(f) !== alignmentTag(baseFences[i]));
+  if (misaligned >= 0) {
+    skippedFiles.push({
+      path,
+      reason: `tag sequence diverges at fence ${misaligned + 1} `
+        + `(${baseFences[misaligned].lang || 'untagged'} -> ${headFences[misaligned].lang || 'untagged'})`,
+    });
     continue;
   }
 
@@ -402,7 +487,13 @@ if (skippedFiles.length) console.log(`  ${skippedFiles.length} file(s) skipped (
 console.log('');
 
 if (findings.length === 0) {
-  console.log('No substitution pair leaves a translated placeholder cited in prose.');
+  // Qualified by what was actually examined. An unqualified "no findings" over
+  // zero comparisons is the clean-looking zero this file's other guards exist
+  // to reject, and every drop path above now carries a counter so the two
+  // numbers can be reconciled.
+  console.log(fencesCompared === 0
+    ? 'NOTHING WAS EXAMINED — no frozen fence in this range could be compared.'
+    : `No substitution pair leaves a translated placeholder cited nearby (${fencesCompared} fence(s) examined).`);
 } else {
   // Strongest register first. An author who writes a placeholder in backticks
   // is NAMING it; a token that merely occurs as a word inside an exempt block is

--- a/scripts/check-placeholder-drift.js
+++ b/scripts/check-placeholder-drift.js
@@ -1,0 +1,441 @@
+#!/usr/bin/env node
+/**
+ * check-placeholder-drift.js
+ *
+ * Advisory detector for the review hazard #477 names as "prose can reference
+ * in-fence identifiers" (#497). Run it on every fence-restore batch.
+ *
+ * ## What it is for
+ *
+ * Restoring a frozen fence to its English body is correct by the #472 rule, but
+ * the fence does not stand alone: the prose around it, and the exempt
+ * `text`/`markdown` fences beside it, may name the same placeholder. Restore one
+ * and not the other and the file names one thing two ways.
+ *
+ * #496 did exactly that. Two `bash` fences in
+ * `i18n/de/skills/release-package-version/SKILL.md` went `paketname` ->
+ * `packagename`, while the prose explaining those commands and the exempt
+ * ```markdown NEWS.md example kept saying `paketname`. Fixed in `8ed584a4`.
+ *
+ * Three things were pointed at that batch and only one caught it:
+ *
+ *   | check                                        | result          |
+ *   |----------------------------------------------|-----------------|
+ *   | ad-hoc detector keyed on code-shaped tokens   | 0 — missed it   |
+ *   | 6 locale-sharded review agents + refuters     | 0 — missed it   |
+ *   | Copilot                                       | found it        |
+ *
+ * ## Why shape does not work, and structure does
+ *
+ * The detector that missed it keyed on token SHAPE — snake_case, CONSTANT_CASE,
+ * kebab-case, dotted.path, camelCase. `paketname` is a plain lowercase word and
+ * matched none of them. That is the most likely form of this defect, because a
+ * translator renames `packagename` to a plain word in their own language, not to
+ * a camelCase one. Worse, that filter had been tuned from 216 false positives
+ * down to 0 with no confirmed true positive to test against, so the tuning
+ * deleted the target class and the resulting zero read as success.
+ *
+ * The predicate here is structural instead. A **substitution pair**: within a
+ * frozen fence, an old and a new line are identical except for exactly one
+ * token, and the removed form is still cited in a localisable register — prose
+ * inline-code, or the body of an exempt `text`/`markdown`/`md` fence.
+ *
+ * "Exactly one token" is what carries it. The same commit rewrote
+ * `git commit -m "Entwicklung fuer naechste Version beginnen"` to
+ * `git commit -m "Begin development for next version"` — five tokens changed,
+ * an ordinary translation restore, and not a placeholder rename. Requiring a
+ * single differing token separates a rename from a retranslation without
+ * knowing anything about what the token looks like.
+ *
+ * ## It stays advisory
+ *
+ * Not every hit is a defect. `de/prune-agent-memory` changes `Eintraege` ->
+ * `entries` inside an echoed shell string, which is a frozen fence carrying an
+ * English output string: exactly what the rule requires. A reviewer should see
+ * it and dismiss it. A gate that must be overridden routinely trains the reflex
+ * #472 exists to prevent, so this reports and exits 0 on findings.
+ *
+ * ## Scope limit
+ *
+ * It compares two revisions, so it sees only drift a change INTRODUCES.
+ * Pre-existing drift in the corpus is invisible to it and needs a separate
+ * one-shot scan.
+ *
+ * Usage:
+ *   node scripts/check-placeholder-drift.js                      # HEAD~1..HEAD
+ *   node scripts/check-placeholder-drift.js --base <ref>
+ *   node scripts/check-placeholder-drift.js --base <ref> --head <ref>
+ *   node scripts/check-placeholder-drift.js --json
+ *   node scripts/check-placeholder-drift.js --compare            # rejected predicates too
+ */
+
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+import { extractFences, toLines, isGated } from './lib/fences.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const GIT_BUFFER = 512 * 1024 * 1024;
+
+// ---- arguments: default-deny, same shape as normalize-i18n-fences.js ----
+const BOOL_FLAGS = new Set(['--json', '--compare']);
+const VALUE_FLAGS = new Set(['--base', '--head']);
+
+function usageError(message) {
+  console.error(`ERROR: ${message}`);
+  console.error(`Usage: ${[...BOOL_FLAGS, ...VALUE_FLAGS].join(' ')}`);
+  process.exit(2);
+}
+
+const opts = { json: false, compare: false, base: 'HEAD~1', head: 'HEAD' };
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i];
+  const eq = arg.indexOf('=');
+  const name = eq >= 0 ? arg.slice(0, eq) : arg;
+  if (BOOL_FLAGS.has(name)) {
+    if (eq >= 0) usageError(`${name} takes no value (got '${arg}')`);
+    opts[name.slice(2)] = true;
+  } else if (VALUE_FLAGS.has(name)) {
+    const value = eq >= 0 ? arg.slice(eq + 1) : argv[++i];
+    if (value === undefined || value === '' || (eq < 0 && value.startsWith('--'))) {
+      usageError(`${name} requires a value`);
+    }
+    opts[name.slice(2)] = value;
+  } else {
+    usageError(`unknown argument '${arg}'`);
+  }
+}
+
+function git(args) {
+  const r = spawnSync('git', args, { cwd: ROOT, encoding: 'utf8', maxBuffer: GIT_BUFFER });
+  return r.status === 0 ? r.stdout : null;
+}
+
+function resolveRef(ref) {
+  const out = git(['rev-parse', '--verify', `${ref}^{commit}`]);
+  if (out === null) {
+    console.error(`ERROR: --base/--head ref does not resolve to a commit: '${ref}'`);
+    process.exit(2);
+  }
+  return out.trim();
+}
+
+const BASE = resolveRef(opts.base);
+const HEAD = resolveRef(opts.head);
+
+/**
+ * A token, for the purpose of "identical except one token".
+ *
+ * Unicode letters, because the removed side is by definition the translated one
+ * — `Eintraege`, `Duesendurchmesser`, and in other locales tokens outside ASCII
+ * entirely. An ASCII-only class would drop the very side being measured.
+ *
+ * A trailing `.`/`-` is kept inside the token so `v0.2.0` and `--dry-run` read
+ * as one, which is what makes `"Release paketname v0.2.0"` a single-token change
+ * rather than a four-token one.
+ */
+const TOKEN = /[\p{L}_][\p{L}\p{N}_.-]*/gu;
+const tokensOf = (line) => line.match(TOKEN) ?? [];
+
+/** Shapes the detector that MISSED the defect keyed on. Kept only for --compare. */
+const CODE_SHAPED = /^(?:[a-z0-9]+_[a-z0-9_]+|[A-Z0-9]+_[A-Z0-9_]+|[a-z0-9]+-[a-z0-9-]+|\w+\.\w+|[a-z]+[A-Z]\w*)$/;
+
+/**
+ * Every token cited in a register a translation is ALLOWED to localise, in one
+ * revision of one file: prose inline-code spans, and exempt fence bodies.
+ *
+ * Bare prose is deliberately excluded — admitting it is one of the predicates
+ * #497 rejected, and `--compare` still measures it: 223 hits over #496's 3,242
+ * removed tokens, almost all ordinary German words that happen to sit in an
+ * exempt block somewhere. (#497 quotes 143 for that predicate and 0 for the
+ * code-shape one; the prototype behind those figures no longer exists, so the
+ * exact definitions are unrecoverable and the numbers here are this file's own.
+ * What reproduces is the shape of the comparison, not the digits.)
+ *
+ * The register is recorded rather than filtered on, and it turns out to separate
+ * the classes by itself. Across all seven merged batches plus the #476 re-mirror
+ * — 992 frozen fences — the two registers split 4 / 5:
+ *
+ *   inline-code   4, all in #496, two of them the real `paketname` defect
+ *   exempt-fence  5, every one an ordinary German word (`von` ×4, `Datei`)
+ *
+ * Someone who writes a placeholder in backticks is NAMING it. A token that
+ * merely occurs as a word inside an exempt block usually is not. Sorting on that
+ * puts the target class first and makes the rest a one-glance dismissal, without
+ * deleting anything — with a single confirmed true positive on record, filtering
+ * on it is exactly the move that tuned the previous detector to zero.
+ */
+function localisableCitations(text) {
+  const lines = toLines(text);
+  const fences = extractFences(text);
+  const inFence = new Array(lines.length).fill(false);
+  /** token -> 'inline-code' | 'exempt-fence'; inline-code wins when both. */
+  const cited = new Map();
+  const note = (t, register) => {
+    if (register === 'inline-code' || !cited.has(t)) cited.set(t, register);
+  };
+
+  for (const f of fences) {
+    // Blank the delimiters too, so a fence opener never reads as prose.
+    for (let i = Math.max(0, f.line - 1); i <= Math.min(lines.length - 1, f.bodyEnd); i++) {
+      inFence[i] = true;
+    }
+    if (isGated(f)) continue;
+    for (const t of tokensOf(f.body)) note(t, 'exempt-fence');
+    for (const m of f.body.matchAll(/`([^`\n]+)`/g)) {
+      for (const t of tokensOf(m[1])) note(t, 'inline-code');
+    }
+  }
+
+  const prose = lines.filter((_, i) => !inFence[i]).join('\n');
+  for (const m of prose.matchAll(/`([^`\n]+)`/g)) {
+    for (const t of tokensOf(m[1])) note(t, 'inline-code');
+  }
+  return cited;
+}
+
+/**
+ * Pair the changed lines of two fence bodies by LCS.
+ *
+ * Index pairing, which this replaces, could only examine a fence whose two
+ * bodies had the SAME line count — 67 of batch 1's 172 changed fences failed
+ * that and went unexamined. A fence that gained or lost a line can still carry
+ * a substitution pair in the lines around it.
+ *
+ * Returns `null` rather than a partial answer when the table would be
+ * pathologically large, so the caller counts it as unexamined instead of
+ * quietly clearing it.
+ */
+function changeBlocks(before, after) {
+  const n = before.length;
+  const m = after.length;
+  if (n * m > 400000) return null;
+
+  const dp = Array.from({ length: n + 1 }, () => new Uint32Array(m + 1));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = before[i] === after[j]
+        ? dp[i + 1][j + 1] + 1
+        : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+
+  const blocks = [];
+  let pendingBefore = [];
+  let pendingAfter = [];
+  const flush = () => {
+    if (pendingBefore.length || pendingAfter.length) {
+      blocks.push({ before: pendingBefore, after: pendingAfter });
+    }
+    pendingBefore = [];
+    pendingAfter = [];
+  };
+
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (before[i] === after[j]) { flush(); i++; j++; continue; }
+    if (dp[i + 1][j] >= dp[i][j + 1]) pendingBefore.push({ text: before[i], index: i++ });
+    else pendingAfter.push({ text: after[j], index: j++ });
+  }
+  while (i < n) pendingBefore.push({ text: before[i], index: i++ });
+  while (j < m) pendingAfter.push({ text: after[j], index: j++ });
+  flush();
+  return blocks;
+}
+
+/**
+ * The removed/added token when two lines are identical except for exactly one
+ * token, else null.
+ *
+ * "Exactly one" is what carries the whole detector. #496 rewrote
+ * `git commit -m "Entwicklung fuer naechste Version beginnen"` to
+ * `git commit -m "Begin development for next version"` in the same batch as the
+ * `paketname` rename — five tokens, an ordinary retranslation. Requiring a
+ * single differing token separates a rename from a retranslation without knowing
+ * anything about what the token looks like.
+ */
+function substitution(beforeLine, afterLine) {
+  const from = tokensOf(beforeLine);
+  const to = tokensOf(afterLine);
+  if (from.length !== to.length) return null;
+  let at = -1;
+  for (let k = 0; k < to.length; k++) {
+    if (from[k] === to[k]) continue;
+    if (at >= 0) return null;
+    at = k;
+  }
+  return at < 0 ? null : { removed: from[at], added: to[at] };
+}
+
+/** Every token appearing in ANY exempt fence — the other rejected predicate. */
+function exemptFenceTokens(text) {
+  const cited = new Set();
+  for (const f of extractFences(text)) {
+    if (!isGated(f)) for (const t of tokensOf(f.body)) cited.add(t);
+  }
+  return cited;
+}
+
+// ---- scan ----
+const changed = (git(['diff', '--name-only', BASE, HEAD, '--', 'i18n/']) || '')
+  .split('\n')
+  .filter((p) => p.endsWith('.md'));
+
+const findings = [];
+/**
+ * The two predicates #497 rejected, measured over the SAME candidate universe
+ * they were originally run against: every token removed from a frozen fence
+ * line, NOT only the ones that survive the substitution-pair filter. Scoping
+ * them to substitution pairs would flatter both — the pair filter is most of
+ * what makes this detector quiet, so crediting it to them hides the comparison
+ * the issue exists to record.
+ */
+const alternatives = { candidates: 0, codeShaped: 0, anyExemptFence: 0 };
+let fencesCompared = 0;
+let unalignedFences = 0;
+const skippedFiles = [];
+
+for (const path of changed) {
+  const baseText = git(['show', `${BASE}:${path}`]);
+  const headText = git(['show', `${HEAD}:${path}`]);
+  if (baseText === null || headText === null) continue; // added or deleted
+
+  const baseFences = extractFences(baseText);
+  const headFences = extractFences(headText);
+  if (baseFences.length !== headFences.length) {
+    skippedFiles.push({ path, reason: `fence count ${baseFences.length} -> ${headFences.length}` });
+    continue;
+  }
+
+  const cited = localisableCitations(headText);
+  const exemptOnly = opts.compare ? exemptFenceTokens(headText) : null;
+
+  for (let i = 0; i < headFences.length; i++) {
+    const before = baseFences[i];
+    const after = headFences[i];
+    if (!isGated(after) || before.body === after.body) continue;
+
+    const blocks = changeBlocks(before.body.split('\n'), after.body.split('\n'));
+    if (blocks === null) {
+      // Reported, never silently dropped: an unexamined fence is not a cleared
+      // one, and a detector that conflates the two is how a zero stops meaning
+      // anything.
+      unalignedFences++;
+      continue;
+    }
+    fencesCompared++;
+
+    for (const block of blocks) {
+      if (opts.compare) {
+        // Per block, not per line pair: which tokens the block removed is a
+        // property of the block, and counting them per candidate pairing would
+        // multiply them by the cross product below.
+        const kept = new Set(block.after.flatMap((l) => tokensOf(l.text)));
+        for (const t of block.before.flatMap((l) => tokensOf(l.text))) {
+          if (kept.has(t)) continue;
+          alternatives.candidates++;
+          if (CODE_SHAPED.test(t)) alternatives.codeShaped++;
+          if (exemptOnly.has(t)) alternatives.anyExemptFence++;
+        }
+      }
+
+      // Every before x after combination within the block, rather than a guessed
+      // pairing. Positional pairing — the first version — mispairs the moment a
+      // block holds an insertion before the rename: a fence that gained a line
+      // paired the renamed line against the INSERTED one, found many differing
+      // tokens, and cleared the fence.
+      //
+      // The cross product is safe precisely because the predicate is so narrow.
+      // Two unrelated lines matching "identical except exactly one token"
+      // requires every other token to agree in order, which does not happen by
+      // accident; blocks are also small. At most one hit per new line, so an
+      // insertion cannot inflate the count.
+      const claimed = new Set();
+      for (const afterLine of block.after) {
+        for (const beforeLine of block.before) {
+          if (claimed.has(afterLine.index)) break;
+          const sub = substitution(beforeLine.text, afterLine.text);
+          if (sub === null) continue;
+          const register = cited.get(sub.removed);
+          if (register === undefined) continue;
+          claimed.add(afterLine.index);
+          findings.push({
+            path,
+            fence: i + 1,
+            tag: after.lang || 'untagged',
+            line: after.line + 1 + afterLine.index,
+            removed: sub.removed,
+            added: sub.added,
+            register,
+            context: afterLine.text.trim().slice(0, 120),
+          });
+        }
+      }
+    }
+  }
+}
+
+// A run that compared nothing is not a clean run. Without this the natural
+// mistake — pointing it at a merge commit, or a ref pair with no i18n/ change —
+// reports "0 findings" and reads as a pass.
+if (changed.length === 0) {
+  console.error(`ERROR: no i18n/*.md changed between ${BASE.slice(0, 9)} and ${HEAD.slice(0, 9)}.`);
+  console.error('Nothing would be compared, and the run would report a clean-looking zero.');
+  process.exit(2);
+}
+
+if (opts.json) {
+  console.log(JSON.stringify({
+    base: BASE, head: HEAD, filesChanged: changed.length, fencesCompared, unalignedFences,
+    findings, skippedFiles,
+    ...(opts.compare ? { alternatives } : {}),
+  }, null, 2));
+  process.exit(0);
+}
+
+console.log(`placeholder drift: ${BASE.slice(0, 9)} -> ${HEAD.slice(0, 9)}`);
+console.log(`  ${changed.length} changed i18n file(s); ${fencesCompared} frozen fence(s) compared`);
+if (unalignedFences) console.log(`  ${unalignedFences} fence(s) not examined (line counts differ)`);
+if (skippedFiles.length) console.log(`  ${skippedFiles.length} file(s) skipped (fence count changed)`);
+console.log('');
+
+if (findings.length === 0) {
+  console.log('No substitution pair leaves a translated placeholder cited in prose.');
+} else {
+  // Strongest register first. An author who writes a placeholder in backticks
+  // is NAMING it; a token that merely occurs as a word inside an exempt block is
+  // usually an ordinary word of the locale. Batch 1's four `von` -> `from` hits
+  // are the whole of that second class, and they are dismissed in one glance
+  // once the register is on the line.
+  //
+  // Sorted, not filtered. There is exactly one confirmed true positive on
+  // record, and dropping the weaker register on that evidence is how the
+  // previous detector tuned 216 false positives down to 0 and deleted the target
+  // class with them.
+  const strong = findings.filter((f) => f.register === 'inline-code');
+  const weak = findings.filter((f) => f.register !== 'inline-code');
+  console.log(`${findings.length} substitution pair(s) whose removed form is still cited nearby`);
+  console.log(`  ${strong.length} cited in inline-code · ${weak.length} cited only as a word in an exempt fence`);
+  console.log('');
+  for (const f of [...strong, ...weak]) {
+    console.log(`  ${f.path}:${f.line}  [${f.tag}] fence ${f.fence}  (cited in ${f.register})`);
+    console.log(`    ${f.removed}  ->  ${f.added}`);
+    console.log(`    ${f.context}`);
+  }
+  console.log('');
+  console.log('ADVISORY. Each needs a human call: an English output string inside a frozen');
+  console.log('fence is what the rule requires, and reads the same as a placeholder rename.');
+}
+
+if (opts.compare) {
+  console.log('');
+  console.log(`rejected predicates over the same ${alternatives.candidates} removed token(s):`);
+  console.log(`  code-shaped removed token          : ${alternatives.codeShaped}`);
+  console.log(`  removed token in any exempt fence  : ${alternatives.anyExemptFence}`);
+  console.log(`  substitution pair + cited (shipped): ${findings.length}`);
+}
+
+// Advisory by design — see the header. Findings do not fail the run.
+process.exit(0);

--- a/scripts/test/check-placeholder-drift.test.js
+++ b/scripts/test/check-placeholder-drift.test.js
@@ -111,9 +111,13 @@ test('a retranslation is not a rename — more than one token changed', async (t
   // The same #496 commit rewrote a whole commit message from German to English.
   // Requiring exactly one differing token separates that from a placeholder
   // rename without knowing what the token looks like.
+  // The prose cites BOTH the first and the last differing token. Without that,
+  // this test passes on a build with the exactly-one guard deleted: `at` would
+  // simply end on the last differing index, report `beginnen`, and find it
+  // uncited — so the assertion held for the wrong reason and the mutant lived.
   const before = [
     '---', 'name: demo', 'locale: de', '---', '',
-    'Siehe `Entwicklung`.', '',
+    'Siehe `Entwicklung` und `beginnen`.', '',
     '```bash', 'git commit -m "Entwicklung fuer naechste Version beginnen"', '```', '',
   ].join('\n');
   const after = before.replace(
@@ -171,12 +175,15 @@ test('the two registers are reported separately in the human output', async (t) 
 test('an exempt fence is never itself treated as a frozen fence', async (t) => {
   // Localisable fences are what a translation exists to change; reading a
   // substitution out of one would report every translated table.
+  // `offen` must be cited, or the exempt-fence check is untested: with the
+  // `isGated` guard removed this fence IS read as frozen, yielding the
+  // substitution `offen` -> `open`, and only a citation makes that observable.
   const before = [
     '---', 'name: demo', 'locale: de', '---', '',
-    'Siehe `Status`.', '',
+    'Siehe `Status`, derzeit `offen`.', '',
     '```text', 'Status: offen', '```', '',
   ].join('\n');
-  const after = before.replace('Status: offen', 'Status: open');
+  const after = before.replace('```text\nStatus: offen', '```text\nStatus: open');
   const dir = makeFixture(t, before, after);
 
   assert.equal(json(dir).findings.length, 0);

--- a/scripts/test/check-placeholder-drift.test.js
+++ b/scripts/test/check-placeholder-drift.test.js
@@ -269,3 +269,31 @@ test('findings do not fail the run — it is advisory by design', async (t) => {
   assert.equal(r.status, 0);
   assert.match(r.stdout, /ADVISORY/);
 });
+
+test('change blocks are scoped by matching context, so distant lines are not paired', async (t) => {
+  // The cross product inside a block is safe only because a block is bounded by
+  // lines that match. Merge adjacent blocks and it spans the whole fence, and
+  // the FIRST changed line starts pairing against the LAST one.
+  //
+  // Here `alpha` is cited and `beta` is not, so the correct scoping yields
+  // exactly one finding, `alpha -> gamma`. Merged blocks would additionally
+  // pair `run alpha` against `run delta` and report `alpha -> delta`, a
+  // substitution between two lines that were never each other's counterpart.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `alpha`.', '',
+    '```bash', 'run alpha', 'same1', 'same2', 'run beta', '```', '',
+  ].join('\n');
+  const after = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `alpha`.', '',
+    '```bash', 'run gamma', 'same1', 'same2', 'run delta', '```', '',
+  ].join('\n');
+  const dir = makeFixture(t, before, after);
+
+  const r = json(dir);
+
+  assert.equal(r.findings.length, 1, JSON.stringify(r.findings));
+  assert.equal(r.findings[0].removed, 'alpha');
+  assert.equal(r.findings[0].added, 'gamma', 'a distant line was paired as a counterpart');
+});

--- a/scripts/test/check-placeholder-drift.test.js
+++ b/scripts/test/check-placeholder-drift.test.js
@@ -297,3 +297,134 @@ test('change blocks are scoped by matching context, so distant lines are not pai
   assert.equal(r.findings[0].removed, 'alpha');
   assert.equal(r.findings[0].added, 'gamma', 'a distant line was paired as a counterpart');
 });
+
+// ── gaps an adversarial review found: mutants that survived the suite ────────
+
+test('one rename applied TWICE on a line is one substitution, and is reported', async (t) => {
+  // The commonest shape a placeholder takes in a fence, and the first version
+  // inverted on it: counting differing POSITIONS meant a rename applied
+  // completely to a line was invisible, and only a rename occurring exactly
+  // once per line could be seen. 5,783 gated-fence lines across 1,571 corpus
+  // files repeat a token.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `meineapp`.', '',
+    '```bash', 'docker tag meineapp:latest ghcr.io/USERNAME/meineapp:latest', '```', '',
+  ].join('\n');
+  const after = before.replace(
+    'docker tag meineapp:latest ghcr.io/USERNAME/meineapp:latest',
+    'docker tag myapp:latest ghcr.io/USERNAME/myapp:latest',
+  );
+  const dir = makeFixture(t, before, after);
+
+  const r = json(dir);
+
+  assert.equal(r.findings.length, 1, JSON.stringify(r.findings));
+  assert.equal(r.findings[0].removed, 'meineapp');
+  assert.equal(r.findings[0].added, 'myapp');
+});
+
+test('TWO different renames on one line are still rejected', async (t) => {
+  // The distinct-pair rule must not become "any number of renames". One line
+  // carrying two renames is not what this predicate claims to read, and
+  // admitting it reopens the retranslation class.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `datei.txt` und `ziel`.', '',
+    '```bash', 'cp datei.txt ziel/', '```', '',
+  ].join('\n');
+  const after = before.replace('cp datei.txt ziel/', 'cp file.txt target/');
+  const dir = makeFixture(t, before, after);
+
+  assert.equal(json(dir).findings.length, 0);
+});
+
+test('--compare actually counts the code-shape predicate it reports', async (t) => {
+  // Positive control. The existing test asserts `codeShaped === 0`, which also
+  // passes when the counter never increments — the file's own diagnosed failure
+  // mode ("tuned to 0 with no true positive to test against") reproduced inside
+  // the suite built to prevent it.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `paket_name`.', '',
+    '```bash', 'echo "$paket_name"', '```', '',
+  ].join('\n');
+  const after = before.replace('echo "$paket_name"', 'echo "$package_name"');
+  const dir = makeFixture(t, before, after);
+
+  const r = json(dir, ['--compare']);
+
+  assert.equal(r.alternatives.codeShaped, 1, 'the code-shape counter never fired');
+  assert.ok(r.alternatives.candidates > 0, 'the candidate universe is empty');
+});
+
+test('a gated fence body is never itself a citation register', async (t) => {
+  // Two frozen fences both naming the placeholder; the batch restores one. If
+  // gated bodies counted as citations, the restored fence would be "still
+  // cited" by its own untouched sibling — a pure false positive. The guard
+  // exists; nothing held it to that answer.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Keine Zitate in Prosa.', '',
+    '```bash', 'echo "paketname"', '```', '',
+    '```bash', 'build paketname', '```', '',
+  ].join('\n');
+  const after = before.replace('echo "paketname"', 'echo "packagename"');
+  const dir = makeFixture(t, before, after);
+
+  assert.equal(json(dir).findings.length, 0, 'a frozen fence cited the placeholder');
+});
+
+test('a line that lost a token is not read as a substitution', async (t) => {
+  // Without the length guard the comparison loop runs only to the shorter
+  // length, so a truncated line reads as a clean rename.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `alpha`.', '',
+    '```bash', 'echo alpha extra', '```', '',
+  ].join('\n');
+  const after = before.replace('echo alpha extra', 'echo gamma');
+  const dir = makeFixture(t, before, after);
+
+  assert.equal(json(dir).findings.length, 0);
+});
+
+test('the reported line number is the changed line, not the first body line', async (t) => {
+  // The existing line-number test uses a one-line fence body, where index 0
+  // makes `after.line + 1 + index` and `after.line + 1` identical.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `paketname`.', '',
+    '```bash', 'git add DESCRIPTION', 'git commit -m "Release paketname"', '```', '',
+  ].join('\n');
+  const after = before.replace('Release paketname', 'Release packagename');
+  const dir = makeFixture(t, before, after);
+
+  const r = json(dir);
+  const line = after.split('\n')[r.findings[0].line - 1];
+
+  assert.match(line, /packagename/, `line ${r.findings[0].line} is ${JSON.stringify(line)}`);
+});
+
+test('a retagged fence is skipped, not trusted by ordinal', async (t) => {
+  // Equal fence counts do not make ordinal mapping sound: a text -> yaml retag
+  // keeps the count and makes a translated table the "before body" of a frozen
+  // fence.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `offen`.', '',
+    '```text', 'Status: offen', '```', '',
+  ].join('\n');
+  const after = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `offen`.', '',
+    '```yaml', 'Status: open', '```', '',
+  ].join('\n');
+  const dir = makeFixture(t, before, after);
+
+  const r = json(dir);
+
+  assert.equal(r.findings.length, 0);
+  assert.equal(r.skippedFiles.length, 1);
+  assert.match(r.skippedFiles[0].reason, /tag sequence diverges/);
+});

--- a/scripts/test/check-placeholder-drift.test.js
+++ b/scripts/test/check-placeholder-drift.test.js
@@ -1,0 +1,264 @@
+/**
+ * Tests for `scripts/check-placeholder-drift.js` (#497).
+ *
+ * The detector this replaces returned 0 on the batch that introduced the defect
+ * it existed to find, because its filter had been tuned from 216 false positives
+ * down to 0 with no confirmed true positive to test against. So the first
+ * obligation of this suite is to pin the true positive by SHAPE — a plain
+ * lowercase placeholder, which is the form the old filter could not express —
+ * and to prove the rejected predicate still cannot see it.
+ *
+ * Every fixture is a throwaway git repo with two commits: a translation, then
+ * the restore that would introduce the drift. That is the shape the tool reads,
+ * and it keeps a run under a second.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = 'scripts/check-placeholder-drift.js';
+
+function git(cwd, args) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(r.status, 0, `git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+function run(dir, args = []) {
+  const r = spawnSync(process.execPath, [SCRIPT, ...args], { cwd: dir, encoding: 'utf8' });
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+function json(dir, args = []) {
+  const r = run(dir, [...args, '--json']);
+  assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+  return JSON.parse(r.stdout);
+}
+
+/**
+ * `before` and `after` are the two revisions of one translated file. The tool
+ * resolves ROOT from `__dirname/..`, so it always reads the tree it sits in.
+ */
+function makeFixture(t, before, after) {
+  const dir = mkdtempSync(join(tmpdir(), 'drift-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+  cpSync(join(REPO, 'scripts', 'lib'), join(dir, 'scripts', 'lib'), { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+
+  const p = join(dir, 'i18n', 'de', 'skills', 'demo', 'SKILL.md');
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, before, 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'translation']);
+
+  writeFileSync(p, after, 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'restore frozen fences to English']);
+  return dir;
+}
+
+/** The real #496 defect, reduced: a plain lowercase placeholder in a bash fence. */
+const PAKETNAME_BEFORE = [
+  '---', 'name: demo', 'locale: de', '---', '',
+  '# Demo', '',
+  'Eine `# paketname x.y.z`-Ueberschrift zu NEWS.md hinzufuegen.', '',
+  '```bash', 'git commit -m "Release paketname v0.2.0"', '```', '',
+  '```markdown', '# paketname 0.2.0', '```', '',
+].join('\n');
+const PAKETNAME_AFTER = PAKETNAME_BEFORE.replace(
+  'git commit -m "Release paketname v0.2.0"',
+  'git commit -m "Release packagename v0.2.0"',
+);
+
+test('the real defect is found: a plain lowercase placeholder renamed in a frozen fence', async (t) => {
+  const dir = makeFixture(t, PAKETNAME_BEFORE, PAKETNAME_AFTER);
+
+  const r = json(dir);
+
+  assert.equal(r.findings.length, 1, JSON.stringify(r.findings));
+  assert.equal(r.findings[0].removed, 'paketname');
+  assert.equal(r.findings[0].added, 'packagename');
+  assert.equal(r.findings[0].register, 'inline-code');
+});
+
+test('the rejected code-shape predicate provably cannot express the defect', async (t) => {
+  // `paketname` is a plain lowercase word: not snake_case, CONSTANT_CASE,
+  // kebab-case, dotted.path or camelCase. This is the whole reason the previous
+  // detector returned 0 on the batch that introduced it, and the reason the
+  // predicate here keys on structure instead of shape.
+  const dir = makeFixture(t, PAKETNAME_BEFORE, PAKETNAME_AFTER);
+
+  const r = json(dir, ['--compare']);
+
+  assert.equal(r.findings.length, 1);
+  assert.equal(r.alternatives.codeShaped, 0, 'a code-shape filter would have caught it after all');
+});
+
+test('a retranslation is not a rename — more than one token changed', async (t) => {
+  // The same #496 commit rewrote a whole commit message from German to English.
+  // Requiring exactly one differing token separates that from a placeholder
+  // rename without knowing what the token looks like.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `Entwicklung`.', '',
+    '```bash', 'git commit -m "Entwicklung fuer naechste Version beginnen"', '```', '',
+  ].join('\n');
+  const after = before.replace(
+    'git commit -m "Entwicklung fuer naechste Version beginnen"',
+    'git commit -m "Begin development for next version"',
+  );
+  const dir = makeFixture(t, before, after);
+
+  assert.equal(json(dir).findings.length, 0);
+});
+
+test('a rename whose old form is cited NOWHERE is not reported', async (t) => {
+  // Restoring a frozen fence is the point of the repair. It only becomes drift
+  // when the old form survives somewhere the reader still sees.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Kein Zitat hier.', '',
+    '```bash', 'git commit -m "Release paketname v0.2.0"', '```', '',
+  ].join('\n');
+  const after = before.replace('paketname', 'packagename');
+  const dir = makeFixture(t, before, after);
+
+  assert.equal(json(dir).findings.length, 0);
+});
+
+test('a citation in an exempt fence alone is reported, but in the weaker register', async (t) => {
+  // Batch 1's four `von` -> `from` hits are exactly this shape and are all
+  // ordinary German. They are sorted last rather than dropped: with one
+  // confirmed true positive on record, filtering here is how the previous
+  // detector deleted its own target class.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    '```text', 'Reduziere die Geschwindigkeit von 50.', '```', '',
+    '```yaml', 'perimeter_speed: 40mm/s (von 50)', '```', '',
+  ].join('\n');
+  const after = before.replace('(von 50)', '(from 50)');
+  const dir = makeFixture(t, before, after);
+
+  const r = json(dir);
+
+  assert.equal(r.findings.length, 1);
+  assert.equal(r.findings[0].register, 'exempt-fence');
+});
+
+test('the two registers are reported separately in the human output', async (t) => {
+  const dir = makeFixture(t, PAKETNAME_BEFORE, PAKETNAME_AFTER);
+
+  const r = run(dir);
+
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /1 cited in inline-code · 0 cited only as a word in an exempt fence/);
+  assert.match(r.stdout, /\(cited in inline-code\)/);
+});
+
+test('an exempt fence is never itself treated as a frozen fence', async (t) => {
+  // Localisable fences are what a translation exists to change; reading a
+  // substitution out of one would report every translated table.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Siehe `Status`.', '',
+    '```text', 'Status: offen', '```', '',
+  ].join('\n');
+  const after = before.replace('Status: offen', 'Status: open');
+  const dir = makeFixture(t, before, after);
+
+  assert.equal(json(dir).findings.length, 0);
+});
+
+// ── the alignment ───────────────────────────────────────────────────────────
+
+test('a fence that gained a line is still examined', async (t) => {
+  // Index pairing, which the LCS alignment replaces, could only read a fence
+  // whose two bodies had the same line count — 67 of batch 1's 172 changed
+  // fences failed that and went unexamined while reporting nothing.
+  const before = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Eine `paketname`-Ueberschrift.', '',
+    '```bash', 'git add DESCRIPTION', 'git commit -m "Release paketname"', '```', '',
+  ].join('\n');
+  const after = [
+    '---', 'name: demo', 'locale: de', '---', '',
+    'Eine `paketname`-Ueberschrift.', '',
+    '```bash', 'git add DESCRIPTION', 'git add NEWS.md', 'git commit -m "Release packagename"', '```', '',
+  ].join('\n');
+  const dir = makeFixture(t, before, after);
+
+  const r = json(dir);
+
+  assert.equal(r.unalignedFences, 0);
+  assert.equal(r.findings.length, 1, JSON.stringify(r.findings));
+  assert.equal(r.findings[0].removed, 'paketname');
+});
+
+test('the reported line number points at the changed line in the NEW revision', async (t) => {
+  const dir = makeFixture(t, PAKETNAME_BEFORE, PAKETNAME_AFTER);
+
+  const r = json(dir);
+  const lines = PAKETNAME_AFTER.split('\n');
+
+  assert.ok(
+    lines[r.findings[0].line - 1].includes('packagename'),
+    `line ${r.findings[0].line} is ${JSON.stringify(lines[r.findings[0].line - 1])}`,
+  );
+});
+
+// ── the no-op guard ─────────────────────────────────────────────────────────
+
+test('a range touching no i18n file is an error, not a clean-looking zero', async (t) => {
+  const dir = makeFixture(t, PAKETNAME_BEFORE, PAKETNAME_AFTER);
+  writeFileSync(join(dir, 'README.md'), 'unrelated\n', 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'unrelated change']);
+
+  const r = run(dir);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /no i18n\/\*\.md changed/);
+});
+
+test('an unresolvable ref is an error', async (t) => {
+  const dir = makeFixture(t, PAKETNAME_BEFORE, PAKETNAME_AFTER);
+
+  const r = run(dir, ['--base', 'no-such-ref']);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /does not resolve to a commit/);
+});
+
+test('an unknown argument is an error, not a silently narrower run', async (t) => {
+  const dir = makeFixture(t, PAKETNAME_BEFORE, PAKETNAME_AFTER);
+
+  const r = run(dir, ['--basis', 'HEAD~1']);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /unknown argument/);
+});
+
+test('findings do not fail the run — it is advisory by design', async (t) => {
+  // A gate that must be overridden routinely trains the reflex #472 exists to
+  // prevent, and one of the hits on the batch this was built from is a
+  // legitimate English output string a human must dismiss.
+  const dir = makeFixture(t, PAKETNAME_BEFORE, PAKETNAME_AFTER);
+
+  const r = run(dir);
+
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /ADVISORY/);
+});


### PR DESCRIPTION
Closes #497. Independent of #512 — this shares only `scripts/lib/fences.js`, which is already on `main`.

Restoring a frozen fence to English is correct by the #472 rule, but the fence does not stand
alone. The prose around it, and the exempt `text`/`markdown` fences beside it, may name the same
placeholder. Restore one and not the other and the file names one thing two ways.

#496 did that. Two `bash` fences in `i18n/de/skills/release-package-version/SKILL.md` went
`paketname` → `packagename` while the prose explaining those commands and the exempt NEWS.md
example kept saying `paketname`. Fixed after the fact in `8ed584a4`.

## Structure, not shape

The detector that missed it keyed on token **shape** — snake_case, CONSTANT_CASE, kebab-case,
dotted.path, camelCase. `paketname` is a plain lowercase word and matched none of them, which is
the *likely* form of this defect: a translator renames `packagename` to a plain word in their own
language, not to a camelCase one. That filter had been tuned from 216 false positives down to 0
with no confirmed true positive to test against, so the tuning deleted the target class and the
resulting zero read as success.

The predicate here is a **substitution pair**: within a frozen fence, an old and a new line differ
by exactly one *distinct substitution*, and the removed form is still cited in a localisable
register — prose inline-code, or an exempt `text`/`markdown`/`md` fence body.

That narrowness is what carries it. The same commit rewrote
`git commit -m "Entwicklung fuer naechste Version beginnen"` to
`git commit -m "Begin development for next version"` — five distinct substitutions, an ordinary
retranslation. One-distinct-substitution separates a rename from a retranslation without knowing
anything about what either token looks like.

**Distinct substitutions, not differing positions.** The first version counted positions, which
inverted the detector on the commonest shape a placeholder takes — a rename applied *completely* to
a line was invisible, and only a rename occurring exactly once per line could be seen:

```
docker tag meineapp:latest ghcr.io/USERNAME/meineapp:latest
docker tag myapp:latest    ghcr.io/USERNAME/myapp:latest
```

Two positions, one rename, dropped. **5,783 gated-fence lines across 1,571 corpus files repeat a
token**, so the shape is pervasive rather than incidental.

A test pins the contrast with the rejected predicate directly: on a fixture the shipped predicate
flags, `--compare` reports `codeShaped: 0`, with a positive control proving that counter fires.

## Retroactive sweep

976 fence comparisons across the seven merged batches plus the #476 re-mirror, 9 hits:

| batch | fences | hits |
|---|---:|---|
| #495 yaml+json | 172 | 4 — all `von` → `from`, exempt-fence register |
| #496 bash | 449 | 4 — inline-code; **2 are the real defect** |
| #499 r | 218 | 0 |
| #503 python | 86 | 0 |
| #505 dockerfile | 16 | 0 |
| #508 yaml+ts | 9 | 1 — `Datei` → `File`, exempt-fence register |
| #509 tail | 26 | 0 |
| #476 re-mirror | 0 | 0 — 44 files skipped, tag/fence structure changed |

Nothing real was introduced by batches 3–7. Precision is 2 real of 9: two more are dismissable
inline-code hits (`Eintraege` → `entries`, an English output string in a shell fence, and `config`
→ `configuration` in a caveman-ultra comment) and five are the exempt-fence word class.

## Registers are recorded, not filtered on

| register | hits | what they are |
|---|---:|---|
| inline-code | 4 | all in #496; two are the real `paketname` defect |
| exempt-fence | 5 | every one an ordinary German word (`von` ×4, `Datei`) |

**This split is not evidence the register discriminates, and the sort is a hunch rather than a
finding.** The one confirmed true positive is cited in *both* registers — `paketname` appears in
prose inline-code at lines 69 and 167 of the #496 revision **and** in the exempt ```markdown
example at line 75 — so it lands in the strong bucket by the tie-break in `note()`, not by
discrimination. Had that batch repaired the backticks and left only the markdown example stale, the
identical defect would have sorted last. Register is also perfectly confounded with batch: all four
inline-code hits are in #496 and all five exempt-fence hits are elsewhere, so "register predicts
truth" is not separable from "#496 was the batch with the bug", and n = one independent rename.

It is kept because it costs nothing and the mechanism is plausible, and because filtering on it on
this evidence is the same move that tuned the previous detector to zero. Falsified by a real defect
whose only citation is in an exempt fence, or by a backticked ordinary locale word producing an
inline-code false positive.

## Coverage is reported, not assumed

Lines are aligned by LCS and compared as change blocks. Index pairing — the first version — could
only read a fence whose two bodies had the same line count, and **67 of batch 1's 172 changed
fences failed that** and went unexamined while reporting nothing.

Within a block, every before × after combination is tested rather than a guessed pairing.
Positional pairing mispairs the moment a block holds an insertion before the rename: a fence that
gained a line paired the renamed line against the *inserted* one and cleared the fence. Caught by a
test, not by review.

Every unexamined path increments a counter — `skippedFiles` for a fence-count change, a
tag-sequence divergence, or a file added/deleted/renamed in the range; `unalignedFences` for an
oversized LCS table — and a run that compared nothing prints `NOTHING WAS EXAMINED` rather than a
clean line. Adding the tag check changed a live result: the #476 re-mirror had reported 16 fences
compared and now reports 0 with 44 files skipped. Those comparisons were never trustworthy.

## What it cannot see

Stated in the header, measured rather than assumed:

- **Pre-existing drift.** It diffs two revisions, so it sees only drift a change *introduces*.
- **Two different placeholders renamed on one line** — two distinct substitutions, rejected with
  the retranslations.
- **A rename that changes the token count.** `-`, `_` and `.` are inside the token class, so
  `paket-name` → `package-name` is caught; `paket-name` → `package name` is 1 → 2 and is dropped.
  Largely theoretical for de/es, since it needs the English placeholder to contain a space.
- **CJK.** `\p{L}` covers Han and kana, which do not delimit words with spaces, so a phrase
  collapses to one token and adjacent Latin merges with it. Latent, not live: no instance of a
  placeholder riding such a line inside a gated fence was found.

## Advisory, and why

Exits 0 on findings. One of #496's own hits is a frozen fence carrying an English output string,
which is exactly what the rule requires. A gate that must be overridden routinely trains the reflex
#472 exists to prevent.

## Twelve mutants, all killed

```
seen.size > 1        -> seen.size > 0      (one distinct substitution)  KILLED by 10
if (misaligned >= 0) -> if (false)         (tag-sequence check)         KILLED by 1
delete `if (CODE_SHAPED.test(t)) ...`      (--compare counter)          KILLED by 1
line: +1+index       -> line: +1           (changed-line number)        KILLED by 1
delete `if (isGated(f)) continue;`         (citation registers)         KILLED by 1
delete `if (from.length !== to.length)`    (token-count guard)          KILLED by 1
delete `if (at >= 0) return null;`         (one-substitution, original) KILLED by 1
delete `if (register === undefined)`       (citation filter)            KILLED by 1
if (changed.length === 0) -> if (false)    (no-op guard)                KILLED by 1
drop the isGated() check at the fence loop (exempt not frozen)          KILLED by 1
drop flush() on a matching line            (block scoping)              KILLED by 1
inline-code loses priority over exempt     (register tie-break)         KILLED by 2
```

Six of these were written only after mutation runs showed the mutant surviving — including two
where the *fixtures* were at fault rather than the assertions, and one that made `--compare`'s
numbers untestable because the test asserted only `codeShaped === 0`, which also passes when the
counter never fires. That is this file's own diagnosed failure mode reproduced inside the suite
built to prevent it.

`npm run test:scripts`: 58 → 79 on this branch.

## Review provenance

Copilot could not be triggered on this PR, so `advocatus-diaboli` reviewed it under the standing
fallback. Six findings, all verified against the corpus before acting — one was substantially
larger than reported (the 5,783-line figure above, against an estimated 395), and one cited a
before-line that no longer exists at that path, though its mechanism held.

Separately, a literal **NUL byte** had landed in the substitution key, making the file read as
binary to `rg`. Functionally inert — which is exactly why all tests passed — now replaced and
verified absent from every other file touched on both branches.

## The issue's comparison figures do not reproduce

#497 quotes 0 for the code-shape predicate and 143 for "token appears in any exempt fence". The
prototype behind those numbers no longer exists, so their definitions are unrecoverable. Under this
file's own definitions, over #496's 3,242 removed tokens, `--compare` reports 15 and 223 against
the shipped predicate's 4. The shape of the comparison reproduces; the digits are this
implementation's and are labelled as such in the header.
