### PR TITLE
fix(content): repair five runaway fences in write-incident-runbook EXAMPLES (#511)

### DIFF
--- a/skills/write-incident-runbook/references/EXAMPLES.md
+++ b/skills/write-incident-runbook/references/EXAMPLES.md
@@ -685,7 +685,7 @@ Escalate **proactively** if:
 
 ### Internal Communication Templates (All Variants)
 
-```markdown
+````markdown
 ## Communication Templates
 
 ### Initial Incident Declaration
@@ -705,7 +705,7 @@ Escalate **proactively** if:
 Quick Summary: [1-2 sentences on what's wrong and initial assessment]
 
 Next update in 15 minutes.
-```text
+```
 
 ### Progress Update (Every 15-30 minutes)
 
@@ -725,7 +725,7 @@ Next update in 15 minutes.
 **Impact Update**: [Any change in scope/severity]
 
 Next update in 15 minutes or upon significant change.
-```text
+```
 
 ### Mitigation Announcement
 
@@ -743,7 +743,7 @@ Next update in 15 minutes or upon significant change.
 
 Continuing to monitor for 30 minutes before declaring resolved.
 Next update in 15 minutes.
-```text
+```
 
 ### Incident Resolution
 
@@ -765,7 +765,7 @@ Next update in 15 minutes.
 **Dashboard**: [Link to incident metrics]
 
 Thank you to everyone who helped resolve this incident.
-```text
+```
 
 ### False Alarm / Resolved Without Action
 
@@ -779,7 +779,7 @@ Thank you to everyone who helped resolve this incident.
 
 No customer impact.
 No follow-up needed.
-```text
+```
 
 ### External Status Page Updates
 
@@ -796,7 +796,7 @@ Our engineering team has been notified and is actively investigating.
 **Next Update**: [HH:MM UTC] (15 minutes)
 
 We apologize for any inconvenience.
-```text
+```
 
 **Progress Update**:
 ```
@@ -809,7 +809,7 @@ Our team is implementing a fix.
 **Impact**: [Percentage or description of affected users]
 **Estimated Resolution**: [Timeframe if known, or "working on it" if not]
 **Next Update**: [HH:MM UTC]
-```text
+```
 
 **Resolution Post**:
 ```
@@ -826,7 +826,7 @@ All services are operating normally.
 We have implemented measures to prevent this from happening again and will continue monitoring closely.
 
 We apologize for any inconvenience this may have caused.
-```text
+```
 
 ### Customer Support Email Template
 
@@ -863,8 +863,8 @@ If you have any questions, please contact our support team at [email/phone].
 Best regards,
 [Name]
 [Title]
-```text
 ```
+````
 
 ## Step 6: Alert Integration Examples
 

--- a/skills/write-incident-runbook/references/EXAMPLES.md
+++ b/skills/write-incident-runbook/references/EXAMPLES.md
@@ -6,7 +6,7 @@ Complete configuration files, templates, and multi-variant examples extracted fr
 
 ### Advanced SRE Runbook Template (Complete)
 
-```markdown
+````markdown
 # [Service Name] - [Incident Type] Runbook
 
 ## Metadata
@@ -116,7 +116,7 @@ Confirm incident is resolved and system is healthy.
 **Slack Channel**: #incident-response
 
 **Initial Message Template**:
-```text
+```
 🚨 INCIDENT: [Title]
 Severity: [Critical/High/Medium]
 Impact: [Description]
@@ -126,7 +126,7 @@ Dashboard: [link]
 ```
 
 **Update Template** (every 15-30 minutes):
-```text
+```
 📊 UPDATE: [Title]
 Current Status: [In Progress/Mitigated/Resolved]
 Actions Taken: [Summary]
@@ -135,7 +135,7 @@ ETA: [Estimated resolution time]
 ```
 
 **Resolution Message Template**:
-```text
+```
 ✅ RESOLVED: [Title]
 Duration: [Time to resolution]
 Impact: [Final customer impact assessment]
@@ -145,7 +145,7 @@ Post-Mortem: [Link to doc]
 
 ### External Communication
 **Status Page Update Template**:
-```text
+```
 We are currently investigating reports of [issue description].
 Our team is actively working to resolve this issue.
 We will provide updates every 30 minutes.
@@ -201,13 +201,13 @@ Next update: [time]
 | Date | Author | Changes |
 |---|---|---|
 | 2024-01-15 | @user | Initial version |
-```text
+````
 
 ## Step 2: Complete Diagnostic Procedures
 
 ### Diagnostic Checklist with Full Queries
 
-```markdown
+````markdown
 ## Diagnostic Procedures
 
 ### 1. Verify Service Health
@@ -330,7 +330,7 @@ histogram_quantile(0.99,
 )
 # Identify slow external dependencies
 ```
-```text
+````
 
 ### Failure Pattern Decision Tree
 
@@ -365,7 +365,7 @@ histogram_quantile(0.99,
 
 ### Resolution Procedures with All Options
 
-```markdown
+````markdown
 ## Resolution Procedures
 
 ### Option 1: Rollback Deployment (Fastest)
@@ -534,11 +534,11 @@ After any resolution attempt, verify:
 - [ ] **Downstream services**: All dependencies healthy
 - [ ] **User-facing tests**: Sample transactions succeeding
 - [ ] **Alerts**: No active critical alerts
-```text
+````
 
 ### Rollback Procedure
 
-```markdown
+````markdown
 ## Rollback Procedure
 
 If resolution attempt makes situation worse:
@@ -568,13 +568,13 @@ If resolution attempt makes situation worse:
 
 4. **Reassess situation**:
    Return to diagnostic phase with new information.
-```text
+````
 
 ## Step 4: Complete Escalation Guidelines
 
 ### Escalation Levels and Contact Directory (Complete)
 
-```markdown
+````markdown
 ## Escalation Guidelines
 
 ### When to Escalate
@@ -640,7 +640,7 @@ Escalate **proactively** if:
    Actions taken: [what you've tried]
    Requesting: [specific help needed]
    Dashboard: [link]
-   ```text
+   ```
 
 2. **Handoff if needed**:
    - Share incident timeline
@@ -679,7 +679,7 @@ Escalate **proactively** if:
 #### CDN Provider (e.g., Cloudflare)
 - **Critical**: +1-888-XXX-XXXX
 - **Account**: CF-67890
-```
+````
 
 ## Step 5: Complete Communication Templates
 


### PR DESCRIPTION
Closes #511.

`skills/write-incident-runbook/references/EXAMPLES.md` had four `text` fences that had swallowed the document's own structure — **122 lines rendering as preformatted text**, burying `## Step 2: Complete Diagnostic Procedures` and `## Step 4: Complete Escalation Guidelines`.

## Root cause, from git rather than inference

Every one of these delimiters was a bare ``` in the file as its author wrote it. `33b561c96` ("style(content): tag untagged code fences", #272) rewrote **17** bare delimiters to ```` ```text ```` — `main` carries 18 such lines, one of which predates that pass. Wherever its parser had already been thrown by a nested tagged fence, it tagged a **closer** as an opener.

Line 204 is the clearest case — it closes the runbook template opened at line 9, and sits directly under a Revision History table with nothing after it to open a block for:

```
   9: ```markdown        <- template opens
  45: ```promql          <- nested
  49: ```                <- closes the TEMPLATE, not the promql block
 204: ```   ->  ```text  <- tagger now believes it is at document level
```

## The repair

Rather than patch delimiters one at a time across 920 lines, this rebuilds from `33b561c96^` — the author's own delimiters — and raises the **six** ```` ```markdown ```` templates that *nest* a fence to four backticks, opener and closer. Inside a four-backtick fence the nested ``` are literal content and can no longer close the template early.

Every bare delimiter in this file then turns out to be interior to a template, so #272's "tag untagged fences" rule has nothing to do here at all. Of `main`'s 18 `text` lines, **14 revert to bare** and **4 become four-backtick closers** (204, 333, 537, 571); none remain.

**Nothing landed on this file between the tagging pass and this PR** (`git log` shows `33b561c96` as the newest commit touching it), so rebuilding from its parent reverts nothing.

## Two runaways the issue did not list

#511 names four (204, 333, 537, 571), found by the #510 detector's "H2 inside a `text` fence" signal.

- **Line 643** is the same defect — a tagged closer of the escalation-message block opened at 636 — missed because its fence contains only an H3.
- **The template at line 688** nests nine blocks and runs to **867**, not 694. A stack-based reading closes it at the first bare ```; only the content settles it, since line 689 is the template's own `## Communication Templates` heading. Leaving it unraised inverted every delimiter in that region — line 708 follows "Next update in 15 minutes." and line 866 follows "Best regards,", and both had been tagged as if they opened something.

The tell for that second one was an **empty `text` fence at line 866** in the first pass — the signature of an off-by-one, where 866 closes the last nested block and 867 closes the template.

This is why the issue asked for the closer to be "identified per block rather than pattern-matched": every automatic reading of these delimiters, including the one I wrote first, gets this template wrong.

## Measured

| | before | after |
|---|---:|---:|
| fences | 57 | 9 |
| runaway fences (H2 buried in a text/untagged fence) | 4 | **0** |
| untagged fences | 0 | 0 |
| empty fences | 1 | **0** |
| fenced lines | 391 | 860 |
| buried `## Step N` headings | 2 | **0** |

Fence count falls because nested delimiters are now literal content — the file is 7 `markdown` templates plus one `yaml` and one `json` block. Fenced lines rise because the templates finally hold their full bodies. The 122 preformatted lines the issue counted are 15 + 28 + 15 + 64, exactly the four runaway bodies.

**25 lines changed, every one a delimiter.** Content is byte-identical to `main` once delimiter lines are excluded — verified by diffing both revisions with delimiters filtered out.

Not mirrored — `i18n/<locale>/skills/write-incident-runbook/` holds only `SKILL.md` — so this is 1 file with no re-mirror cost.

`validate:integrity` passes; `validate:line-endings` clean; content-style clean on added lines.
