### PR TITLE
feat(i18n): extend the fence normalizer to the mirrors, and restore all 87 (#477)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,9 +272,17 @@ fence-count and tag-sequence checks that decide whether ordinal mapping is
 trustworthy at all. A tag matching no divergent fence exits 2 rather than
 reporting a clean-looking zero.
 
-It repairs `skills/` only; the checker covers all four trees, so an agent, team
-or guide violation shows up as `files to change: 0` and needs repairing by hand
-(#477).
+`--tree <list>` scopes the same way across content trees, and the normalizer now
+covers all four — `skills`, `agents`, `teams`, `guides` — so it repairs exactly
+what the checker flags. It was skills-only until the mirrors became the last
+mechanically-repairable slice of #477 (87 fences / 11 files, cleared in #518).
+
+Both scoping flags are validated against what the run actually reached, never
+against a static list: a `--tag` matching no divergent fence exits 2, and so does
+a `--tree` naming a tree the selected `--locale` carries no translations for.
+Validating `--tree` corpus-wide instead let `--locale wenyan --tree guides` clear
+both guards independently and report `files to change: 0` — six of the ten
+locales carry `skills/` alone.
 
 Runs **warn-only** in CI until the backlog clears (#477), then flips to blocking.
 Warn is a temporary state with a named exit, not the design. Quote the current

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -74,9 +74,11 @@ uncommitted work with it (#486).
 tag matching no divergent fence exits 2 rather than reporting zero, so a typo
 cannot read as "this batch is already done".
 
-It repairs `skills/` only; agent, team and guide violations are reported by the
-checker but show up here as `files to change: 0`, and need repairing by hand
-(#477).
+`--tree <list>` scopes the same way across content trees. The normalizer covers
+all four — `skills`, `agents`, `teams`, `guides` — so it repairs exactly what the
+checker flags; it was skills-only until the mirror slice was cleared in #518. A
+`--tree` naming a tree the selected `--locale` carries no translations for exits
+2, for the same reason a `--tag` matching nothing does.
 
 Runs **warn-only** in CI until the backlog clears (#477), then flips to blocking.
 

--- a/i18n/de/agents/contemplative.md
+++ b/i18n/de/agents/contemplative.md
@@ -134,10 +134,10 @@ Dieser Agent verwendet einen Kommunikationsstil der **stillen Praesenz**:
 ```yaml
 settings:
   depth: standard          # light, standard, deep
-  sequence: adaptive       # adaptive, fixed (meditate->heal->center->shine)
+  sequence: adaptive       # adaptive, fixed (meditate→heal→center→shine)
   expression: minimal      # minimal, moderate, full
   attunement: enabled      # enabled, disabled
-  memory_integration: true # Dauerhafte Einsichten in MEMORY.md schreiben
+  memory_integration: true # write durable insights to MEMORY.md
 ```
 
 ## Werkzeuganforderungen

--- a/i18n/de/agents/r-developer.md
+++ b/i18n/de/agents/r-developer.md
@@ -118,9 +118,9 @@ Agent: [Erstellt modulare Funktionen, behandelt fehlende Daten, generiert Berich
 ## Konfigurationsoptionen
 
 ```yaml
-# R-Entwicklungspraeferenzen
+# R development preferences
 settings:
-  coding_style: tidyverse  # oder base_r, data_table
+  coding_style: tidyverse  # or base_r, data_table
   documentation: roxygen2
   testing_framework: testthat
   version_control: git
@@ -264,11 +264,11 @@ result <- data %>%
 
 ### Statistische Modellierung
 ```r
-# Lineares gemischtes Modell
+# Linear mixed-effects model
 library(lme4)
 model <- lmer(response ~ predictor + (1|subject), data = df)
 summary(model)
-plot(model)  # Diagnostikdiagramme
+plot(model)  # Diagnostic plots
 ```
 
 ### Paketfunktions-Vorlage

--- a/i18n/de/guides/quick-reference.md
+++ b/i18n/de/guides/quick-reference.md
@@ -23,13 +23,13 @@ Befehlsuebersicht zum Aufrufen von Agenten, Skills und Teams durch Claude Code, 
 Skills werden als Slash-Befehle in Claude Code aufgerufen, wenn sie in `.claude/skills/` verlinkt sind:
 
 ```bash
-# Einen Skill als Slash-Befehl verfuegbar machen
+# Make a skill available as a slash command
 ln -s ../../skills/submit-to-cran .claude/skills/submit-to-cran
 
-# In Claude Code aufrufen mit:
+# In Claude Code, invoke with:
 /submit-to-cran
 
-# Weitere Beispiele
+# Other examples
 /commit-changes
 /security-audit-codebase
 /review-skill-format
@@ -64,28 +64,28 @@ Verfuegbare Teams: r-package-review, gxp-compliance-validation, fullstack-web-de
 ### Registry-Abfragen
 
 ```bash
-# Skills, Agenten, Teams zaehlen
+# Count skills, agents, teams
 grep "total_skills" skills/_registry.yml
 grep "total_agents" agents/_registry.yml
 grep "total_teams" teams/_registry.yml
 
-# Alle Domaenen auflisten
+# List all domains
 grep "^  [a-z]" skills/_registry.yml | head -50
 
-# Alle Agenten auflisten
+# List all agents
 grep "^  - id:" agents/_registry.yml
 
-# Alle Teams auflisten
+# List all teams
 grep "^  - id:" teams/_registry.yml
 ```
 
 ### README-Automatisierung
 
 ```bash
-# Alle READMEs aus Registries neu generieren
+# Regenerate all READMEs from registries
 npm run update-readmes
 
-# Pruefen ob READMEs aktuell sind (CI-Trockenlauf)
+# Check if READMEs are up to date (CI dry-run)
 npm run check-readmes
 ```
 
@@ -94,15 +94,15 @@ npm run check-readmes
 ### Pfadkonvertierung
 
 ```bash
-# Windows nach WSL
+# Windows to WSL
 C:\Users\Name\Documents  ->  /mnt/c/Users/Name/Documents
 D:\dev\projects          ->  /mnt/d/dev/projects
 
-# Windows-R von WSL aus zugreifen (Version anpassen)
+# Access Windows R from WSL (adjust version)
 "/mnt/c/Program Files/R/R-4.5.0/bin/R.exe"
 "/mnt/c/Program Files/R/R-4.5.0/bin/Rscript.exe"
 
-# Aktuelles Verzeichnis im Windows Explorer oeffnen
+# Open current directory in Windows Explorer
 explorer.exe .
 ```
 
@@ -111,11 +111,11 @@ explorer.exe .
 ### Entwicklungszyklus
 
 ```r
-devtools::load_all()        # Paket fuer Entwicklung laden
-devtools::document()        # Dokumentation aktualisieren
-devtools::test()            # Tests ausfuehren
-devtools::check()           # Vollstaendige Paketpruefung
-devtools::install()         # Paket installieren
+devtools::load_all()        # Load package for development
+devtools::document()        # Update documentation
+devtools::test()            # Run tests
+devtools::check()           # Full package check
+devtools::install()         # Install package
 ```
 
 ### Schnellpruefungen
@@ -130,19 +130,19 @@ urlchecker::url_check()
 ### CRAN-Einreichung
 
 ```r
-devtools::check_win_devel()     # Windows Builder
-devtools::check_win_release()   # Windows Builder
-rhub::rhub_check()              # R-hub Multiplattform
-devtools::release()             # Interaktive CRAN-Einreichung
+devtools::check_win_devel()     # Windows builder
+devtools::check_win_release()   # Windows builder
+rhub::rhub_check()              # R-hub multi-platform
+devtools::release()             # Interactive CRAN submission
 ```
 
 ### Geruest erstellen
 
 ```r
-usethis::use_r("function_name")           # Neue R-Datei
-usethis::use_test("function_name")        # Neue Testdatei
-usethis::use_vignette("guide_name")       # Neue Vignette
-usethis::use_mit_license()                # MIT-Lizenz hinzufuegen
+usethis::use_r("function_name")           # New R file
+usethis::use_test("function_name")        # New test file
+usethis::use_vignette("guide_name")       # New vignette
+usethis::use_mit_license()                # Add MIT license
 usethis::use_github_action_check_standard() # CI/CD
 ```
 
@@ -151,27 +151,27 @@ usethis::use_github_action_check_standard() # CI/CD
 ### Taegliche Operationen
 
 ```bash
-git status                 # Arbeitsbaumstatus anzeigen
-git diff                   # Nicht bereitgestellte Aenderungen anzeigen
-git diff --staged          # Bereitgestellte Aenderungen anzeigen
-git log --oneline -10      # Letzte Commits
+git status                 # Show working tree status
+git diff                   # Show unstaged changes
+git diff --staged          # Show staged changes
+git log --oneline -10      # Recent commits
 
-git add filename           # Bestimmte Datei bereitstellen
-git commit -m "message"    # Commit mit Nachricht
-git commit --amend         # Letzten Commit nachbessern
+git add filename           # Stage specific file
+git commit -m "message"    # Commit with message
+git commit --amend         # Amend last commit
 
-git checkout -b new-branch # Branch erstellen und wechseln
-git merge feature-branch   # Branch mergen
+git checkout -b new-branch # Create and switch to branch
+git merge feature-branch   # Merge branch
 ```
 
 ### Remote-Operationen
 
 ```bash
-git remote -v              # Remotes auflisten
-git fetch origin           # Aenderungen abrufen
-git pull origin main       # Pullen und mergen
-git push origin main       # Zum Remote pushen
-git push -u origin branch  # Neuen Branch pushen
+git remote -v              # List remotes
+git fetch origin           # Fetch changes
+git pull origin main       # Pull and merge
+git push origin main       # Push to remote
+git push -u origin branch  # Push new branch
 ```
 
 ### Nuetzliche Aliase
@@ -189,9 +189,9 @@ git config --global alias.last 'log -1 HEAD'
 ### Sitzungsverwaltung
 
 ```bash
-claude                     # Claude Code starten
-claude mcp list            # Konfigurierte MCP-Server auflisten
-claude mcp get r-mcptools  # Serverdetails abrufen
+claude                     # Start Claude Code
+claude mcp list            # List configured MCP servers
+claude mcp get r-mcptools  # Get server details
 ```
 
 ### Konfigurationsdateien
@@ -204,7 +204,7 @@ Claude Desktop (GUI/Win):   %APPDATA%\Claude\claude_desktop_config.json
 ### MCP-Server
 
 ```bash
-# R-Integration
+# R integration
 claude mcp add r-mcptools stdio \
   "/mnt/c/Program Files/R/R-4.5.0/bin/Rscript.exe" \
   -e "mcptools::mcp_server()"
@@ -220,34 +220,34 @@ claude mcp add hf-mcp-server \
 ### Navigation und Suche
 
 ```bash
-pwd                        # Arbeitsverzeichnis anzeigen
-ls -la                     # Dateien mit Details auflisten
-tree                       # Verzeichnisbaum anzeigen
-z project-name             # Zu haeufigem Verzeichnis springen
+pwd                        # Print working directory
+ls -la                     # List files with details
+tree                       # Show directory tree
+z project-name             # Jump to frequent directory
 
-rg "pattern"               # Ripgrep-Suche
-rg -t r "pattern"          # Nur in R-Dateien suchen
-fd "pattern"               # Benutzerfreundliches Find
-fd -e R                    # Nach Erweiterung suchen
+rg "pattern"               # Ripgrep search
+rg -t r "pattern"          # Search only R files
+fd "pattern"               # User-friendly find
+fd -e R                    # Find by extension
 ```
 
 ### Dateioperationen
 
 ```bash
-mkdir -p path/to/dir       # Verschachtelte Verzeichnisse erstellen
-cp -r source/ dest/        # Verzeichnis rekursiv kopieren
-tar -czf archive.tar.gz dir/  # Komprimiertes tar erstellen
-tar -xzf archive.tar.gz      # tar.gz extrahieren
-du -sh directory           # Verzeichnisgroesse
-df -h                      # Speicherplatznutzung
+mkdir -p path/to/dir       # Create nested directories
+cp -r source/ dest/        # Copy directory recursively
+tar -czf archive.tar.gz dir/  # Create compressed tar
+tar -xzf archive.tar.gz      # Extract tar.gz
+du -sh directory           # Directory size
+df -h                      # Disk space usage
 ```
 
 ### Prozessverwaltung
 
 ```bash
-htop                       # Interaktiver Prozessbetrachter
-ps aux | grep process      # Bestimmten Prozess finden
-kill PID                   # Prozess nach ID beenden
+htop                       # Interactive process viewer
+ps aux | grep process      # Find specific process
+kill PID                   # Kill process by ID
 ```
 
 ## Tastenkuerzel
@@ -278,11 +278,11 @@ Strg+Umsch+P   Befehlspalette     F1            Befehlspalette
 ## Umgebungsvariablen
 
 ```bash
-printenv              # Alle Umgebungsvariablen
-echo $PATH            # PATH-Variable
-export VAR=value      # Fuer aktuelle Sitzung setzen
+printenv              # All environment variables
+echo $PATH            # PATH variable
+export VAR=value      # Set for current session
 
-# Dauerhaft setzen
+# Set permanently
 echo 'export VAR=value' >> ~/.bashrc
 source ~/.bashrc
 ```
@@ -294,14 +294,14 @@ source ~/.bashrc
 sudo apt update && sudo apt install package
 
 # npm
-npm install -g package       # Global installieren
-npm list -g --depth=0        # Globale Pakete auflisten
+npm install -g package       # Install globally
+npm list -g --depth=0        # List global packages
 
 # R (renv)
-renv::init()                 # renv initialisieren
-renv::install("package")     # Paket installieren
-renv::snapshot()             # Lockfile speichern
-renv::restore()              # Aus Lockfile wiederherstellen
+renv::init()                 # Initialize renv
+renv::install("package")     # Install package
+renv::snapshot()             # Save lockfile
+renv::restore()              # Restore from lockfile
 ```
 
 ## Fehlerbehebung
@@ -309,26 +309,26 @@ renv::restore()              # Aus Lockfile wiederherstellen
 ### R-Paket-Probleme
 
 ```bash
-which R                               # R-Speicherort
-R --version                           # R-Version
-Rscript -e ".libPaths()"             # Bibliothekspfade
-echo $RSTUDIO_PANDOC                  # Pandoc-Pfad pruefen
+which R                               # R location
+R --version                           # R version
+Rscript -e ".libPaths()"             # Library paths
+echo $RSTUDIO_PANDOC                  # Check pandoc path
 ```
 
 ### WSL-Probleme
 
 ```bash
-wsl --list --verbose   # WSL-Distributionen auflisten
-wsl --status           # WSL-Status
-ip addr                # IP-Adressen
+wsl --list --verbose   # List WSL distributions
+wsl --status           # WSL status
+ip addr                # IP addresses
 ```
 
 ### Git-Probleme
 
 ```bash
-git config --list          # Gesamte Konfiguration anzeigen
-git remote show origin     # Remote-Details anzeigen
-git status --porcelain     # Maschinenlesbarer Status
+git config --list          # Show all config
+git remote show origin     # Show remote details
+git status --porcelain     # Machine-readable status
 ```
 
 ## Verwandte Ressourcen

--- a/i18n/es/agents/contemplative.md
+++ b/i18n/es/agents/contemplative.md
@@ -134,10 +134,10 @@ Este agente usa un estilo de comunicación de **presencia serena**:
 ```yaml
 settings:
   depth: standard          # light, standard, deep
-  sequence: adaptive       # adaptive, fixed (meditate->heal->center->shine)
+  sequence: adaptive       # adaptive, fixed (meditate→heal→center→shine)
   expression: minimal      # minimal, moderate, full
   attunement: enabled      # enabled, disabled
-  memory_integration: true # escribir insights duraderos en MEMORY.md
+  memory_integration: true # write durable insights to MEMORY.md
 ```
 
 ## Requisitos de Herramientas

--- a/i18n/es/agents/r-developer.md
+++ b/i18n/es/agents/r-developer.md
@@ -118,9 +118,9 @@ Agente: [Crea funciones modulares, maneja datos faltantes, genera informes]
 ## Opciones de Configuración
 
 ```yaml
-# Preferencias de desarrollo R
+# R development preferences
 settings:
-  coding_style: tidyverse  # o base_r, data_table
+  coding_style: tidyverse  # or base_r, data_table
   documentation: roxygen2
   testing_framework: testthat
   version_control: git
@@ -264,11 +264,11 @@ result <- data %>%
 
 ### Modelado Estadístico
 ```r
-# Modelo lineal de efectos mixtos
+# Linear mixed-effects model
 library(lme4)
 model <- lmer(response ~ predictor + (1|subject), data = df)
 summary(model)
-plot(model)  # Gráficos de diagnóstico
+plot(model)  # Diagnostic plots
 ```
 
 ### Plantilla de Función de Paquete

--- a/i18n/es/guides/quick-reference.md
+++ b/i18n/es/guides/quick-reference.md
@@ -23,13 +23,13 @@ Hoja de referencia de comandos para invocar agentes, habilidades y equipos a tra
 Las habilidades se invocan como comandos de barra en Claude Code cuando están enlazadas simbólicamente en `.claude/skills/`:
 
 ```bash
-# Hacer disponible una habilidad como comando de barra
+# Make a skill available as a slash command
 ln -s ../../skills/submit-to-cran .claude/skills/submit-to-cran
 
-# En Claude Code, invocar con:
+# In Claude Code, invoke with:
 /submit-to-cran
 
-# Otros ejemplos
+# Other examples
 /commit-changes
 /security-audit-codebase
 /review-skill-format
@@ -64,28 +64,28 @@ Equipos disponibles: r-package-review, gxp-compliance-validation, fullstack-web-
 ### Consultas al Registro
 
 ```bash
-# Contar habilidades, agentes, equipos
+# Count skills, agents, teams
 grep "total_skills" skills/_registry.yml
 grep "total_agents" agents/_registry.yml
 grep "total_teams" teams/_registry.yml
 
-# Listar todos los dominios
+# List all domains
 grep "^  [a-z]" skills/_registry.yml | head -50
 
-# Listar todos los agentes
+# List all agents
 grep "^  - id:" agents/_registry.yml
 
-# Listar todos los equipos
+# List all teams
 grep "^  - id:" teams/_registry.yml
 ```
 
 ### Automatización de README
 
 ```bash
-# Regenerar todos los READMEs desde los registros
+# Regenerate all READMEs from registries
 npm run update-readmes
 
-# Verificar si los READMEs están actualizados (prueba seca de CI)
+# Check if READMEs are up to date (CI dry-run)
 npm run check-readmes
 ```
 
@@ -94,15 +94,15 @@ npm run check-readmes
 ### Conversión de Rutas
 
 ```bash
-# Windows a WSL
+# Windows to WSL
 C:\Users\Name\Documents  ->  /mnt/c/Users/Name/Documents
 D:\dev\projects          ->  /mnt/d/dev/projects
 
-# Acceder a R de Windows desde WSL (ajustar versión)
+# Access Windows R from WSL (adjust version)
 "/mnt/c/Program Files/R/R-4.5.0/bin/R.exe"
 "/mnt/c/Program Files/R/R-4.5.0/bin/Rscript.exe"
 
-# Abrir el directorio actual en el Explorador de Windows
+# Open current directory in Windows Explorer
 explorer.exe .
 ```
 
@@ -111,11 +111,11 @@ explorer.exe .
 ### Ciclo de Desarrollo
 
 ```r
-devtools::load_all()        # Cargar paquete para desarrollo
-devtools::document()        # Actualizar documentación
-devtools::test()            # Ejecutar pruebas
-devtools::check()           # Verificación completa del paquete
-devtools::install()         # Instalar paquete
+devtools::load_all()        # Load package for development
+devtools::document()        # Update documentation
+devtools::test()            # Run tests
+devtools::check()           # Full package check
+devtools::install()         # Install package
 ```
 
 ### Verificaciones Rápidas
@@ -132,17 +132,17 @@ urlchecker::url_check()
 ```r
 devtools::check_win_devel()     # Windows builder
 devtools::check_win_release()   # Windows builder
-rhub::rhub_check()              # R-hub multiplataforma
-devtools::release()             # Envío interactivo a CRAN
+rhub::rhub_check()              # R-hub multi-platform
+devtools::release()             # Interactive CRAN submission
 ```
 
 ### Estructura Inicial
 
 ```r
-usethis::use_r("function_name")           # Nuevo archivo R
-usethis::use_test("function_name")        # Nuevo archivo de pruebas
-usethis::use_vignette("guide_name")       # Nueva viñeta
-usethis::use_mit_license()                # Agregar licencia MIT
+usethis::use_r("function_name")           # New R file
+usethis::use_test("function_name")        # New test file
+usethis::use_vignette("guide_name")       # New vignette
+usethis::use_mit_license()                # Add MIT license
 usethis::use_github_action_check_standard() # CI/CD
 ```
 
@@ -151,27 +151,27 @@ usethis::use_github_action_check_standard() # CI/CD
 ### Operaciones Diarias
 
 ```bash
-git status                 # Mostrar estado del árbol de trabajo
-git diff                   # Mostrar cambios no preparados
-git diff --staged          # Mostrar cambios preparados
-git log --oneline -10      # Commits recientes
+git status                 # Show working tree status
+git diff                   # Show unstaged changes
+git diff --staged          # Show staged changes
+git log --oneline -10      # Recent commits
 
-git add filename           # Preparar archivo específico
-git commit -m "message"    # Confirmar con mensaje
-git commit --amend         # Enmendar último commit
+git add filename           # Stage specific file
+git commit -m "message"    # Commit with message
+git commit --amend         # Amend last commit
 
-git checkout -b new-branch # Crear y cambiar a rama
-git merge feature-branch   # Fusionar rama
+git checkout -b new-branch # Create and switch to branch
+git merge feature-branch   # Merge branch
 ```
 
 ### Operaciones Remotas
 
 ```bash
-git remote -v              # Listar remotos
-git fetch origin           # Obtener cambios
-git pull origin main       # Pull y merge
-git push origin main       # Enviar al remoto
-git push -u origin branch  # Enviar nueva rama
+git remote -v              # List remotes
+git fetch origin           # Fetch changes
+git pull origin main       # Pull and merge
+git push origin main       # Push to remote
+git push -u origin branch  # Push new branch
 ```
 
 ### Alias Útiles
@@ -189,9 +189,9 @@ git config --global alias.last 'log -1 HEAD'
 ### Gestión de Sesión
 
 ```bash
-claude                     # Iniciar Claude Code
-claude mcp list            # Listar servidores MCP configurados
-claude mcp get r-mcptools  # Obtener detalles del servidor
+claude                     # Start Claude Code
+claude mcp list            # List configured MCP servers
+claude mcp get r-mcptools  # Get server details
 ```
 
 ### Archivos de Configuración
@@ -204,7 +204,7 @@ Claude Desktop (GUI/Win):   %APPDATA%\Claude\claude_desktop_config.json
 ### Servidores MCP
 
 ```bash
-# Integración R
+# R integration
 claude mcp add r-mcptools stdio \
   "/mnt/c/Program Files/R/R-4.5.0/bin/Rscript.exe" \
   -e "mcptools::mcp_server()"
@@ -220,34 +220,34 @@ claude mcp add hf-mcp-server \
 ### Navegación y Búsqueda
 
 ```bash
-pwd                        # Mostrar directorio de trabajo
-ls -la                     # Listar archivos con detalles
-tree                       # Mostrar árbol de directorios
-z project-name             # Saltar a directorio frecuente
+pwd                        # Print working directory
+ls -la                     # List files with details
+tree                       # Show directory tree
+z project-name             # Jump to frequent directory
 
-rg "pattern"               # Búsqueda con Ripgrep
-rg -t r "pattern"          # Buscar solo en archivos R
-fd "pattern"               # Find amigable
-fd -e R                    # Buscar por extensión
+rg "pattern"               # Ripgrep search
+rg -t r "pattern"          # Search only R files
+fd "pattern"               # User-friendly find
+fd -e R                    # Find by extension
 ```
 
 ### Operaciones con Archivos
 
 ```bash
-mkdir -p path/to/dir       # Crear directorios anidados
-cp -r source/ dest/        # Copiar directorio recursivamente
-tar -czf archive.tar.gz dir/  # Crear tar comprimido
-tar -xzf archive.tar.gz      # Extraer tar.gz
-du -sh directory           # Tamaño del directorio
-df -h                      # Uso de espacio en disco
+mkdir -p path/to/dir       # Create nested directories
+cp -r source/ dest/        # Copy directory recursively
+tar -czf archive.tar.gz dir/  # Create compressed tar
+tar -xzf archive.tar.gz      # Extract tar.gz
+du -sh directory           # Directory size
+df -h                      # Disk space usage
 ```
 
 ### Gestión de Procesos
 
 ```bash
-htop                       # Visor interactivo de procesos
-ps aux | grep process      # Buscar proceso específico
-kill PID                   # Terminar proceso por ID
+htop                       # Interactive process viewer
+ps aux | grep process      # Find specific process
+kill PID                   # Kill process by ID
 ```
 
 ## Atajos de Teclado
@@ -278,11 +278,11 @@ Ctrl+Shift+P   Paleta de comandos       F1            Paleta de comandos
 ## Variables de Entorno
 
 ```bash
-printenv              # Todas las variables de entorno
-echo $PATH            # Variable PATH
-export VAR=value      # Establecer para la sesión actual
+printenv              # All environment variables
+echo $PATH            # PATH variable
+export VAR=value      # Set for current session
 
-# Establecer permanentemente
+# Set permanently
 echo 'export VAR=value' >> ~/.bashrc
 source ~/.bashrc
 ```
@@ -294,14 +294,14 @@ source ~/.bashrc
 sudo apt update && sudo apt install package
 
 # npm
-npm install -g package       # Instalar globalmente
-npm list -g --depth=0        # Listar paquetes globales
+npm install -g package       # Install globally
+npm list -g --depth=0        # List global packages
 
 # R (renv)
-renv::init()                 # Inicializar renv
-renv::install("package")     # Instalar paquete
-renv::snapshot()             # Guardar lockfile
-renv::restore()              # Restaurar desde lockfile
+renv::init()                 # Initialize renv
+renv::install("package")     # Install package
+renv::snapshot()             # Save lockfile
+renv::restore()              # Restore from lockfile
 ```
 
 ## Resolución de Problemas
@@ -309,26 +309,26 @@ renv::restore()              # Restaurar desde lockfile
 ### Problemas con Paquetes R
 
 ```bash
-which R                               # Ubicación de R
-R --version                           # Versión de R
-Rscript -e ".libPaths()"             # Rutas de bibliotecas
-echo $RSTUDIO_PANDOC                  # Verificar ruta de pandoc
+which R                               # R location
+R --version                           # R version
+Rscript -e ".libPaths()"             # Library paths
+echo $RSTUDIO_PANDOC                  # Check pandoc path
 ```
 
 ### Problemas con WSL
 
 ```bash
-wsl --list --verbose   # Listar distribuciones WSL
-wsl --status           # Estado de WSL
-ip addr                # Direcciones IP
+wsl --list --verbose   # List WSL distributions
+wsl --status           # WSL status
+ip addr                # IP addresses
 ```
 
 ### Problemas con Git
 
 ```bash
-git config --list          # Mostrar toda la configuración
-git remote show origin     # Mostrar detalles del remoto
-git status --porcelain     # Estado legible por máquina
+git config --list          # Show all config
+git remote show origin     # Show remote details
+git status --porcelain     # Machine-readable status
 ```
 
 ## Recursos Relacionados

--- a/i18n/ja/agents/r-developer.md
+++ b/i18n/ja/agents/r-developer.md
@@ -118,7 +118,7 @@ Rパッケージの作成からメンテナンスまでの完全なワークフ�
 ## 設定オプション
 
 ```yaml
-# R開発プリファレンス
+# R development preferences
 settings:
   coding_style: tidyverse  # or base_r, data_table
   documentation: roxygen2
@@ -264,7 +264,7 @@ result <- data %>%
 
 ### 統計モデリング
 ```r
-# 線形混合効果モデル
+# Linear mixed-effects model
 library(lme4)
 model <- lmer(response ~ predictor + (1|subject), data = df)
 summary(model)

--- a/i18n/ja/guides/quick-reference.md
+++ b/i18n/ja/guides/quick-reference.md
@@ -23,13 +23,13 @@ Claude Codeを通じたエージェント、スキル、チームの呼び出し
 スキルは `.claude/skills/` にシンボリックリンクを作成すると、Claude Codeのスラッシュコマンドとして利用できる:
 
 ```bash
-# スキルをスラッシュコマンドとして利用可能にする
+# Make a skill available as a slash command
 ln -s ../../skills/submit-to-cran .claude/skills/submit-to-cran
 
-# Claude Code内での呼び出し:
+# In Claude Code, invoke with:
 /submit-to-cran
 
-# その他の例
+# Other examples
 /commit-changes
 /security-audit-codebase
 /review-skill-format
@@ -64,28 +64,28 @@ ln -s ../../skills/submit-to-cran .claude/skills/submit-to-cran
 ### レジストリ検索
 
 ```bash
-# スキル、エージェント、チームの数を確認
+# Count skills, agents, teams
 grep "total_skills" skills/_registry.yml
 grep "total_agents" agents/_registry.yml
 grep "total_teams" teams/_registry.yml
 
-# 全ドメインを一覧表示
+# List all domains
 grep "^  [a-z]" skills/_registry.yml | head -50
 
-# 全エージェントを一覧表示
+# List all agents
 grep "^  - id:" agents/_registry.yml
 
-# 全チームを一覧表示
+# List all teams
 grep "^  - id:" teams/_registry.yml
 ```
 
 ### README自動生成
 
 ```bash
-# レジストリから全READMEを再生成
+# Regenerate all READMEs from registries
 npm run update-readmes
 
-# READMEが最新かチェック（CIドライラン）
+# Check if READMEs are up to date (CI dry-run)
 npm run check-readmes
 ```
 
@@ -94,15 +94,15 @@ npm run check-readmes
 ### パス変換
 
 ```bash
-# WindowsからWSL
+# Windows to WSL
 C:\Users\Name\Documents  ->  /mnt/c/Users/Name/Documents
 D:\dev\projects          ->  /mnt/d/dev/projects
 
-# WSLからWindows版Rにアクセス（バージョンに合わせて調整）
+# Access Windows R from WSL (adjust version)
 "/mnt/c/Program Files/R/R-4.5.0/bin/R.exe"
 "/mnt/c/Program Files/R/R-4.5.0/bin/Rscript.exe"
 
-# 現在のディレクトリをWindowsエクスプローラーで開く
+# Open current directory in Windows Explorer
 explorer.exe .
 ```
 
@@ -111,11 +111,11 @@ explorer.exe .
 ### 開発サイクル
 
 ```r
-devtools::load_all()        # 開発用にパッケージをロード
-devtools::document()        # ドキュメントを更新
-devtools::test()            # テストを実行
-devtools::check()           # パッケージの完全チェック
-devtools::install()         # パッケージをインストール
+devtools::load_all()        # Load package for development
+devtools::document()        # Update documentation
+devtools::test()            # Run tests
+devtools::check()           # Full package check
+devtools::install()         # Install package
 ```
 
 ### クイックチェック
@@ -130,19 +130,19 @@ urlchecker::url_check()
 ### CRAN提出
 
 ```r
-devtools::check_win_devel()     # Windowsビルダー
-devtools::check_win_release()   # Windowsビルダー
-rhub::rhub_check()              # R-hubマルチプラットフォーム
-devtools::release()             # 対話的なCRAN提出
+devtools::check_win_devel()     # Windows builder
+devtools::check_win_release()   # Windows builder
+rhub::rhub_check()              # R-hub multi-platform
+devtools::release()             # Interactive CRAN submission
 ```
 
 ### スキャフォールディング
 
 ```r
-usethis::use_r("function_name")           # 新しいRファイル
-usethis::use_test("function_name")        # 新しいテストファイル
-usethis::use_vignette("guide_name")       # 新しいビネット
-usethis::use_mit_license()                # MITライセンスを追加
+usethis::use_r("function_name")           # New R file
+usethis::use_test("function_name")        # New test file
+usethis::use_vignette("guide_name")       # New vignette
+usethis::use_mit_license()                # Add MIT license
 usethis::use_github_action_check_standard() # CI/CD
 ```
 
@@ -151,27 +151,27 @@ usethis::use_github_action_check_standard() # CI/CD
 ### 日常操作
 
 ```bash
-git status                 # ワーキングツリーの状態を表示
-git diff                   # ステージされていない変更を表示
-git diff --staged          # ステージされた変更を表示
-git log --oneline -10      # 最近のコミット
+git status                 # Show working tree status
+git diff                   # Show unstaged changes
+git diff --staged          # Show staged changes
+git log --oneline -10      # Recent commits
 
-git add filename           # 特定のファイルをステージ
-git commit -m "message"    # メッセージ付きコミット
-git commit --amend         # 直前のコミットを修正
+git add filename           # Stage specific file
+git commit -m "message"    # Commit with message
+git commit --amend         # Amend last commit
 
-git checkout -b new-branch # ブランチを作成して切り替え
-git merge feature-branch   # ブランチをマージ
+git checkout -b new-branch # Create and switch to branch
+git merge feature-branch   # Merge branch
 ```
 
 ### リモート操作
 
 ```bash
-git remote -v              # リモートを一覧表示
-git fetch origin           # 変更を取得
-git pull origin main       # プルしてマージ
-git push origin main       # リモートにプッシュ
-git push -u origin branch  # 新しいブランチをプッシュ
+git remote -v              # List remotes
+git fetch origin           # Fetch changes
+git pull origin main       # Pull and merge
+git push origin main       # Push to remote
+git push -u origin branch  # Push new branch
 ```
 
 ### 便利なエイリアス
@@ -189,9 +189,9 @@ git config --global alias.last 'log -1 HEAD'
 ### セッション管理
 
 ```bash
-claude                     # Claude Codeを起動
-claude mcp list            # 設定済みMCPサーバーを一覧表示
-claude mcp get r-mcptools  # サーバー詳細を取得
+claude                     # Start Claude Code
+claude mcp list            # List configured MCP servers
+claude mcp get r-mcptools  # Get server details
 ```
 
 ### 設定ファイル
@@ -204,7 +204,7 @@ Claude Desktop (GUI/Win):   %APPDATA%\Claude\claude_desktop_config.json
 ### MCPサーバー
 
 ```bash
-# R連携
+# R integration
 claude mcp add r-mcptools stdio \
   "/mnt/c/Program Files/R/R-4.5.0/bin/Rscript.exe" \
   -e "mcptools::mcp_server()"
@@ -220,34 +220,34 @@ claude mcp add hf-mcp-server \
 ### ナビゲーションと検索
 
 ```bash
-pwd                        # カレントディレクトリを表示
-ls -la                     # 詳細なファイル一覧
-tree                       # ディレクトリツリーを表示
-z project-name             # よく使うディレクトリにジャンプ
+pwd                        # Print working directory
+ls -la                     # List files with details
+tree                       # Show directory tree
+z project-name             # Jump to frequent directory
 
-rg "pattern"               # Ripgrep検索
-rg -t r "pattern"          # Rファイルのみ検索
-fd "pattern"               # ユーザーフレンドリーなfind
-fd -e R                    # 拡張子で検索
+rg "pattern"               # Ripgrep search
+rg -t r "pattern"          # Search only R files
+fd "pattern"               # User-friendly find
+fd -e R                    # Find by extension
 ```
 
 ### ファイル操作
 
 ```bash
-mkdir -p path/to/dir       # ネストしたディレクトリを作成
-cp -r source/ dest/        # ディレクトリを再帰的にコピー
-tar -czf archive.tar.gz dir/  # 圧縮tarを作成
-tar -xzf archive.tar.gz      # tar.gzを展開
-du -sh directory           # ディレクトリサイズ
-df -h                      # ディスク使用量
+mkdir -p path/to/dir       # Create nested directories
+cp -r source/ dest/        # Copy directory recursively
+tar -czf archive.tar.gz dir/  # Create compressed tar
+tar -xzf archive.tar.gz      # Extract tar.gz
+du -sh directory           # Directory size
+df -h                      # Disk space usage
 ```
 
 ### プロセス管理
 
 ```bash
-htop                       # 対話的プロセスビューア
-ps aux | grep process      # 特定のプロセスを検索
-kill PID                   # プロセスIDで終了
+htop                       # Interactive process viewer
+ps aux | grep process      # Find specific process
+kill PID                   # Kill process by ID
 ```
 
 ## キーボードショートカット
@@ -278,11 +278,11 @@ Ctrl+Shift+P   コマンドパレット    F1            コマンドパレッ�
 ## 環境変数
 
 ```bash
-printenv              # 全環境変数
-echo $PATH            # PATH変数
-export VAR=value      # 現在のセッションに設定
+printenv              # All environment variables
+echo $PATH            # PATH variable
+export VAR=value      # Set for current session
 
-# 永続的に設定
+# Set permanently
 echo 'export VAR=value' >> ~/.bashrc
 source ~/.bashrc
 ```
@@ -294,14 +294,14 @@ source ~/.bashrc
 sudo apt update && sudo apt install package
 
 # npm
-npm install -g package       # グローバルインストール
-npm list -g --depth=0        # グローバルパッケージを一覧表示
+npm install -g package       # Install globally
+npm list -g --depth=0        # List global packages
 
 # R (renv)
-renv::init()                 # renvを初期化
-renv::install("package")     # パッケージをインストール
-renv::snapshot()             # ロックファイルを保存
-renv::restore()              # ロックファイルから復元
+renv::init()                 # Initialize renv
+renv::install("package")     # Install package
+renv::snapshot()             # Save lockfile
+renv::restore()              # Restore from lockfile
 ```
 
 ## トラブルシューティング
@@ -309,26 +309,26 @@ renv::restore()              # ロックファイルから復元
 ### Rパッケージの問題
 
 ```bash
-which R                               # Rの場所
-R --version                           # Rのバージョン
-Rscript -e ".libPaths()"             # ライブラリパス
-echo $RSTUDIO_PANDOC                  # pandocパスの確認
+which R                               # R location
+R --version                           # R version
+Rscript -e ".libPaths()"             # Library paths
+echo $RSTUDIO_PANDOC                  # Check pandoc path
 ```
 
 ### WSLの問題
 
 ```bash
-wsl --list --verbose   # WSLディストリビューションを一覧表示
-wsl --status           # WSLステータス
-ip addr                # IPアドレス
+wsl --list --verbose   # List WSL distributions
+wsl --status           # WSL status
+ip addr                # IP addresses
 ```
 
 ### Gitの問題
 
 ```bash
-git config --list          # 全設定を表示
-git remote show origin     # リモート詳細を表示
-git status --porcelain     # 機械可読ステータス
+git config --list          # Show all config
+git remote show origin     # Show remote details
+git status --porcelain     # Machine-readable status
 ```
 
 ## 関連リソース

--- a/i18n/zh-CN/agents/contemplative.md
+++ b/i18n/zh-CN/agents/contemplative.md
@@ -136,7 +136,7 @@ settings:
   sequence: adaptive       # adaptive, fixed (meditate→heal→center→shine)
   expression: minimal      # minimal, moderate, full
   attunement: enabled      # enabled, disabled
-  memory_integration: true # 将持久洞见写入 MEMORY.md
+  memory_integration: true # write durable insights to MEMORY.md
 ```
 
 ## 工具要求

--- a/i18n/zh-CN/agents/r-developer.md
+++ b/i18n/zh-CN/agents/r-developer.md
@@ -118,9 +118,9 @@ Core skills (loaded automatically when spawned as subagent) are marked with **[c
 ## 配置选项
 
 ```yaml
-# R 开发偏好
+# R development preferences
 settings:
-  coding_style: tidyverse  # 或 base_r, data_table
+  coding_style: tidyverse  # or base_r, data_table
   documentation: roxygen2
   testing_framework: testthat
   version_control: git
@@ -264,11 +264,11 @@ result <- data %>%
 
 ### 统计建模
 ```r
-# 线性混合效应模型
+# Linear mixed-effects model
 library(lme4)
 model <- lmer(response ~ predictor + (1|subject), data = df)
 summary(model)
-plot(model)  # 诊断图
+plot(model)  # Diagnostic plots
 ```
 
 ### 包函数模板

--- a/i18n/zh-CN/guides/quick-reference.md
+++ b/i18n/zh-CN/guides/quick-reference.md
@@ -23,13 +23,13 @@ translation_date: "2026-03-13"
 技能在符号链接到 `.claude/skills/` 后可作为 Claude Code 的斜杠命令使用：
 
 ```bash
-# 将技能设为斜杠命令
+# Make a skill available as a slash command
 ln -s ../../skills/submit-to-cran .claude/skills/submit-to-cran
 
-# 在 Claude Code 中调用：
+# In Claude Code, invoke with:
 /submit-to-cran
 
-# 其他示例
+# Other examples
 /commit-changes
 /security-audit-codebase
 /review-skill-format
@@ -64,28 +64,28 @@ ln -s ../../skills/submit-to-cran .claude/skills/submit-to-cran
 ### 注册表查询
 
 ```bash
-# 统计技能、智能体、团队数量
+# Count skills, agents, teams
 grep "total_skills" skills/_registry.yml
 grep "total_agents" agents/_registry.yml
 grep "total_teams" teams/_registry.yml
 
-# 列出所有领域
+# List all domains
 grep "^  [a-z]" skills/_registry.yml | head -50
 
-# 列出所有智能体
+# List all agents
 grep "^  - id:" agents/_registry.yml
 
-# 列出所有团队
+# List all teams
 grep "^  - id:" teams/_registry.yml
 ```
 
 ### README 自动化
 
 ```bash
-# 从注册表重新生成所有 README
+# Regenerate all READMEs from registries
 npm run update-readmes
 
-# 检查 README 是否最新（CI 预检）
+# Check if READMEs are up to date (CI dry-run)
 npm run check-readmes
 ```
 
@@ -94,15 +94,15 @@ npm run check-readmes
 ### 路径转换
 
 ```bash
-# Windows 到 WSL
+# Windows to WSL
 C:\Users\Name\Documents  ->  /mnt/c/Users/Name/Documents
 D:\dev\projects          ->  /mnt/d/dev/projects
 
-# 从 WSL 访问 Windows R（调整版本号）
+# Access Windows R from WSL (adjust version)
 "/mnt/c/Program Files/R/R-4.5.0/bin/R.exe"
 "/mnt/c/Program Files/R/R-4.5.0/bin/Rscript.exe"
 
-# 在 Windows 资源管理器中打开当前目录
+# Open current directory in Windows Explorer
 explorer.exe .
 ```
 
@@ -111,11 +111,11 @@ explorer.exe .
 ### 开发循环
 
 ```r
-devtools::load_all()        # 加载包用于开发
-devtools::document()        # 更新文档
-devtools::test()            # 运行测试
-devtools::check()           # 完整包检查
-devtools::install()         # 安装包
+devtools::load_all()        # Load package for development
+devtools::document()        # Update documentation
+devtools::test()            # Run tests
+devtools::check()           # Full package check
+devtools::install()         # Install package
 ```
 
 ### 快速检查
@@ -130,19 +130,19 @@ urlchecker::url_check()
 ### CRAN 提交
 
 ```r
-devtools::check_win_devel()     # Windows 构建器
-devtools::check_win_release()   # Windows 构建器
-rhub::rhub_check()              # R-hub 多平台
-devtools::release()             # 交互式 CRAN 提交
+devtools::check_win_devel()     # Windows builder
+devtools::check_win_release()   # Windows builder
+rhub::rhub_check()              # R-hub multi-platform
+devtools::release()             # Interactive CRAN submission
 ```
 
 ### 脚手架
 
 ```r
-usethis::use_r("function_name")           # 新 R 文件
-usethis::use_test("function_name")        # 新测试文件
-usethis::use_vignette("guide_name")       # 新 vignette
-usethis::use_mit_license()                # 添加 MIT 许可证
+usethis::use_r("function_name")           # New R file
+usethis::use_test("function_name")        # New test file
+usethis::use_vignette("guide_name")       # New vignette
+usethis::use_mit_license()                # Add MIT license
 usethis::use_github_action_check_standard() # CI/CD
 ```
 
@@ -151,27 +151,27 @@ usethis::use_github_action_check_standard() # CI/CD
 ### 日常操作
 
 ```bash
-git status                 # 显示工作树状态
-git diff                   # 显示未暂存的变更
-git diff --staged          # 显示已暂存的变更
-git log --oneline -10      # 最近的提交
+git status                 # Show working tree status
+git diff                   # Show unstaged changes
+git diff --staged          # Show staged changes
+git log --oneline -10      # Recent commits
 
-git add filename           # 暂存特定文件
-git commit -m "message"    # 带消息提交
-git commit --amend         # 修改上一次提交
+git add filename           # Stage specific file
+git commit -m "message"    # Commit with message
+git commit --amend         # Amend last commit
 
-git checkout -b new-branch # 创建并切换到分支
-git merge feature-branch   # 合并分支
+git checkout -b new-branch # Create and switch to branch
+git merge feature-branch   # Merge branch
 ```
 
 ### 远程操作
 
 ```bash
-git remote -v              # 列出远程仓库
-git fetch origin           # 获取变更
-git pull origin main       # 拉取并合并
-git push origin main       # 推送到远程
-git push -u origin branch  # 推送新分支
+git remote -v              # List remotes
+git fetch origin           # Fetch changes
+git pull origin main       # Pull and merge
+git push origin main       # Push to remote
+git push -u origin branch  # Push new branch
 ```
 
 ### 常用别名
@@ -189,9 +189,9 @@ git config --global alias.last 'log -1 HEAD'
 ### 会话管理
 
 ```bash
-claude                     # 启动 Claude Code
-claude mcp list            # 列出已配置的 MCP 服务器
-claude mcp get r-mcptools  # 获取服务器详情
+claude                     # Start Claude Code
+claude mcp list            # List configured MCP servers
+claude mcp get r-mcptools  # Get server details
 ```
 
 ### 配置文件
@@ -204,7 +204,7 @@ Claude Desktop (GUI/Win):   %APPDATA%\Claude\claude_desktop_config.json
 ### MCP 服务器
 
 ```bash
-# R 集成
+# R integration
 claude mcp add r-mcptools stdio \
   "/mnt/c/Program Files/R/R-4.5.0/bin/Rscript.exe" \
   -e "mcptools::mcp_server()"
@@ -220,34 +220,34 @@ claude mcp add hf-mcp-server \
 ### 导航和搜索
 
 ```bash
-pwd                        # 显示当前工作目录
-ls -la                     # 列出文件详情
-tree                       # 显示目录树
-z project-name             # 跳转到常用目录
+pwd                        # Print working directory
+ls -la                     # List files with details
+tree                       # Show directory tree
+z project-name             # Jump to frequent directory
 
-rg "pattern"               # Ripgrep 搜索
-rg -t r "pattern"          # 仅搜索 R 文件
-fd "pattern"               # 友好的 find 替代
-fd -e R                    # 按扩展名查找
+rg "pattern"               # Ripgrep search
+rg -t r "pattern"          # Search only R files
+fd "pattern"               # User-friendly find
+fd -e R                    # Find by extension
 ```
 
 ### 文件操作
 
 ```bash
-mkdir -p path/to/dir       # 创建嵌套目录
-cp -r source/ dest/        # 递归复制目录
-tar -czf archive.tar.gz dir/  # 创建压缩包
-tar -xzf archive.tar.gz      # 解压压缩包
-du -sh directory           # 目录大小
-df -h                      # 磁盘使用情况
+mkdir -p path/to/dir       # Create nested directories
+cp -r source/ dest/        # Copy directory recursively
+tar -czf archive.tar.gz dir/  # Create compressed tar
+tar -xzf archive.tar.gz      # Extract tar.gz
+du -sh directory           # Directory size
+df -h                      # Disk space usage
 ```
 
 ### 进程管理
 
 ```bash
-htop                       # 交互式进程查看器
-ps aux | grep process      # 查找特定进程
-kill PID                   # 按 ID 终止进程
+htop                       # Interactive process viewer
+ps aux | grep process      # Find specific process
+kill PID                   # Kill process by ID
 ```
 
 ## 键盘快捷键
@@ -278,11 +278,11 @@ Ctrl+Shift+P   命令面板          F1            命令面板
 ## 环境变量
 
 ```bash
-printenv              # 所有环境变量
-echo $PATH            # PATH 变量
-export VAR=value      # 设置当前会话变量
+printenv              # All environment variables
+echo $PATH            # PATH variable
+export VAR=value      # Set for current session
 
-# 永久设置
+# Set permanently
 echo 'export VAR=value' >> ~/.bashrc
 source ~/.bashrc
 ```
@@ -294,14 +294,14 @@ source ~/.bashrc
 sudo apt update && sudo apt install package
 
 # npm
-npm install -g package       # 全局安装
-npm list -g --depth=0        # 列出全局包
+npm install -g package       # Install globally
+npm list -g --depth=0        # List global packages
 
 # R (renv)
-renv::init()                 # 初始化 renv
-renv::install("package")     # 安装包
-renv::snapshot()             # 保存锁文件
-renv::restore()              # 从锁文件恢复
+renv::init()                 # Initialize renv
+renv::install("package")     # Install package
+renv::snapshot()             # Save lockfile
+renv::restore()              # Restore from lockfile
 ```
 
 ## 故障排除
@@ -309,26 +309,26 @@ renv::restore()              # 从锁文件恢复
 ### R 包问题
 
 ```bash
-which R                               # R 所在位置
-R --version                           # R 版本
-Rscript -e ".libPaths()"             # 库路径
-echo $RSTUDIO_PANDOC                  # 检查 pandoc 路径
+which R                               # R location
+R --version                           # R version
+Rscript -e ".libPaths()"             # Library paths
+echo $RSTUDIO_PANDOC                  # Check pandoc path
 ```
 
 ### WSL 问题
 
 ```bash
-wsl --list --verbose   # 列出 WSL 发行版
-wsl --status           # WSL 状态
-ip addr                # IP 地址
+wsl --list --verbose   # List WSL distributions
+wsl --status           # WSL status
+ip addr                # IP addresses
 ```
 
 ### Git 问题
 
 ```bash
-git config --list          # 显示所有配置
-git remote show origin     # 显示远程详情
-git status --porcelain     # 机器可读状态
+git config --list          # Show all config
+git remote show origin     # Show remote details
+git status --porcelain     # Machine-readable status
 ```
 
 ## 相关资源

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -45,8 +45,18 @@
  * positional rule can safely reconstruct. Those 46 carry 206 fences and are
  * tracked as content forks in #478.
  *
- * Scope: skills only. The checker also covers the agents/teams/guides mirrors,
- * whose 87 gated violations this tool does not yet repair (#477).
+ * Scope: all four content trees — `skills`, `agents`, `teams`, `guides` — so it
+ * covers exactly what `check-i18n-fence-parity.js` flags. It was skills-only
+ * until the mirrors became the last mechanically-repairable slice of #477: 87 of
+ * the 335 gated violations, 76 of them in `guides/quick-reference.md` across
+ * four locales, and every one a translated comment inside a `bash`, `r` or
+ * `yaml` fence.
+ *
+ * `--tree` scopes a run the way `--tag` scopes one, so the mirrors land as their
+ * own reviewable batch. Paths differ by tree — `skills/<id>/SKILL.md` against
+ * `<tree>/<id>.md` — and which names count as content at all is decided by
+ * `contentKey` from `lib/fences.js`, the same function the history index is
+ * built with, rather than by a second list here that could drift from it.
  *
  * ## Why preview is the default (#486)
  *
@@ -75,19 +85,21 @@
  *   node scripts/normalize-i18n-fences.js --basis head
  *   node scripts/normalize-i18n-fences.js --locale de    # restrict to one locale
  *   node scripts/normalize-i18n-fences.js --tag yaml,json  # restrict to tags (#477 batches)
+ *   node scripts/normalize-i18n-fences.js --tree guides,agents  # restrict to trees
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
-import { extractFences, toLines, isGated, buildEnglishFenceHistory } from './lib/fences.js';
+import {
+  extractFences, toLines, isGated, buildEnglishFenceHistory, TREES, contentKey,
+} from './lib/fences.js';
 import { assertNotShallow } from './lib/git-freshness.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 const I18N_DIR = resolve(ROOT, 'i18n');
-const SKILLS_DIR = resolve(ROOT, 'skills');
 
 const argv = process.argv.slice(2);
 
@@ -112,7 +124,7 @@ const argv = process.argv.slice(2);
  * `"--dry"` as the locale value.
  */
 const BOOL_FLAGS = new Set(['--write', '--dry']);
-const VALUE_FLAGS = new Set(['--basis', '--locale', '--tag']);
+const VALUE_FLAGS = new Set(['--basis', '--locale', '--tag', '--tree']);
 
 function usageError(message) {
   console.error(`ERROR: ${message}`);
@@ -120,7 +132,7 @@ function usageError(message) {
   process.exit(2);
 }
 
-const opts = { write: false, dry: false, basis: 'source-commit', locale: null, tag: null };
+const opts = { write: false, dry: false, basis: 'source-commit', locale: null, tag: null, tree: null };
 for (let i = 0; i < argv.length; i++) {
   const arg = argv[i];
   const eq = arg.indexOf('=');
@@ -195,10 +207,44 @@ const tagOf = (fence) => (fence.lang === '' ? 'untagged' : fence.lang);
  * Membership in the scan's own list is the only formulation that cannot drift
  * from the scan.
  */
-const SCANNABLE_LOCALES = readdirSync(I18N_DIR).filter((entry) => {
-  const localeSkills = join(I18N_DIR, entry, 'skills');
-  return existsSync(localeSkills) && statSync(localeSkills).isDirectory();
-});
+const hasTree = (locale, tree) => {
+  const p = join(I18N_DIR, locale, tree);
+  return existsSync(p) && statSync(p).isDirectory();
+};
+
+/**
+ * Scoped to content trees, so the mirrors can be repaired as their own batch —
+ * 87 of the 335 gated violations live in `agents`/`teams`/`guides`, and 76 of
+ * those in one guide across four locales.
+ *
+ * Validated against the trees this repository actually carries rather than
+ * against `TREES`, for the same reason `--locale` is validated against the
+ * scan's own list: a value that names a real tree the corpus has no
+ * translations for would otherwise report the clean-looking zero both guards
+ * exist to reject.
+ */
+const PRESENT_TREES = TREES.filter((tree) =>
+  readdirSync(I18N_DIR).some((locale) => hasTree(locale, tree)));
+
+const ONLY_TREES = opts.tree === null ? null : new Set(
+  opts.tree.split(',').map((t) => t.trim().toLowerCase()).filter((t) => t !== ''),
+);
+if (ONLY_TREES !== null) {
+  if (ONLY_TREES.size === 0) {
+    console.error(`ERROR: --tree was given no usable value (got '${opts.tree}').`);
+    process.exit(2);
+  }
+  const unknown = [...ONLY_TREES].filter((t) => !PRESENT_TREES.includes(t));
+  if (unknown.length) {
+    console.error(`ERROR: --tree names no translated content tree: ${unknown.join(', ')}`);
+    console.error('Nothing would be scanned, and the run would report a clean-looking zero.');
+    console.error(`Available: ${PRESENT_TREES.join(', ') || '(none)'}`);
+    process.exit(2);
+  }
+}
+
+const SCANNABLE_LOCALES = readdirSync(I18N_DIR).filter((entry) =>
+  PRESENT_TREES.some((tree) => hasTree(entry, tree)));
 
 if (ONLY_LOCALE && !SCANNABLE_LOCALES.includes(ONLY_LOCALE)) {
   console.error(`ERROR: --locale '${ONLY_LOCALE}' is not a translated locale under i18n/.`);
@@ -321,25 +367,35 @@ const history = buildEnglishFenceHistory();
 const targets = [];
 for (const locale of SCANNABLE_LOCALES) {
   if (ONLY_LOCALE && locale !== ONLY_LOCALE) continue;
-  const localeSkills = join(I18N_DIR, locale, 'skills');
-  for (const skill of readdirSync(localeSkills)) {
-    const translated = join(localeSkills, skill, 'SKILL.md');
-    const english = join(SKILLS_DIR, skill, 'SKILL.md');
-    if (!existsSync(translated) || !existsSync(english)) continue;
-    const text = readFileSync(translated, 'utf8');
-    targets.push({
-      locale, skill, path: translated, english,
-      relPath: `i18n/${locale}/skills/${skill}/SKILL.md`,
-      text,
-      sourceCommit: frontmatterField(text, 'source_commit'),
-    });
+  for (const tree of PRESENT_TREES) {
+    if (ONLY_TREES && !ONLY_TREES.has(tree)) continue;
+    if (!hasTree(locale, tree)) continue;
+    for (const entry of readdirSync(join(I18N_DIR, locale, tree))) {
+      // `skills/<id>/SKILL.md` for skills, `<tree>/<id>.md` for the mirrors.
+      // `contentKey` decides which names are content at all, so `_template.md`,
+      // `README.md` and `_registry.yml` fall out here rather than needing a
+      // second list that could drift from the checker's.
+      const englishRel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
+      const key = contentKey(englishRel);
+      if (key === null) continue;
+      const translated = join(I18N_DIR, locale, englishRel);
+      const english = join(ROOT, englishRel);
+      if (!existsSync(translated) || !existsSync(english)) continue;
+      const text = readFileSync(translated, 'utf8');
+      targets.push({
+        locale, tree, key, path: translated, english, englishRel,
+        relPath: `i18n/${locale}/${englishRel}`,
+        text,
+        sourceCommit: frontmatterField(text, 'source_commit'),
+      });
+    }
   }
 }
 
 // ---- resolve each target's English basis ----
 const specs = BASIS === 'source-commit'
   ? [...new Set(targets.filter((t) => t.sourceCommit)
-      .map((t) => `${t.sourceCommit}:skills/${t.skill}/SKILL.md`))]
+      .map((t) => `${t.sourceCommit}:${t.englishRel}`))]
   : [];
 const blobs = readBlobs(specs);
 
@@ -360,17 +416,18 @@ for (const t of targets) {
   // `head` made the report claim a provenance the bytes did not have.
   let basisLabel = 'worktree';
   if (BASIS === 'source-commit' && t.sourceCommit) {
-    basisText = blobs.get(`${t.sourceCommit}:skills/${t.skill}/SKILL.md`) ?? null;
+    basisText = blobs.get(`${t.sourceCommit}:${t.englishRel}`) ?? null;
     basisLabel = t.sourceCommit;
   }
   if (basisText === null) { basisText = readFileSync(t.english, 'utf8'); basisLabel = 'worktree'; }
 
   const translatedFences = extractFences(t.text);
   const basisFences = extractFences(basisText);
-  // Keys are `<tree>/<id>` (see lib/fences.js contentKey). A bare `t.skill`
-  // lookup returns undefined for every file, which the `everEnglish &&` guard
-  // below silently turns into "nothing to repair" — a clean-looking zero.
-  const everEnglish = history.get(`skills/${t.skill}`);
+  // Keys are `<tree>/<id>`, produced by the same `contentKey` the history is
+  // built with, so the two cannot disagree about what an id is. A bare `t.skill`
+  // lookup returned undefined for every file, which the `everEnglish &&` guard
+  // below silently turned into "nothing to repair" — a clean-looking zero.
+  const everEnglish = history.get(t.key);
   if (!everEnglish) {
     skipped.push({ file: t.relPath, reason: 'no English history for this id', n: 0 });
     continue;

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -3,7 +3,7 @@
  * normalize-i18n-fences.js
  *
  * Companion repair tool to `check-i18n-fence-parity.js` (#472). Restores the
- * English body of gated code fences in translated skills, which the
+ * English body of gated code fences in translated content, which the
  * keep-code-in-English rule requires them to carry verbatim.
  *
  * Shares `lib/fences.js` with the checker, so the two can never disagree about
@@ -30,9 +30,9 @@
  * Note that "head" reads the WORKING TREE, not the HEAD commit — and so does the
  * default basis whenever a translation's `source_commit` fails to resolve. An
  * uncommitted English edit is a legitimate parity basis, so this is deliberate,
- * but it means a dirty `skills/` changes what is spliced into the corpus. Such
- * restores are reported as basis `worktree`; a `--write` run warns when
- * `skills/` is dirty.
+ * but it means a dirty English tree changes what is spliced into the corpus. Such
+ * restores are reported as basis `worktree`; a `--write` run warns when any
+ * English content tree is dirty.
  *
  * ## What it refuses to touch
  *
@@ -195,8 +195,8 @@ const tagOf = (fence) => (fence.lang === '' ? 'untagged' : fence.lang);
 
 /**
  * The locales this tool can actually scan: a directory under `i18n/` carrying a
- * `skills/` subtree. Derived once and used BOTH to validate `--locale` and to
- * drive the scan below, so the two cannot disagree about what a locale is.
+ * content tree. Derived once and used BOTH to validate `--locale` and to drive
+ * the scan below, so the two cannot disagree about what a locale is.
  *
  * Validating instead by `existsSync` on the constructed `i18n/<value>` path —
  * the first version of this guard — accepted every input that named some
@@ -229,19 +229,18 @@ const PRESENT_TREES = TREES.filter((tree) =>
 const ONLY_TREES = opts.tree === null ? null : new Set(
   opts.tree.split(',').map((t) => t.trim().toLowerCase()).filter((t) => t !== ''),
 );
-if (ONLY_TREES !== null) {
-  if (ONLY_TREES.size === 0) {
-    console.error(`ERROR: --tree was given no usable value (got '${opts.tree}').`);
-    process.exit(2);
-  }
-  const unknown = [...ONLY_TREES].filter((t) => !PRESENT_TREES.includes(t));
-  if (unknown.length) {
-    console.error(`ERROR: --tree names no translated content tree: ${unknown.join(', ')}`);
-    console.error('Nothing would be scanned, and the run would report a clean-looking zero.');
-    console.error(`Available: ${PRESENT_TREES.join(', ') || '(none)'}`);
-    process.exit(2);
-  }
+if (ONLY_TREES !== null && ONLY_TREES.size === 0) {
+  console.error(`ERROR: --tree was given no usable value (got '${opts.tree}').`);
+  process.exit(2);
 }
+// The membership check is deliberately NOT here. Validating against
+// `PRESENT_TREES` — a corpus-wide union — passes for any tree some locale
+// carries, which stops being "the scan's own list" the moment `--locale`
+// narrows the scan: `--locale wenyan --tree guides` cleared both guards
+// independently and reported `files to change: 0`, the exact clean-looking zero
+// they exist to reject, because six of the ten locales carry `skills/` alone.
+// It is checked after the scan instead, against the trees the SCOPED run
+// actually visited — the same shape as `--tag`, and for the same reason.
 
 const SCANNABLE_LOCALES = readdirSync(I18N_DIR).filter((entry) =>
   PRESENT_TREES.some((tree) => hasTree(entry, tree)));
@@ -265,8 +264,8 @@ const WRITE_SCOPE = ONLY_LOCALE ? `i18n/${ONLY_LOCALE}` : 'i18n';
 // for this tool, and it discards uncommitted work along with the repair — so a
 // stray run over unstaged edits is unrecoverable in exactly the case where
 // recovery matters most. Checked before the ~90s history build so it fails fast.
-function gitStatus(pathspec) {
-  const status = spawnSync('git', ['status', '--porcelain', '--', pathspec], {
+function gitStatus(...pathspecs) {
+  const status = spawnSync('git', ['status', '--porcelain', '--', ...pathspecs], {
     cwd: ROOT, encoding: 'utf8',
   });
   // `status.error` is set and stdout/stderr are null when the spawn itself
@@ -310,9 +309,14 @@ if (WRITE) {
   // `skills/` changes what gets spliced into the corpus, and the run would
   // report it as basis `head`. Warn rather than refuse: refusing would block
   // the ordinary edit-English-then-repair pass this tool is for.
-  const english = gitStatus('skills');
+  // Every tree that can be spliced FROM, not just skills. The English basis is
+  // read off disk whenever a `source_commit` fails to resolve and always under
+  // `--basis head`, and `t.english` is now `guides/quick-reference.md` as
+  // readily as `skills/<id>/SKILL.md` — so a warning scoped to `skills` was
+  // silently half the surface it claimed to cover.
+  const english = gitStatus(...PRESENT_TREES);
   if (english.ok && english.dirty) {
-    console.error(`NOTE: skills/ has ${english.dirty.split('\n').length} uncommitted change(s).`);
+    console.error(`NOTE: English content (${PRESENT_TREES.join(', ')}) has ${english.dirty.split('\n').length} uncommitted change(s).`);
     console.error('      Fences restored from the working tree are labelled `worktree`, not a commit.');
   }
 }
@@ -328,7 +332,7 @@ function frontmatterField(text, field) {
   return m[1].replace(/\s+#.*$/, '').trim().replace(/^["']|["']$/g, '');
 }
 
-/** Batch-resolve `<commit>:skills/<id>/SKILL.md` blobs in one git process. */
+/** Batch-resolve `<commit>:<englishRel>` blobs in one git process. */
 function readBlobs(specs) {
   const out = new Map();
   if (!specs.length) return out;
@@ -365,10 +369,11 @@ const history = buildEnglishFenceHistory();
 
 // ---- gather targets ----
 const targets = [];
+/** Trees the locale-scoped scan found translated content in, before `--tree`. */
+const treesInScope = new Set();
 for (const locale of SCANNABLE_LOCALES) {
   if (ONLY_LOCALE && locale !== ONLY_LOCALE) continue;
   for (const tree of PRESENT_TREES) {
-    if (ONLY_TREES && !ONLY_TREES.has(tree)) continue;
     if (!hasTree(locale, tree)) continue;
     for (const entry of readdirSync(join(I18N_DIR, locale, tree))) {
       // `skills/<id>/SKILL.md` for skills, `<tree>/<id>.md` for the mirrors.
@@ -380,7 +385,20 @@ for (const locale of SCANNABLE_LOCALES) {
       if (key === null) continue;
       const translated = join(I18N_DIR, locale, englishRel);
       const english = join(ROOT, englishRel);
-      if (!existsSync(translated) || !existsSync(english)) continue;
+      // `isFile`, not merely `existsSync`, matching the checker. For skills the
+      // entry is a directory and the file is `SKILL.md`, so existence alone was
+      // safe by construction; on the mirror branch the ENTRY is the file, and a
+      // directory named `foo.md` would reach readFileSync and kill the run with
+      // EISDIR where the checker skips it.
+      if (!existsSync(translated) || !statSync(translated).isFile()) continue;
+      if (!existsSync(english) || !statSync(english).isFile()) continue;
+      // Recorded BEFORE the `--tree` filter, so the accept-list describes what
+      // this locale-scoped run could have reached rather than what it selected.
+      // Collected after the existence checks, so it means "carries translated
+      // content" and not merely "has a directory of that name" — the same
+      // distinction the `--locale` guard turns on.
+      treesInScope.add(tree);
+      if (ONLY_TREES && !ONLY_TREES.has(tree)) continue;
       const text = readFileSync(translated, 'utf8');
       targets.push({
         locale, tree, key, path: translated, english, englishRel,
@@ -389,6 +407,27 @@ for (const locale of SCANNABLE_LOCALES) {
         sourceCommit: frontmatterField(text, 'source_commit'),
       });
     }
+  }
+}
+
+/**
+ * Validate `--tree` against what the SCOPED scan actually reached, not against
+ * a corpus-wide union. Checked here rather than at parse time because the
+ * accept-list is the scan's own output — the only formulation that cannot drift
+ * from the scan — and before any write, so a mistyped or unreachable batch
+ * cannot touch the corpus.
+ *
+ * The pre-scan version passed `--locale wenyan --tree guides` and reported
+ * `files to change: 0`: each guard was satisfied on its own and neither saw the
+ * composition, while six of the ten locales carry `skills/` alone.
+ */
+if (ONLY_TREES !== null) {
+  const unreachable = [...ONLY_TREES].filter((t) => !treesInScope.has(t));
+  if (unreachable.length) {
+    console.error(`ERROR: --tree matched no translated content${ONLY_LOCALE ? ` in locale '${ONLY_LOCALE}'` : ''}: ${unreachable.join(', ')}`);
+    console.error('Nothing would be scanned, and the run would report a clean-looking zero.');
+    console.error(`Reachable here: ${[...treesInScope].sort().join(', ') || '(none)'}`);
+    process.exit(2);
   }
 }
 

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -436,3 +436,106 @@ test('--locale scopes the dirty check to that locale', async (t) => {
   assert.equal(r.status, 0, r.stderr);
   assert.doesNotMatch(readFileSync(translated, 'utf8'), /hallo/);
 });
+
+// ── the mirrors: agents / teams / guides (#477) ─────────────────────────────
+
+/**
+ * A translated GUIDE, which lives at `<tree>/<id>.md` rather than
+ * `skills/<id>/SKILL.md`. The tool was skills-only until the mirrors became the
+ * last mechanically-repairable slice of #477 — 87 of 335 gated violations, 76 of
+ * them in one guide across four locales.
+ */
+function addGuideMirror(dir) {
+  mkdirSync(join(dir, 'guides'), { recursive: true });
+  writeFileSync(join(dir, 'guides', 'quick-ref.md'), [
+    '---', 'title: Quick Reference', 'description: Commands.', '---', '',
+    '# Quick Reference', '',
+    '```bash', '# Count the skills', 'ls skills | wc -l', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english guide']);
+  const sc = git(dir, ['rev-parse', 'HEAD']);
+
+  const translated = join(dir, 'i18n', 'de', 'guides', 'quick-ref.md');
+  mkdirSync(dirname(translated), { recursive: true });
+  writeFileSync(translated, [
+    '---', 'title: Kurzreferenz', 'description: Befehle.',
+    'locale: de', 'source_locale: en', `source_commit: ${sc}`, '---', '',
+    '# Kurzreferenz', '',
+    '```bash', '# Die Skills zaehlen', 'ls skills | wc -l', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de guide with a translated comment in a frozen fence']);
+  return translated;
+}
+
+test('a translated GUIDE mirror is repaired, not just skills', async (t) => {
+  const { dir } = makeFixture(t);
+  const guide = addGuideMirror(dir);
+
+  const r = run(dir, ['--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  const after = readFileSync(guide, 'utf8');
+  assert.ok(after.includes('# Count the skills'), 'the English comment was not restored');
+  assert.ok(!after.includes('# Die Skills zaehlen'), 'the translated comment survived');
+  // The guide's prose must be untouched — only the frozen fence is restored.
+  assert.ok(after.includes('# Kurzreferenz'), 'translated prose was overwritten');
+  assert.ok(after.includes('title: Kurzreferenz'), 'translated frontmatter was overwritten');
+});
+
+test('--tree scopes a run the way --tag does', async (t) => {
+  const { dir, translated } = makeFixture(t);
+  const guide = addGuideMirror(dir);
+
+  const r = run(dir, ['--tree', 'guides', '--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /files changed: 1/);
+  assert.ok(readFileSync(guide, 'utf8').includes('# Count the skills'), 'the guide was not repaired');
+  assert.ok(readFileSync(translated, 'utf8').includes(TRANSLATED_FENCE), 'the skill was repaired despite --tree guides');
+});
+
+test('--tree naming no translated tree is an error, not a clean-looking zero', async (t) => {
+  const { dir } = makeFixture(t);
+
+  const r = run(dir, ['--tree', 'teams', '--write']);
+
+  assert.equal(r.status, 2, r.stdout);
+  assert.match(r.stderr, /names no translated content tree/);
+  assert.match(r.stderr, /Available: skills/);
+});
+
+test('--tree with no usable value is an error', async (t) => {
+  const { dir } = makeFixture(t);
+
+  for (const value of [',', ' , ']) {
+    const r = run(dir, ['--tree', value]);
+    assert.equal(r.status, 2, `'${value}' was accepted`);
+    assert.match(r.stderr, /no usable value/);
+  }
+});
+
+test('a template or README inside a tree is not a target', async (t) => {
+  // Which names count as content is decided by `contentKey` in lib/fences.js —
+  // the same function the English history index is built with — so this cannot
+  // drift from what the checker considers a file.
+  const { dir } = makeFixture(t);
+  addGuideMirror(dir);
+  for (const name of ['_template.md', 'README.md']) {
+    writeFileSync(join(dir, 'guides', name), '# Not content\n\n```bash\necho english\n```\n', 'utf8');
+    const p = join(dir, 'i18n', 'de', 'guides', name);
+    writeFileSync(p, '# Kein Inhalt\n\n```bash\necho uebersetzt\n```\n', 'utf8');
+  }
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'add a template and a README to the guides tree']);
+
+  const r = run(dir, ['--tree', 'guides', '--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /files changed: 1/);
+  for (const name of ['_template.md', 'README.md']) {
+    const after = readFileSync(join(dir, 'i18n', 'de', 'guides', name), 'utf8');
+    assert.ok(after.includes('echo uebersetzt'), `${name} was treated as content`);
+  }
+});

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -502,8 +502,69 @@ test('--tree naming no translated tree is an error, not a clean-looking zero', a
   const r = run(dir, ['--tree', 'teams', '--write']);
 
   assert.equal(r.status, 2, r.stdout);
-  assert.match(r.stderr, /names no translated content tree/);
-  assert.match(r.stderr, /Available: skills/);
+  assert.match(r.stderr, /matched no translated content/);
+  assert.match(r.stderr, /Reachable here: skills/);
+});
+
+/**
+ * A locale carrying `skills/` and nothing else — the dominant shape of the real
+ * corpus, where six of the ten locales are skills-only, and a shape no fixture
+ * had. Its absence hid two things at once: the per-locale `hasTree` guard was
+ * uncovered, and the `--locale`/`--tree` composition below was unreachable.
+ */
+function addSkillsOnlyLocale(dir) {
+  const p = join(dir, 'i18n', 'caveman', 'skills', 'demo-skill', 'SKILL.md');
+  mkdirSync(dirname(p), { recursive: true });
+  const sc = git(dir, ['rev-parse', 'HEAD']);
+  writeFileSync(p, [
+    '---', 'name: demo-skill', 'description: Demo.',
+    'locale: caveman', 'source_locale: en', `source_commit: ${sc}`, '---', '',
+    '# DEMO', '', '## STEPS', '',
+    '```bash', 'echo "UGG"', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'a skills-only locale']);
+  return p;
+}
+
+test('a locale missing a tree is skipped, not scanned into a crash', async (t) => {
+  const { dir } = makeFixture(t);
+  addGuideMirror(dir);
+  addSkillsOnlyLocale(dir);
+
+  const r = run(dir);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /i18n\/de\/guides\/quick-ref\.md/);
+  assert.match(r.stdout, /i18n\/caveman\/skills\/demo-skill\/SKILL\.md/);
+});
+
+test('--tree is validated against the SCOPED scan, not a corpus-wide union', async (t) => {
+  // `--locale caveman --tree guides` satisfied each guard on its own while
+  // neither saw the composition, and reported `files to change: 0` — the exact
+  // clean-looking zero the guard family exists to reject.
+  const { dir } = makeFixture(t);
+  addGuideMirror(dir);
+  addSkillsOnlyLocale(dir);
+
+  const r = run(dir, ['--locale', 'caveman', '--tree', 'guides', '--write']);
+
+  assert.equal(r.status, 2, r.stdout);
+  assert.match(r.stderr, /matched no translated content in locale 'caveman'/);
+  assert.match(r.stderr, /Reachable here: skills/);
+});
+
+test('the same --tree value still works for a locale that does carry it', async (t) => {
+  // The paired positive: without it the test above passes on a build that
+  // rejects every --tree value.
+  const { dir } = makeFixture(t);
+  const guide = addGuideMirror(dir);
+  addSkillsOnlyLocale(dir);
+
+  const r = run(dir, ['--locale', 'de', '--tree', 'guides', '--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.ok(readFileSync(guide, 'utf8').includes('# Count the skills'));
 });
 
 test('--tree with no usable value is an error', async (t) => {
@@ -538,4 +599,11 @@ test('a template or README inside a tree is not a target', async (t) => {
     const after = readFileSync(join(dir, 'i18n', 'de', 'guides', name), 'utf8');
     assert.ok(after.includes('echo uebersetzt'), `${name} was treated as content`);
   }
+  // Not merely unwritten — not a TARGET. Deleting the `contentKey` null-guard
+  // leaves the bytes untouched too, because the history lookup then misses and
+  // the file falls through to the unsound-mapping path. That mutant kept the
+  // whole suite green while sending a reviewer to hand-repair a template, so
+  // the report is what has to be asserted.
+  assert.doesNotMatch(r.stdout, /_template\.md/, 'a template reached the skipped list');
+  assert.doesNotMatch(r.stdout, /README\.md/, 'a README reached the skipped list');
 });

--- a/skills/translate-content/SKILL.md
+++ b/skills/translate-content/SKILL.md
@@ -156,10 +156,12 @@ npm run translate:scaffold -- <content-type> <id> <locale>
    given fence tags, which is how the #477 backlog is cleared in reviewable
    batches.
 
-   **The normalizer only repairs `skills/`.** The checker covers all four trees,
-   so an agent, team or guide translation can fail the gate and still produce
-   `files to change: 0` here — a clean-looking zero that is not a clean bill of
-   health. Repair those by hand against the English source until #477 lands.
+   The normalizer covers all four content trees — `skills`, `agents`, `teams`,
+   `guides` — so it repairs exactly what the checker flags. `-- --tree
+   guides,agents` scopes a run by tree the way `--tag` scopes it by fence tag,
+   which is how the mirror slice was cleared as its own batch (#518). A `--tree`
+   naming a tree your `--locale` carries no translations for exits 2 rather than
+   reporting a clean-looking zero.
 
    This step said "diff the fenced blocks" from the day the i18n tree was created,
    and the corpus still accumulated 1,307 violations, because reading a fence and


### PR DESCRIPTION
Clears the `agents`/`teams`/`guides` mirror slice of #477 — **the last mechanically-repairable part of the fence backlog.**

> ⚠️ **Conflicts with #512.** Both PRs edit `scripts/normalize-i18n-fences.js` and its test file. I tested the merge rather than assuming — it does not auto-resolve. Whichever lands first, I will rebase the other; I wrote both sides, so the resolution is mechanical. See the note at the bottom.

## The gap

The normalizer was skills-only while `check-i18n-fence-parity.js` covered all four content trees, so 87 of the 335 gated violations were flagged by one tool and unreachable by the other.

## The fix

Paths differ by tree — `skills/<id>/SKILL.md` against `<tree>/<id>.md` — and which names count as content is now decided by `contentKey` from `lib/fences.js`, the same function `buildEnglishFenceHistory` keys on.

That matters more than it looks. The history lookup was `history.get('skills/' + t.skill)` — a hand-built key that only *happened* to agree with `contentKey`'s output for the skills tree. Deriving both from one function is what stops `_template.md`, `README.md` and `_registry.yml` needing a second exclusion list here that could drift from the checker's.

Adds `--tree`, which scopes a run the way `--tag` does. Validated against the trees the repository **actually carries**, not against the `TREES` constant: a value naming a real tree the corpus has no translations for would otherwise produce the clean-looking zero `--locale` and `--tag` already guard against. `--tree teams` exits 2 here, because no team translation carries a divergence.

## The repair

```
normalize-i18n-fences.js --tree guides,agents,teams --write
  11 files, 87 fences    de=22  es=22  zh-CN=22  ja=21

  i18n/{de,es,ja,zh-CN}/guides/quick-reference.md   19 each
  i18n/{de,es,ja,zh-CN}/agents/r-developer.md        2 each
  i18n/{de,es,zh-CN}/agents/contemplative.md         1 each
```

All 87 are translated comments inside frozen fences — `# Die Skills zaehlen` back to `# Count the skills`, `# 线性混合效应模型` back to `# Linear mixed-effects model`. The diff is 341 lines each way and every one sits inside a gated fence: no prose, no headings, no frontmatter.

Restored from each translation's own `source_commit`, so nothing is entangled with the separate staleness backlog (#278).

## Measured

| | before | after |
|---|---:|---:|
| gated-fence violations | 335 | **248** |
| files | 75 | **64** |

Exactly the 87 fences and 11 files the checker attributed to the mirrors. The remaining 248 are the parked sets registered in #501 — the regulated carve-out, the #478/#483 ordinal-unsound files, and the #476-blocked mirrors. **Nothing mechanically repairable remains.**

## Tests

Five new, 29 total in the suite. Including that a guide's translated **prose and frontmatter survive** while only its frozen fence is restored — the failure mode that would matter most here — and that a `_template.md` dropped into a tree is not treated as content.

## On the conflict with #512

#512 adds the step-correspondence (fork) guard to the same file. This branch does **not** carry that guard, so these 87 fences were restored without it. That is acceptable for this slice and worth stating plainly: all 11 files pass the fence-count and tag-sequence soundness checks, and the diff was read — every change is a comment inside a fence, which is the shape a fork detector exists to distinguish *from*. Once both land, mirror batches get the guard automatically.