### PR TITLE
feat(i18n): gate that a yaml fence is actually YAML, and fix the six it found (#507)

### DIFF
--- a/.github/workflows/validate-content-style.yml
+++ b/.github/workflows/validate-content-style.yml
@@ -10,6 +10,7 @@ on:
       - 'guides/**'
       - 'i18n/**'
       - 'scripts/check-yaml-fences.js'
+      - '.github/workflows/validate-content-style.yml'
   pull_request:
     paths:
       - 'skills/**'
@@ -18,6 +19,7 @@ on:
       - 'guides/**'
       - 'i18n/**'
       - 'scripts/check-yaml-fences.js'
+      - '.github/workflows/validate-content-style.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/validate-content-style.yml
+++ b/.github/workflows/validate-content-style.yml
@@ -3,9 +3,21 @@ name: Validate Content Style
 on:
   push:
     branches: [main]
-    paths: ['skills/**', 'agents/**', 'teams/**', 'guides/**', 'i18n/**']
+    paths:
+      - 'skills/**'
+      - 'agents/**'
+      - 'teams/**'
+      - 'guides/**'
+      - 'i18n/**'
+      - 'scripts/check-yaml-fences.js'
   pull_request:
-    paths: ['skills/**', 'agents/**', 'teams/**', 'guides/**', 'i18n/**']
+    paths:
+      - 'skills/**'
+      - 'agents/**'
+      - 'teams/**'
+      - 'guides/**'
+      - 'i18n/**'
+      - 'scripts/check-yaml-fences.js'
   workflow_dispatch:
 
 permissions:
@@ -36,3 +48,19 @@ jobs:
       - name: Repo-wide scan (informational)
         if: github.event_name != 'pull_request'
         run: node scripts/check-content-style.js --all
+
+  # Blocking, and repo-wide rather than added-lines-only: the corpus is at zero
+  # (#507), so there is no legacy backlog to grandfather, and a fence tagged
+  # `yaml` that is not YAML freezes content into ten locales that should have
+  # stayed translatable. Its own job because it needs `npm ci` for js-yaml,
+  # which the style job does not.
+  yaml-fences:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run validate:yaml-fences

--- a/i18n/caveman-lite/skills/escalate-issues/SKILL.md
+++ b/i18n/caveman-lite/skills/escalate-issues/SKILL.md
@@ -196,6 +196,10 @@ def route_issue(severity, issue_type):
 Generate a formatted report suitable for the target audience (agent or human).
 
 **For Specialist Agents** (structured format for MCP tools):
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -204,8 +208,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/caveman-lite/skills/escalate-issues/SKILL.md
+++ b/i18n/caveman-lite/skills/escalate-issues/SKILL.md
@@ -197,14 +197,17 @@ Generate a formatted report suitable for the target audience (agent or human).
 
 **For Specialist Agents** (structured format for MCP tools):
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/caveman-lite/skills/render-publication-graphic/SKILL.md
+++ b/i18n/caveman-lite/skills/render-publication-graphic/SKILL.md
@@ -53,7 +53,7 @@ Produce publication-ready graphics that meet technical requirements for academic
 
 Identify technical specifications for target publication:
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/caveman-lite/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/caveman-lite/skills/troubleshoot-print-issues/SKILL.md
@@ -196,7 +196,7 @@ Implement immediate solutions for common issues:
 ```
 
 **Retraction tuning**:
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -249,7 +249,7 @@ jerk: 8mm/s (from 15)
 ### Warping
 
 **Thermal management**:
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -309,7 +309,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Over-Extrusion
 
 **Flow rate reduction**:
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/caveman-lite/skills/write-helm-chart/SKILL.md
+++ b/i18n/caveman-lite/skills/write-helm-chart/SKILL.md
@@ -338,10 +338,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/i18n/caveman-ultra/skills/escalate-issues/SKILL.md
+++ b/i18n/caveman-ultra/skills/escalate-issues/SKILL.md
@@ -197,14 +197,17 @@ Formatted for target audience.
 
 **Specialist Agents** (structured for MCP):
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/caveman-ultra/skills/escalate-issues/SKILL.md
+++ b/i18n/caveman-ultra/skills/escalate-issues/SKILL.md
@@ -196,6 +196,10 @@ If err: no clear specialist → human for manual route.
 Formatted for target audience.
 
 **Specialist Agents** (structured for MCP):
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -204,8 +208,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/caveman-ultra/skills/render-publication-graphic/SKILL.md
+++ b/i18n/caveman-ultra/skills/render-publication-graphic/SKILL.md
@@ -51,7 +51,7 @@ Produce pub-ready graphics meeting tech req for journals, books, presentations, 
 
 ID tech specs for target pub:
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/caveman-ultra/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/caveman-ultra/skills/troubleshoot-print-issues/SKILL.md
@@ -194,7 +194,7 @@ Root cause: Material choice (ABS) incompatible with open printer in drafty room
 ```
 
 **Retraction**:
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -247,7 +247,7 @@ jerk: 8mm/s (from 15)
 ### Warping
 
 **Thermal**:
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -307,7 +307,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Over-Extrusion
 
 **Flow reduction**:
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/caveman-ultra/skills/write-helm-chart/SKILL.md
+++ b/i18n/caveman-ultra/skills/write-helm-chart/SKILL.md
@@ -338,10 +338,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/i18n/caveman/skills/escalate-issues/SKILL.md
+++ b/i18n/caveman/skills/escalate-issues/SKILL.md
@@ -196,6 +196,10 @@ def route_issue(severity, issue_type):
 Make report matched to target (agent or human).
 
 **For Specialist Agents** (structured format for MCP tools):
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -204,8 +208,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/caveman/skills/escalate-issues/SKILL.md
+++ b/i18n/caveman/skills/escalate-issues/SKILL.md
@@ -197,14 +197,17 @@ Make report matched to target (agent or human).
 
 **For Specialist Agents** (structured format for MCP tools):
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/caveman/skills/render-publication-graphic/SKILL.md
+++ b/i18n/caveman/skills/render-publication-graphic/SKILL.md
@@ -53,7 +53,7 @@ Produce publication-ready graphics that meet technical requirements for academic
 
 ID technical specs for target publication:
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/caveman/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/caveman/skills/troubleshoot-print-issues/SKILL.md
@@ -194,7 +194,7 @@ Implement immediate solutions for common issues:
 ```
 
 **Retraction tuning**:
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -247,7 +247,7 @@ jerk: 8mm/s (from 15)
 ### Warping
 
 **Thermal management**:
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -307,7 +307,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Over-Extrusion
 
 **Flow rate reduction**:
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/caveman/skills/write-helm-chart/SKILL.md
+++ b/i18n/caveman/skills/write-helm-chart/SKILL.md
@@ -338,10 +338,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/i18n/de/skills/escalate-issues/SKILL.md
+++ b/i18n/de/skills/escalate-issues/SKILL.md
@@ -198,6 +198,10 @@ def route_issue(severity, issue_type):
 Einen formatierten Bericht erstellen der fuer die Zielgruppe geeignet ist (Agent oder Mensch).
 
 **Fuer Spezialisten-Agenten** (strukturiertes Format fuer MCP-Tools):
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -206,8 +210,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/de/skills/escalate-issues/SKILL.md
+++ b/i18n/de/skills/escalate-issues/SKILL.md
@@ -199,14 +199,17 @@ Einen formatierten Bericht erstellen der fuer die Zielgruppe geeignet ist (Agent
 
 **Fuer Spezialisten-Agenten** (strukturiertes Format fuer MCP-Tools):
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/de/skills/render-publication-graphic/SKILL.md
+++ b/i18n/de/skills/render-publication-graphic/SKILL.md
@@ -54,7 +54,7 @@ Publikationsfertige Grafiken erzeugen die technische Anforderungen fuer akademis
 
 Technische Spezifikationen fuer die Zielpublikation identifizieren:
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/de/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/de/skills/troubleshoot-print-issues/SKILL.md
@@ -196,7 +196,7 @@ Sofortloesungen fuer gaengige Probleme umsetzen:
 ```
 
 **Einzugs-Tuning**:
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -249,7 +249,7 @@ jerk: 8mm/s (from 15)
 ### Verzug
 
 **Waermemanagement**:
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -309,7 +309,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Ueberextrusion
 
 **Durchflussraten-Reduzierung**:
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/de/skills/write-helm-chart/SKILL.md
+++ b/i18n/de/skills/write-helm-chart/SKILL.md
@@ -340,10 +340,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/i18n/es/skills/escalate-issues/SKILL.md
+++ b/i18n/es/skills/escalate-issues/SKILL.md
@@ -196,6 +196,10 @@ def route_issue(severity, issue_type):
 Generate a formatted report suitable for the target audience (agent or human).
 
 **For Specialist Agents** (structured format for MCP tools):
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -204,8 +208,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/es/skills/escalate-issues/SKILL.md
+++ b/i18n/es/skills/escalate-issues/SKILL.md
@@ -197,14 +197,17 @@ Generate a formatted report suitable for the target audience (agent or human).
 
 **For Specialist Agents** (structured format for MCP tools):
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/es/skills/render-publication-graphic/SKILL.md
+++ b/i18n/es/skills/render-publication-graphic/SKILL.md
@@ -53,7 +53,7 @@ Produce publication-ready graphics that meet technical requirements for academic
 
 Identify technical specifications for target publication:
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/es/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/es/skills/troubleshoot-print-issues/SKILL.md
@@ -196,7 +196,7 @@ Implementar soluciones inmediatas para problemas comunes:
 ```
 
 **Ajuste de retracción**:
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -249,7 +249,7 @@ jerk: 8mm/s (from 15)
 ### Deformación (Warping)
 
 **Gestión térmica**:
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -309,7 +309,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Sobre-Extrusión
 
 **Reducción de tasa de flujo**:
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/es/skills/write-helm-chart/SKILL.md
+++ b/i18n/es/skills/write-helm-chart/SKILL.md
@@ -338,10 +338,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/i18n/ja/skills/escalate-issues/SKILL.md
+++ b/i18n/ja/skills/escalate-issues/SKILL.md
@@ -196,6 +196,10 @@ def route_issue(severity, issue_type):
 ターゲットオーディエンス（エージェントまたは人間）に適したフォーマットのレポートを生成する。
 
 **専門エージェント向け**（MCPツール用の構造化フォーマット）：
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -204,8 +208,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/ja/skills/escalate-issues/SKILL.md
+++ b/i18n/ja/skills/escalate-issues/SKILL.md
@@ -197,14 +197,17 @@ def route_issue(severity, issue_type):
 
 **専門エージェント向け**（MCPツール用の構造化フォーマット）：
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/ja/skills/render-publication-graphic/SKILL.md
+++ b/i18n/ja/skills/render-publication-graphic/SKILL.md
@@ -53,7 +53,7 @@ Produce publication-ready graphics that meet technical requirements for academic
 
 Identify technical specifications for target publication:
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/ja/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/ja/skills/troubleshoot-print-issues/SKILL.md
@@ -196,7 +196,7 @@ Implement immediate solutions for common issues:
 ```
 
 **Retraction tuning**:
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -249,7 +249,7 @@ jerk: 8mm/s (from 15)
 ### Warping
 
 **Thermal management**:
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -309,7 +309,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Over-Extrusion
 
 **Flow rate reduction**:
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/ja/skills/write-helm-chart/SKILL.md
+++ b/i18n/ja/skills/write-helm-chart/SKILL.md
@@ -338,10 +338,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/i18n/wenyan-lite/skills/escalate-issues/SKILL.md
+++ b/i18n/wenyan-lite/skills/escalate-issues/SKILL.md
@@ -196,6 +196,10 @@ def route_issue(severity, issue_type):
 生合於目標對象（代理或人）之格式化報告。
 
 **予專家代理**（MCP 工具之結構式格式）：
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -204,8 +208,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/wenyan-lite/skills/escalate-issues/SKILL.md
+++ b/i18n/wenyan-lite/skills/escalate-issues/SKILL.md
@@ -197,14 +197,17 @@ def route_issue(severity, issue_type):
 
 **予專家代理**（MCP 工具之結構式格式）：
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/wenyan-lite/skills/render-publication-graphic/SKILL.md
+++ b/i18n/wenyan-lite/skills/render-publication-graphic/SKILL.md
@@ -53,7 +53,7 @@ metadata:
 
 辨識目標出版之技術規範：
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/wenyan-lite/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/wenyan-lite/skills/troubleshoot-print-issues/SKILL.md
@@ -196,7 +196,7 @@ Root cause: Material choice (ABS) incompatible with open printer in drafty room
 ```
 
 **回抽調整**：
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -249,7 +249,7 @@ jerk: 8mm/s (from 15)
 ### 翹曲
 
 **熱管理**：
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -309,7 +309,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### 過擠出
 
 **降流速**：
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/wenyan-lite/skills/write-helm-chart/SKILL.md
+++ b/i18n/wenyan-lite/skills/write-helm-chart/SKILL.md
@@ -338,10 +338,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/i18n/wenyan-ultra/skills/escalate-issues/SKILL.md
+++ b/i18n/wenyan-ultra/skills/escalate-issues/SKILL.md
@@ -197,14 +197,17 @@ def route_issue(severity, issue_type):
 
 **予專 agent**（MCP 工具之結構）：
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/wenyan-ultra/skills/escalate-issues/SKILL.md
+++ b/i18n/wenyan-ultra/skills/escalate-issues/SKILL.md
@@ -196,6 +196,10 @@ def route_issue(severity, issue_type):
 生適標眾之格式報（agent 或人）。
 
 **予專 agent**（MCP 工具之結構）：
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -204,8 +208,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/wenyan-ultra/skills/render-publication-graphic/SKILL.md
+++ b/i18n/wenyan-ultra/skills/render-publication-graphic/SKILL.md
@@ -53,7 +53,7 @@ metadata:
 
 識標發之技規：
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/wenyan-ultra/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/wenyan-ultra/skills/troubleshoot-print-issues/SKILL.md
@@ -194,7 +194,7 @@ Root cause: Material choice (ABS) incompatible with open printer in drafty room
 ```
 
 **抽調**：
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -247,7 +247,7 @@ jerk: 8mm/s (from 15)
 #### 翹
 
 **熱管**：
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -307,7 +307,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 #### 過擠
 
 **減流**：
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/wenyan-ultra/skills/write-helm-chart/SKILL.md
+++ b/i18n/wenyan-ultra/skills/write-helm-chart/SKILL.md
@@ -338,10 +338,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/i18n/wenyan/skills/escalate-issues/SKILL.md
+++ b/i18n/wenyan/skills/escalate-issues/SKILL.md
@@ -196,6 +196,10 @@ def route_issue(severity, issue_type):
 生合受者（員或人）之式之報。
 
 **於員**（MCP 工具之結構式）：
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -204,8 +208,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/wenyan/skills/escalate-issues/SKILL.md
+++ b/i18n/wenyan/skills/escalate-issues/SKILL.md
@@ -197,14 +197,17 @@ def route_issue(severity, issue_type):
 
 **於員**（MCP 工具之結構式）：
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/wenyan/skills/render-publication-graphic/SKILL.md
+++ b/i18n/wenyan/skills/render-publication-graphic/SKILL.md
@@ -53,7 +53,7 @@ metadata:
 
 識目示之技規：
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/wenyan/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/wenyan/skills/troubleshoot-print-issues/SKILL.md
@@ -196,7 +196,7 @@ Root cause: Material choice (ABS) incompatible with open printer in drafty room
 ```
 
 **回抽之調**：
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -249,7 +249,7 @@ jerk: 8mm/s (from 15)
 ### 翹曲
 
 **熱之治**：
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -309,7 +309,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### 出料過剩
 
 **減流**：
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/wenyan/skills/write-helm-chart/SKILL.md
+++ b/i18n/wenyan/skills/write-helm-chart/SKILL.md
@@ -338,10 +338,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/i18n/zh-CN/skills/escalate-issues/SKILL.md
+++ b/i18n/zh-CN/skills/escalate-issues/SKILL.md
@@ -195,14 +195,17 @@ def route_issue(severity, issue_type):
 
 **面向专家代理**（MCP 工具的结构化格式）：
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45

--- a/i18n/zh-CN/skills/escalate-issues/SKILL.md
+++ b/i18n/zh-CN/skills/escalate-issues/SKILL.md
@@ -194,6 +194,10 @@ def route_issue(severity, issue_type):
 生成适合目标受众（代理或人工）的格式化报告。
 
 **面向专家代理**（MCP 工具的结构化格式）：
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
+
 ```yaml
 type: escalation
 severity: high
@@ -202,8 +206,6 @@ to_agent: security-analyst
 blocking: false
 ```
 
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/i18n/zh-CN/skills/render-publication-graphic/SKILL.md
+++ b/i18n/zh-CN/skills/render-publication-graphic/SKILL.md
@@ -53,7 +53,7 @@ Produce publication-ready graphics that meet technical requirements for academic
 
 Identify technical specifications for target publication:
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/i18n/zh-CN/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/zh-CN/skills/troubleshoot-print-issues/SKILL.md
@@ -196,7 +196,7 @@ Implement immediate solutions for common issues:
 ```
 
 **Retraction tuning**:
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -249,7 +249,7 @@ jerk: 8mm/s (from 15)
 ### Warping
 
 **Thermal management**:
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -309,7 +309,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Over-Extrusion
 
 **Flow rate reduction**:
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/i18n/zh-CN/skills/write-helm-chart/SKILL.md
+++ b/i18n/zh-CN/skills/write-helm-chart/SKILL.md
@@ -338,10 +338,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "validate:translations": "node scripts/check-translation-freshness.js",
     "validate:i18n-parity": "node scripts/check-i18n-frontmatter-parity.js",
     "validate:i18n-fences": "node scripts/check-i18n-fence-parity.js",
+    "validate:yaml-fences": "node scripts/check-yaml-fences.js",
     "check:placeholder-drift": "node scripts/check-placeholder-drift.js",
     "normalize:i18n-fences": "node scripts/normalize-i18n-fences.js",
     "validate:content-style": "node scripts/check-content-style.js --all",

--- a/scripts/check-yaml-fences.js
+++ b/scripts/check-yaml-fences.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * check-yaml-fences.js
+ *
+ * Every ```yaml fence in English content must parse as YAML (#507).
+ *
+ * ## Why this is a gate and not a style preference
+ *
+ * #472 freezes a fence by its TAG: everything between the delimiters is either
+ * frozen to English or localisable, and `yaml` is frozen. That is the right
+ * answer for a machine-consumed document and the wrong one for a reference table
+ * a human reads, and the tag is the only thing distinguishing them — so a
+ * mislabelled fence quietly freezes content that should have been translatable.
+ *
+ * `skills/escalate-issues/SKILL.md` carried a `yaml` fence holding a routing
+ * header AND the markdown incident report beneath it. The German translation had
+ * that report in German; #508 restored it to English, correctly per the rule,
+ * and the surrounding German prose still told the reader to write one.
+ *
+ * What turns that from a judgement call into a decidable one is that the fence
+ * **was not YAML**. `js-yaml` rejects it at the `---` separating the header from
+ * the prose. Three fences in `troubleshoot-print-issues` and one in
+ * `render-publication-graphic` were the same shape — printer settings and
+ * publication requirements written with ranges (`1.0-2.0mm`), arrows
+ * (`0.98 → 0.96`) and bullet lists, which is a reference table, not a config.
+ *
+ * So the rule is: if it is tagged `yaml`, it parses. If it does not parse, it is
+ * either broken YAML or it is not YAML, and both need fixing at the source rather
+ * than being frozen into ten locales.
+ *
+ * This is also what keeps retagging honest. CLAUDE.md names retagging a `yaml`
+ * fence to `text` as the way the freeze's scope could be edited from inside the
+ * gated file. Correcting a mislabel is not that — but the two are only
+ * distinguishable if something checks which fences are genuinely YAML, and this
+ * is that something.
+ *
+ * ## Exemptions are by ERROR CLASS, not by location
+ *
+ * Two shapes legitimately do not parse, and both are named here with the reason:
+ *
+ * - **Go templates.** `write-helm-chart` shows Helm chart sources, which are Go
+ *   templates that happen to produce YAML. `{{- if .Values… }}` is not YAML and
+ *   is not meant to be.
+ * - **Duplicate-key illustrations.** A good-versus-bad pair in one fence is a
+ *   documented idiom in this corpus's guides, and duplicate keys are exactly what
+ *   makes the bad half bad.
+ *
+ * Pinning exemptions to `file:line` would rot on the first edit above them, and a
+ * rotted exemption either fails a clean file or silently covers a new defect.
+ * Keying on the error class costs some precision — an accidental duplicate key in
+ * a real config example would pass — and buys an exemption list that cannot drift
+ * out of date. Every exempted fence is REPORTED rather than skipped silently, so
+ * the set stays visible and a reviewer can see it grow.
+ *
+ * Scope: English content only. English is canonical, and a translated `yaml`
+ * fence that diverges from it is `check-i18n-fence-parity.js`'s business.
+ *
+ * Usage:
+ *   node scripts/check-yaml-fences.js
+ *   node scripts/check-yaml-fences.js --json
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { resolve, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import * as yaml from 'js-yaml';
+import { extractFences, TREES, contentKey } from './lib/fences.js';
+
+const argv = process.argv.slice(2);
+let JSON_OUT = false;
+let rootArg = null;
+for (let i = 0; i < argv.length; i++) {
+  const arg = argv[i];
+  const eq = arg.indexOf('=');
+  const name = eq >= 0 ? arg.slice(0, eq) : arg;
+  if (name === '--json') {
+    JSON_OUT = true;
+  } else if (name === '--root') {
+    // Read-only, and the reason this file is testable at all: the checks need a
+    // corpus to run against, while `js-yaml` has to resolve from the repository
+    // that installed it. Pointing the real script at a fixture tree separates
+    // those, where copying the script into a throwaway repo could not.
+    rootArg = eq >= 0 ? arg.slice(eq + 1) : argv[++i];
+    if (rootArg === undefined || rootArg === '' || rootArg.startsWith('--')) {
+      console.error('ERROR: --root requires a value');
+      process.exit(2);
+    }
+  } else {
+    console.error(`ERROR: unknown argument '${arg}'`);
+    process.exit(2);
+  }
+}
+
+const ROOT = rootArg
+  ? resolve(rootArg)
+  : resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+if (!existsSync(ROOT) || !statSync(ROOT).isDirectory()) {
+  console.error(`ERROR: --root is not a directory: '${ROOT}'`);
+  process.exit(2);
+}
+
+/** Every English content file the checker also covers. */
+function englishFiles() {
+  const out = [];
+  for (const tree of TREES) {
+    const base = join(ROOT, tree);
+    if (!existsSync(base)) continue;
+    for (const entry of readdirSync(base)) {
+      const rel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
+      if (contentKey(rel) === null) continue;
+      const abs = join(ROOT, rel);
+      if (!existsSync(abs) || !statSync(abs).isFile()) continue;
+      out.push(rel);
+    }
+  }
+  return out.sort();
+}
+
+/**
+ * Why a fence that does not parse is allowed to. Returns null when it is not.
+ * Order matters only for reporting; the two classes do not overlap in practice.
+ */
+function exemption(body, message) {
+  if (/\{\{.*\}\}/s.test(body)) return 'go-template';
+  if (/duplicated mapping key/i.test(message)) return 'duplicate-key-illustration';
+  return null;
+}
+
+const failures = [];
+const exempted = [];
+let checked = 0;
+
+for (const rel of englishFiles()) {
+  const text = readFileSync(join(ROOT, rel), 'utf8');
+  for (const f of extractFences(text)) {
+    if (f.lang !== 'yaml' && f.lang !== 'yml') continue;
+    checked += 1;
+    try {
+      // `loadAll`, not `load`: a multi-document fence is legal YAML and must not
+      // be reported as broken.
+      yaml.loadAll(f.body);
+    } catch (e) {
+      const message = String(e.message).split('\n')[0];
+      const why = exemption(f.body, message);
+      const hit = { file: rel, line: f.line, message: message.slice(0, 120) };
+      if (why) exempted.push({ ...hit, exemption: why });
+      else failures.push(hit);
+    }
+  }
+}
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({ checked, failures, exempted }, null, 2));
+  process.exit(failures.length ? 1 : 0);
+}
+
+console.log(`yaml fences checked: ${checked}`);
+// Reported, never skipped silently: an exemption list nobody can see is one
+// nobody notices growing.
+if (exempted.length) {
+  const byClass = new Map();
+  for (const e of exempted) byClass.set(e.exemption, (byClass.get(e.exemption) || 0) + 1);
+  console.log(`exempted: ${exempted.length}  (${[...byClass.entries()].map(([k, v]) => `${k}=${v}`).join('  ')})`);
+  for (const e of exempted) console.log(`  ${e.file}:${e.line}  [${e.exemption}]`);
+}
+
+if (failures.length === 0) {
+  console.log('\nOK: every yaml-tagged fence parses, or is an exempted class.');
+  process.exit(0);
+}
+
+console.log(`\n${failures.length} yaml-tagged fence(s) do not parse:`);
+for (const f of failures) {
+  console.log(`  ${f.file}:${f.line}`);
+  console.log(`      ${f.message}`);
+}
+console.log('');
+console.log('A fence tagged `yaml` is frozen to English by #472, so a mislabelled one');
+console.log('freezes content that should have been translatable. Either fix the YAML, or');
+console.log('— if it is a reference table a human reads rather than a machine — retag it');
+console.log('`text` and let translators localise it.');
+process.exit(1);

--- a/scripts/check-yaml-fences.js
+++ b/scripts/check-yaml-fences.js
@@ -2,7 +2,7 @@
 /**
  * check-yaml-fences.js
  *
- * Every ```yaml fence in English content must parse as YAML (#507).
+ * Every ```yaml fence in the corpus must parse as YAML (#507).
  *
  * ## Why this is a gate and not a style preference
  *
@@ -34,30 +34,46 @@
  * distinguishable if something checks which fences are genuinely YAML, and this
  * is that something.
  *
- * ## Exemptions are by ERROR CLASS, not by location
+ * ## Exemptions are decided by the ERROR, never by the file or the body
  *
- * Two shapes legitimately do not parse, and both are named here with the reason:
+ * Three shapes legitimately do not parse, each named with its reason:
  *
  * - **Go templates.** `write-helm-chart` shows Helm chart sources, which are Go
  *   templates that happen to produce YAML. `{{- if .Values… }}` is not YAML and
- *   is not meant to be.
+ *   is not meant to be. Recognised by the error landing ON a `{{ … }}` line.
  * - **Duplicate-key illustrations.** A good-versus-bad pair in one fence is a
  *   documented idiom in this corpus's guides, and duplicate keys are exactly what
  *   makes the bad half bad.
+ * - **Tags this parser's schema lacks.** js-yaml 5's DEFAULT_SCHEMA implements no
+ *   custom tags, so CloudFormation shorthand (`!Ref`) and even core `!!binary`
+ *   are rejected. That is the parser, not the document.
  *
  * Pinning exemptions to `file:line` would rot on the first edit above them, and a
  * rotted exemption either fails a clean file or silently covers a new defect.
- * Keying on the error class costs some precision — an accidental duplicate key in
- * a real config example would pass — and buys an exemption list that cannot drift
- * out of date. Every exempted fence is REPORTED rather than skipped silently, so
- * the set stays visible and a reviewer can see it grow.
+ * Keying on the error costs some precision — an accidental duplicate key in a
+ * real config example would pass — and buys a list that cannot drift out of date.
+ * Every exempted fence is REPORTED rather than skipped silently, so the set stays
+ * visible and a reviewer can see it grow.
  *
- * Scope: English content only. English is canonical, and a translated `yaml`
- * fence that diverges from it is `check-i18n-fence-parity.js`'s business.
+ * The Go-template test is on the error's own LINE, and that distinction is the
+ * whole of it. Testing the body for `{{ }}` anywhere reads as "is this a
+ * template?" and means "does this fence contain two braces?" — it matched 24 of
+ * 331 English fences where only 4 are Helm sources, forgiving every parse error
+ * in twenty valid GitHub Actions and Prometheus documents. Those are the MOST
+ * machine-consumed fences in the corpus.
+ *
+ * ## Scope: English and its mirrors
+ *
+ * Scoping this to English was the first version, and the first run of this gate
+ * disproved it: a genuine fix to `write-helm-chart` was applied to English and to
+ * none of its ten mirrors, all of which still failed to parse. Nothing else could
+ * report them — `check-i18n-fence-parity.js` accepts a translated body matching
+ * ANY historical English revision, and a stale broken body is exactly that.
  *
  * Usage:
  *   node scripts/check-yaml-fences.js
  *   node scripts/check-yaml-fences.js --json
+ *   node scripts/check-yaml-fences.js --root <dir>   # for tests
  */
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
@@ -100,18 +116,47 @@ if (!existsSync(ROOT) || !statSync(ROOT).isDirectory()) {
   process.exit(2);
 }
 
-/** Every English content file the checker also covers. */
-function englishFiles() {
+/**
+ * Every content file under one root: the four trees, `_`-prefixed ids skipped
+ * the way `buildEnglishFenceHistory` skips them.
+ */
+function contentFiles(base, prefix = '') {
   const out = [];
   for (const tree of TREES) {
-    const base = join(ROOT, tree);
-    if (!existsSync(base)) continue;
-    for (const entry of readdirSync(base)) {
+    const dir = join(base, tree);
+    if (!existsSync(dir) || !statSync(dir).isDirectory()) continue;
+    for (const entry of readdirSync(dir)) {
+      if (entry.startsWith('_')) continue;
       const rel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
       if (contentKey(rel) === null) continue;
-      const abs = join(ROOT, rel);
+      const abs = join(base, rel);
       if (!existsSync(abs) || !statSync(abs).isFile()) continue;
-      out.push(rel);
+      out.push(prefix + rel);
+    }
+  }
+  return out;
+}
+
+/**
+ * English AND its locale mirrors.
+ *
+ * Scoping this to English was wrong, and the first run of this very gate proved
+ * it: the orphaned-`tls:` fix in `write-helm-chart` was applied to English and
+ * to none of its ten mirrors, which all still failed to parse. Nothing else
+ * could report them — `check-i18n-fence-parity.js` accepts a translated body
+ * matching ANY historical English revision, and a stale broken body is exactly
+ * that, so it is excused forever.
+ *
+ * A frozen fence is a copy of English, so this costs nothing while the copy is
+ * faithful, and names the file when it is not.
+ */
+function allFiles() {
+  const out = contentFiles(ROOT);
+  const i18n = join(ROOT, 'i18n');
+  if (existsSync(i18n) && statSync(i18n).isDirectory()) {
+    for (const loc of readdirSync(i18n)) {
+      if (!statSync(join(i18n, loc)).isDirectory()) continue;
+      out.push(...contentFiles(join(i18n, loc), `i18n/${loc}/`));
     }
   }
   return out.sort();
@@ -119,11 +164,31 @@ function englishFiles() {
 
 /**
  * Why a fence that does not parse is allowed to. Returns null when it is not.
- * Order matters only for reporting; the two classes do not overlap in practice.
+ *
+ * Every test here is on the ERROR, never on the body. The first version tested
+ * `/\{\{.*\}\}/s` against the whole body, which reads as "is this a template?"
+ * and actually means "does this fence contain two braces anywhere?" — matching
+ * 24 of 331 English fences, of which only 4 are Helm sources. The other 20 are
+ * valid GitHub Actions (`${{ matrix.config.os }}`) and Prometheus YAML, i.e.
+ * precisely the fences that ARE machine-consumed, and for all 24 any parse error
+ * whatsoever was forgiven. Two fences differing only by a `${{ }}` expression,
+ * both carrying the orphaned-`tls:` defect this gate was built to catch, were
+ * reported `exempted` and `failing` respectively.
+ *
+ * Keying on the reported line fixes it without losing the real templates: all
+ * four genuine Helm errors land ON a `{{ … }}` line, and a broken workflow's
+ * error does not.
  */
-function exemption(body, message) {
-  if (/\{\{.*\}\}/s.test(body)) return 'go-template';
+function exemption(bodyLines, message, mark) {
+  const errorLine = mark && Number.isInteger(mark.line) ? bodyLines[mark.line] : undefined;
+  if (errorLine !== undefined && /\{\{|\}\}/.test(errorLine)) return 'go-template';
   if (/duplicated mapping key/i.test(message)) return 'duplicate-key-illustration';
+  // js-yaml 5's DEFAULT_SCHEMA implements no custom tags, so CloudFormation
+  // shorthand (`!Ref`) and even core `!!binary` are rejected. That is the
+  // parser's schema, not the document being un-YAML, and the remedy this gate
+  // prints — retag to `text` — would be exactly the freeze-scope edit CLAUDE.md
+  // warns about if applied to one of those.
+  if (/unknown .*tag/i.test(message)) return 'unsupported-tag-schema';
   return null;
 }
 
@@ -131,7 +196,17 @@ const failures = [];
 const exempted = [];
 let checked = 0;
 
-for (const rel of englishFiles()) {
+const files = allFiles();
+// A root with no content trees checks nothing and would print a clean line.
+// `existsSync` + `isDirectory` is a proxy for the question; membership in the
+// scan's own output is the question.
+if (files.length === 0) {
+  console.error(`ERROR: no content trees (${TREES.join(', ')}) under '${ROOT}'`);
+  console.error('Nothing would be checked, and the run would report a clean-looking zero.');
+  process.exit(2);
+}
+
+for (const rel of files) {
   const text = readFileSync(join(ROOT, rel), 'utf8');
   for (const f of extractFences(text)) {
     if (f.lang !== 'yaml' && f.lang !== 'yml') continue;
@@ -142,7 +217,7 @@ for (const rel of englishFiles()) {
       yaml.loadAll(f.body);
     } catch (e) {
       const message = String(e.message).split('\n')[0];
-      const why = exemption(f.body, message);
+      const why = exemption(f.body.split('\n'), message, e.mark);
       const hit = { file: rel, line: f.line, message: message.slice(0, 120) };
       if (why) exempted.push({ ...hit, exemption: why });
       else failures.push(hit);
@@ -177,7 +252,10 @@ for (const f of failures) {
 }
 console.log('');
 console.log('A fence tagged `yaml` is frozen to English by #472, so a mislabelled one');
-console.log('freezes content that should have been translatable. Either fix the YAML, or');
-console.log('— if it is a reference table a human reads rather than a machine — retag it');
-console.log('`text` and let translators localise it.');
+console.log('freezes content that should have been translatable.');
+console.log('');
+console.log('If the fence IS machine-consumed, fix the YAML. That is the default, and');
+console.log('retagging it `text` would be the freeze-scope edit CLAUDE.md warns against.');
+console.log('Retag only when the body is a reference table a human reads rather than a');
+console.log('machine: prose values, ranges, or bullet lists where a parser expects data.');
 process.exit(1);

--- a/scripts/test/check-yaml-fences.test.js
+++ b/scripts/test/check-yaml-fences.test.js
@@ -1,0 +1,235 @@
+/**
+ * Tests for `scripts/check-yaml-fences.js` (#507).
+ *
+ * The gate's whole value is that it decides a question that used to need
+ * judgement: a fence tagged `yaml` is frozen to English by #472, so a
+ * MISLABELLED one silently freezes content that should have been translatable.
+ * If it does not parse, it is either broken YAML or it is not YAML.
+ *
+ * Every fixture below is the shape of something the first corpus run actually
+ * found, so the suite pins the classification rather than an invented one.
+ *
+ * Runs the real script with `--root` pointed at a throwaway tree. Copying the
+ * script into the tree instead would not work: it imports `js-yaml`, which
+ * resolves only from the repository that installed it.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = join(REPO, 'scripts', 'check-yaml-fences.js');
+
+/** A corpus of one skill, whose SKILL.md is `body`. */
+function corpus(t, body) {
+  const dir = mkdtempSync(join(tmpdir(), 'yamlfence-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  mkdirSync(join(dir, 'skills', 'demo'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'demo', 'SKILL.md'),
+    ['---', 'name: demo', '---', '', '# Demo', '', body, ''].join('\n'), 'utf8');
+  return dir;
+}
+
+function run(dir, args = []) {
+  const r = spawnSync(process.execPath, [SCRIPT, '--root', dir, ...args], {
+    cwd: REPO, encoding: 'utf8',
+  });
+  return { status: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+const json = (dir) => JSON.parse(run(dir, ['--json']).stdout);
+
+test('a valid yaml fence passes', async (t) => {
+  const dir = corpus(t, ['```yaml', 'replicas: 3', 'image: nginx', '```'].join('\n'));
+
+  const r = run(dir);
+
+  assert.equal(r.status, 0, r.stdout);
+  assert.match(r.stdout, /yaml fences checked: 1/);
+  assert.match(r.stdout, /OK: every yaml-tagged fence parses/);
+});
+
+test('prose in a yaml fence FAILS — the defect this gate exists for', async (t) => {
+  // `skills/escalate-issues/SKILL.md` shape: a routing header, then a markdown
+  // report that a human writes. The `---` is where js-yaml gives up.
+  const dir = corpus(t, [
+    '```yaml',
+    '---',
+    'type: escalation',
+    'severity: high',
+    '---',
+    '',
+    '# Security Concern',
+    '',
+    '**Request**: Please review whether this is a real secret.',
+    '```',
+  ].join('\n'));
+
+  const r = run(dir);
+
+  assert.equal(r.status, 1, r.stdout);
+  assert.match(r.stdout, /1 yaml-tagged fence\(s\) do not parse/);
+  assert.match(r.stdout, /retag it/);
+});
+
+test('a human reference table in a yaml fence FAILS', async (t) => {
+  // `troubleshoot-print-issues` shape: ranges, arrows and bullet lists. Reads
+  // like config, is not config.
+  const dir = corpus(t, [
+    '```yaml',
+    '# Direct drive extruder:',
+    'retraction_distance: 1.0-2.0mm',
+    '',
+    '# If stringing persists:',
+    '- Enable z-hop: 0.2-0.4mm (lifts nozzle during travel)',
+    '- Reduce travel speed (paradoxically helps)',
+    '```',
+  ].join('\n'));
+
+  assert.equal(run(dir).status, 1);
+});
+
+test('retagging that same body to text passes — the prescribed remedy', async (t) => {
+  // The paired positive. Without it the test above passes on a build that
+  // rejects everything, and the failure message tells the reader to retag.
+  const dir = corpus(t, [
+    '```text',
+    '# Direct drive extruder:',
+    'retraction_distance: 1.0-2.0mm',
+    '',
+    '- Enable z-hop: 0.2-0.4mm',
+    '```',
+  ].join('\n'));
+
+  const r = run(dir);
+
+  assert.equal(r.status, 0, r.stdout);
+  assert.match(r.stdout, /yaml fences checked: 0/);
+});
+
+// ── the two exempted classes ────────────────────────────────────────────────
+
+test('a Go template is exempted, and reported rather than skipped', async (t) => {
+  const dir = corpus(t, [
+    '```yaml',
+    '{{- if .Values.ingress.enabled -}}',
+    'apiVersion: networking.k8s.io/v1',
+    '{{- end }}',
+    '```',
+  ].join('\n'));
+
+  const r = run(dir);
+  const j = json(dir);
+
+  assert.equal(r.status, 0, r.stdout);
+  assert.equal(j.failures.length, 0);
+  assert.equal(j.exempted.length, 1);
+  assert.equal(j.exempted[0].exemption, 'go-template');
+  assert.match(r.stdout, /go-template/, 'an exemption nobody can see is one nobody notices growing');
+});
+
+test('a duplicate-key illustration is exempted, and reported', async (t) => {
+  const dir = corpus(t, [
+    '```yaml',
+    '# Good',
+    'model: sonnet',
+    '',
+    '# Bad',
+    'model: opus',
+    '```',
+  ].join('\n'));
+
+  const j = json(dir);
+
+  assert.equal(j.failures.length, 0);
+  assert.equal(j.exempted[0].exemption, 'duplicate-key-illustration');
+});
+
+test('the exemptions are the only two, and neither swallows a broken fence', async (t) => {
+  // Bad indentation is neither a template nor a duplicate key, so it must fail
+  // even though it sits in a file that also holds exempted fences. This is the
+  // shape the first corpus run found in `write-helm-chart`, where an elision
+  // comment had been dropped into the middle of a mapping and orphaned its
+  // children.
+  const dir = corpus(t, [
+    '```yaml',
+    '{{- if .Values.enabled -}}',
+    'kind: Deployment',
+    '{{- end }}',
+    '```',
+    '',
+    '```yaml',
+    'autoscaling: {enabled: true}',
+    '  tls:',
+    '  - secretName: my-app-tls',
+    '```',
+  ].join('\n'));
+
+  const r = run(dir);
+  const j = json(dir);
+
+  assert.equal(r.status, 1, r.stdout);
+  assert.equal(j.exempted.length, 1, 'the template should still be exempted');
+  assert.equal(j.failures.length, 1, 'the broken fence must not ride the exemption');
+});
+
+// ── parser details that would otherwise bite ────────────────────────────────
+
+test('a multi-document fence is valid, not broken', async (t) => {
+  // `loadAll`, not `load`. Two values-file excerpts separated by `---` is the
+  // idiom that lets one fence show dev and prod without duplicate keys.
+  const dir = corpus(t, [
+    '```yaml',
+    '# values-dev.yaml',
+    'replicaCount: 1',
+    '---',
+    '# values-prod.yaml',
+    'replicaCount: 5',
+    '```',
+  ].join('\n'));
+
+  const r = run(dir);
+
+  assert.equal(r.status, 0, r.stdout);
+  assert.equal(json(dir).exempted.length, 0, 'it should PARSE, not be exempted');
+});
+
+test('yml is checked as well as yaml', async (t) => {
+  const dir = corpus(t, ['```yml', 'a: [1, 2', '```'].join('\n'));
+
+  assert.equal(run(dir).status, 1);
+});
+
+test('non-yaml tags are not checked', async (t) => {
+  const dir = corpus(t, ['```bash', 'echo "a: [unclosed"', '```'].join('\n'));
+
+  const r = run(dir);
+
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /yaml fences checked: 0/);
+});
+
+// ── arguments ───────────────────────────────────────────────────────────────
+
+test('an unknown argument is an error, not a silently different run', async (t) => {
+  const dir = corpus(t, ['```yaml', 'a: 1', '```'].join('\n'));
+
+  const r = run(dir, ['--strict']);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /unknown argument/);
+});
+
+test('--root pointing at nothing is an error, not an empty clean run', async (t) => {
+  const r = spawnSync(process.execPath, [SCRIPT, '--root', join(tmpdir(), 'no-such-dir-xyz')], {
+    cwd: REPO, encoding: 'utf8',
+  });
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /not a directory/);
+});

--- a/scripts/test/check-yaml-fences.test.js
+++ b/scripts/test/check-yaml-fences.test.js
@@ -74,7 +74,7 @@ test('prose in a yaml fence FAILS — the defect this gate exists for', async (t
 
   assert.equal(r.status, 1, r.stdout);
   assert.match(r.stdout, /1 yaml-tagged fence\(s\) do not parse/);
-  assert.match(r.stdout, /retag it/);
+  assert.match(r.stdout, /Retag only when/);
 });
 
 test('a human reference table in a yaml fence FAILS', async (t) => {
@@ -232,4 +232,108 @@ test('--root pointing at nothing is an error, not an empty clean run', async (t)
 
   assert.equal(r.status, 2);
   assert.match(r.stderr, /not a directory/);
+});
+
+// ── the exemption's SCOPE, which is the design's headline invariant ─────────
+
+test('a template expression elsewhere in the body does NOT exempt a broken fence', async (t) => {
+  // The defect this replaces: testing the BODY for `{{ }}` anywhere matched 24
+  // of 331 English fences where only 4 were Helm sources, and forgave every
+  // parse error in twenty valid GitHub Actions and Prometheus documents — the
+  // most machine-consumed fences in the corpus.
+  //
+  // This is a real workflow carrying the exact orphaned-`tls:` defect the gate
+  // was built to catch. The error lands on `  tls:`, not on the `${{ }}` line.
+  const dir = corpus(t, [
+    '```yaml',
+    'jobs:',
+    '  build:',
+    '    runs-on: ${{ matrix.config.os }}',
+    '    steps:',
+    '      - uses: actions/checkout@v4',
+    '     - run: npm ci',
+    '```',
+  ].join('\n'));
+
+  const r = run(dir);
+
+  assert.equal(r.status, 1, `a fence with {{ }} anywhere was exempted:\n${r.stdout}`);
+  assert.equal(json(dir).exempted.length, 0);
+});
+
+test('exemptions are decided by the error, not by the file path', async (t) => {
+  // A location-keyed exemption would cover every exemption this corpus actually
+  // has, and would be the thing the header says it refuses to do. Naming a file
+  // `write-helm-chart` must not buy anything.
+  const dir = mkdtempSync(join(tmpdir(), 'yamlfence-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  mkdirSync(join(dir, 'skills', 'write-helm-chart'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'write-helm-chart', 'SKILL.md'),
+    ['---', 'name: write-helm-chart', '---', '', '```yaml', 'a:', '  b: 1', ' c: 2', '```', ''].join('\n'), 'utf8');
+
+  const r = run(dir);
+
+  assert.equal(r.status, 1, 'the path bought an exemption');
+});
+
+test('a tag js-yaml 5 does not implement is exempted, not called broken', async (t) => {
+  // CloudFormation shorthand is genuinely machine-consumed YAML. Telling its
+  // author to retag it `text` would be the freeze-scope edit CLAUDE.md warns
+  // about, which is why the failure message no longer offers that first.
+  const dir = corpus(t, ['```yaml', 'BucketName: !Ref MyBucket', '```'].join('\n'));
+
+  const r = run(dir);
+
+  assert.equal(r.status, 0, r.stdout);
+  assert.equal(json(dir).exempted[0].exemption, 'unsupported-tag-schema');
+});
+
+test('the failure message leads with fixing the YAML, not with retagging', async (t) => {
+  const dir = corpus(t, ['```yaml', 'a:', '  b: 1', ' c: 2', '```'].join('\n'));
+
+  const r = run(dir);
+
+  assert.match(r.stdout, /If the fence IS machine-consumed, fix the YAML/);
+  assert.match(r.stdout, /freeze-scope edit CLAUDE\.md warns against/);
+});
+
+// ── scope and the no-op guard ───────────────────────────────────────────────
+
+test('locale mirrors are checked, not only English', async (t) => {
+  // The first version was English-only, and the first corpus run proved that
+  // wrong: a real fix reached English and none of its ten mirrors, and no other
+  // gate could ever report them.
+  const dir = corpus(t, ['```yaml', 'a: 1', '```'].join('\n'));
+  mkdirSync(join(dir, 'i18n', 'de', 'skills', 'demo'), { recursive: true });
+  writeFileSync(join(dir, 'i18n', 'de', 'skills', 'demo', 'SKILL.md'),
+    ['---', 'name: demo', 'locale: de', '---', '', '```yaml', 'a:', '  b: 1', ' c: 2', '```', ''].join('\n'), 'utf8');
+
+  const r = run(dir);
+
+  assert.equal(r.status, 1, r.stdout);
+  assert.match(r.stdout, /i18n\/de\/skills\/demo\/SKILL\.md/);
+  assert.match(r.stdout, /yaml fences checked: 2/);
+});
+
+test('a root with no content trees is an error, not an empty clean run', async (t) => {
+  // `existsSync` + `isDirectory` answers a different question from "would this
+  // scan anything" — the proxy-predicate shape CLAUDE.md documents twice.
+  const dir = mkdtempSync(join(tmpdir(), 'yamlfence-empty-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const r = run(dir);
+
+  assert.equal(r.status, 2, r.stdout);
+  assert.match(r.stderr, /no content trees/);
+});
+
+test('--json reports the failure in its exit code too', async (t) => {
+  // Four tests read --json output and none asserted its status, so a fail-open
+  // JSON mode was invisible.
+  const dir = corpus(t, ['```yaml', 'a:', '  b: 1', ' c: 2', '```'].join('\n'));
+
+  const r = run(dir, ['--json']);
+
+  assert.equal(r.status, 1);
+  assert.equal(JSON.parse(r.stdout).failures.length, 1);
 });

--- a/skills/escalate-issues/SKILL.md
+++ b/skills/escalate-issues/SKILL.md
@@ -190,16 +190,23 @@ def route_issue(severity, issue_type):
 
 Generate a formatted report suitable for the target audience (agent or human).
 
-**For Specialist Agents** (structured format for MCP tools):
+**For Specialist Agents** (structured format for MCP tools).
+
+The routing header is machine-consumed — a tool parses these keys, and the agent
+ids are English identifiers:
+
 ```yaml
----
 type: escalation
 severity: high
 from_agent: janitor
 to_agent: security-analyst
 blocking: false
----
+```
 
+The body beneath it is a report a human writes and another human reads, so it is
+localisable and a German reviewer should be able to emit a German one:
+
+```text
 # Security Concern: Hardcoded API Key in Config
 
 **File**: config/production.yml:45
@@ -210,6 +217,8 @@ If valid, recommend secure credential management strategy.
 
 **Context**: Discovered during config cleanup sweep.
 ```
+
+Emit them as one document, with the header delimited by `---` fences.
 
 **For Human Reviewers** (detailed markdown):
 ```markdown

--- a/skills/escalate-issues/SKILL.md
+++ b/skills/escalate-issues/SKILL.md
@@ -192,8 +192,9 @@ Generate a formatted report suitable for the target audience (agent or human).
 
 **For Specialist Agents** (structured format for MCP tools).
 
-The routing header is machine-consumed — a tool parses these keys, and the agent
-ids are English identifiers:
+Emit one document: the routing header delimited by `---` fences, then the report
+body beneath it. The receiving tool parses the header keys, so those and the
+agent ids stay in English.
 
 ```yaml
 type: escalation
@@ -202,9 +203,6 @@ from_agent: janitor
 to_agent: security-analyst
 blocking: false
 ```
-
-The body beneath it is a report a human writes and another human reads, so it is
-localisable and a German reviewer should be able to emit a German one:
 
 ```text
 # Security Concern: Hardcoded API Key in Config

--- a/skills/render-publication-graphic/SKILL.md
+++ b/skills/render-publication-graphic/SKILL.md
@@ -48,7 +48,7 @@ Produce publication-ready graphics that meet technical requirements for academic
 
 Identify technical specifications for target publication:
 
-```yaml
+```text
 # Common publication requirements
 
 academic_journal:

--- a/skills/troubleshoot-print-issues/SKILL.md
+++ b/skills/troubleshoot-print-issues/SKILL.md
@@ -191,7 +191,7 @@ Implement immediate solutions for common issues:
 ```
 
 **Retraction tuning**:
-```yaml
+```text
 # Direct drive extruder:
 retraction_distance: 1.0-2.0mm
 retraction_speed: 40-50mm/s
@@ -244,7 +244,7 @@ jerk: 8mm/s (from 15)
 ### Warping
 
 **Thermal management**:
-```yaml
+```text
 # Increase bed temperature:
 PLA: 60°C → 65°C
 PETG: 80°C → 85°C
@@ -304,7 +304,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Over-Extrusion
 
 **Flow rate reduction**:
-```yaml
+```text
 # Reduce flow in 2% increments:
 extrusion_multiplier: 0.98 → 0.96 → 0.94
 

--- a/skills/write-helm-chart/SKILL.md
+++ b/skills/write-helm-chart/SKILL.md
@@ -333,10 +333,12 @@ resources:
 ingress:
   hosts: [my-app-dev.example.com]
 
+---
 # values-prod.yaml (excerpt)
 replicaCount: 5
 autoscaling: {enabled: true, minReplicas: 3, maxReplicas: 10}
-# ... (see EXAMPLES.md for complete env-specific values)
+ingress:
+  hosts: [my-app.example.com]
   tls:
   - secretName: my-app-tls
     hosts:


### PR DESCRIPTION
Closes #507.

#472 freezes a fence by its **tag**: everything between the delimiters is either frozen to English or localisable, and `yaml` is frozen. That is right for a machine-consumed document and wrong for a reference table a human reads — and the tag is the only thing telling them apart, so a mislabelled fence quietly freezes content that should have stayed translatable.

`skills/escalate-issues/SKILL.md` carried a `yaml` fence holding a routing header **and** the markdown incident report beneath it. The German translation had that report in German; #508 restored it to English, correctly per the rule, and the surrounding German prose still told the reader to write one.

## What makes it decidable

Copilot's observation on #508, recorded in #507: that fence **is not YAML**. `js-yaml` rejects it at the `---` separating header from prose. So the rule is mechanical — if it is tagged `yaml`, it parses. If it does not, it is either broken YAML or it is not YAML, and both want fixing at the source rather than freezing into ten locales.

This is also what keeps retagging honest. CLAUDE.md names retagging `yaml` → `text` as the way the freeze's scope could be edited from inside the gated file. Correcting a mislabel is not that — but the two are only distinguishable if something checks which fences are genuinely YAML. Now something does.

## The gate

`scripts/check-yaml-fences.js`, blocking in CI, repo-wide rather than added-lines-only because the corpus is at zero and there is no legacy backlog to grandfather.

**Exemptions are by error class, not by location.** Two shapes legitimately do not parse — Helm Go templates, and duplicate-key illustrations where a good/bad pair in one fence is a documented idiom in these guides. Pinning exemptions to `file:line` would rot on the first edit above them, and a rotted exemption either fails a clean file or silently covers a new defect. Keying on the error class costs precision (an accidental duplicate key in a real config would pass) and buys a list that cannot drift. **Every exempted fence is reported, not skipped** — an exemption list nobody can see is one nobody notices growing.

## What the first run found

331 English yaml fences, 15 non-parsing: 5 Go templates and 5 duplicate-key illustrations (both exempted), plus **six things to fix** — one more than #507 recorded, which had listed `render-publication-graphic` as unclassified.

| | fix |
|---|---|
| `escalate-issues:194` | **split** — frozen `yaml` header + localisable `text` report, with prose naming which is which |
| `troubleshoot-print-issues` ×3 | **retagged `text`** — ranges (`1.0-2.0mm`), arrows (`0.98 → 0.96`), bullet lists after a mapping |
| `render-publication-graphic:51` | **retagged `text`** — publication requirements with `RGB or CMYK (check guidelines)` |
| `write-helm-chart:328` | **a real defect** — an elision comment dropped into the middle of a mapping, orphaning a `tls:` block under nothing. Same shape as #476's runaway fences. Its two values-file excerpts now carry a `---` separator, so the fence parses as the two documents it always was rather than riding the duplicate-key exemption |

## Re-mirrored into 30 files across 10 locales

**The English retag alone is half a fix.** The parity gate reads a fence's tag off the *translated* file, never off English, so retagging English would have left every mirror frozen — exactly the content this frees — while diverging the tag sequence and making the normalizer refuse those files. I checked this rather than assuming it.

Every mirror carried the English body verbatim (measured 10 of 10, none structurally diverged), so each fence was addressed on its own. A whole-region diff was tried first and matched in **no** locale: the retagged fences are far apart, so the changed region swallows the translated prose between them.

Tag sequences afterwards: `troubleshoot-print-issues` 10/10 aligned, `render-publication-graphic` 10/10, `escalate-issues` 7/10. The three stragglers are **pre-existing and unrelated** — `wenyan`, `wenyan-lite` and `zh-CN` tag fence 3 `text` where English has `python`, and they were already diverged before this change. Filing separately.

## Verification

```
gate:   331 checked, 9 exempted, 0 failures
parity: 248 violations — unchanged, as expected
```

Parity is unchanged because these fences carried English and were never violations. What changes is that a translator may now localise them.

**Four mutants, all killed:**

```
failures.push -> exempted.push          (the gate can fail)     KILLED by 4
delete the go-template exemption                                KILLED by 2
delete the duplicate-key exemption                              KILLED by 1
loadAll -> load                          (multi-document)       KILLED by 1
```

12 tests, each fixture the shape of something the first corpus run actually found — including the paired positive that the prescribed remedy, retagging to `text`, makes the same body pass.